### PR TITLE
fix: post-migration bug fixes, unit tests, and improvements

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,10 +58,32 @@ jobs:
       - name: Run typecheck
         run: pnpm test:typecheck
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck]
+    needs: [lint, typecheck, test]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,9 +2,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['main']
-  push:
-    branches: ['main']
+    branches: ["main"]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 
 .react-router/
 app/database/generated/
+coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,10 @@ Each feature owns all its code through consistent segments:
 - Config at `prisma.config.ts` (project root)
 - Migrations run separately (not on app startup)
 
-**File Storage**:
-- S3-compatible object storage via `@aws-sdk/client-s3`
+**File Storage** (dual driver):
+- **S3**: used when `S3_ENDPOINT` is set. Configured via `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`
+- **Local filesystem**: used when `S3_ENDPOINT` is not set. Files stored in `content/uploads/` (configurable via `LOCAL_STORAGE_PATH`)
 - Key pattern: `{congregationId}/{feature}/{uuid}.pdf`
-- Configured via `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`
 
 **Background Jobs** (BullMQ):
 - `syncQueue` in `app/features/territories/server/sync-queue.server.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,13 @@ pnpm test:lint              # Check linting only
 pnpm test:typecheck         # Generate types and run TypeScript compiler
 ```
 
+### Testing
+```bash
+pnpm test:unit              # Run unit tests once
+pnpm test:unit:watch        # Run tests in watch mode
+pnpm test:unit:coverage     # Run tests with coverage report
+```
+
 ### Database & Infrastructure
 ```bash
 pnpm prisma migrate deploy  # Apply database migrations
@@ -223,12 +230,15 @@ Uses Biome for formatting with these key rules:
 
 ### Testing & Quality
 
+- **Unit tests**: Vitest with co-located test files (`*.server.test.ts` next to source)
+- **Test style**: Black-box testing — assert on observable outcomes, no spy assertions
+- **Config**: `vitest.config.ts` at project root (separate from `vite.config.ts` to avoid reactRouter plugin issues)
+- **Mocking**: `vi.mock()` for `db.server`, `redis.server`, `crypto.server` — mock return values, assert on results
 - TypeScript strict mode enabled
 - Biome linting with custom rules (no console.log in production)
 - Prisma generates types from schema
 - Startup env validation for `DATABASE_URL` and `SESSION_SECRET`
 - `requireParamId()` utility for safe route param parsing
-- Manual testing via development server
 
 ### Gotchas & Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ The project uses [Biome](https://biomejs.dev/) for formatting and linting:
 pnpm build:format    # Auto-format and fix
 pnpm test:lint       # Check linting
 pnpm test:typecheck  # Check TypeScript types
+pnpm test:unit       # Run unit tests
 ```
 
 ### Architecture
@@ -66,6 +67,20 @@ Each feature is organized under `app/features/` with its own segments:
 - `model/` — TypeScript type definitions
 
 Business logic belongs in service functions (`features/*/server/`), not in route loaders/actions.
+
+### Testing
+
+Unit tests use [Vitest](https://vitest.dev/) with co-located test files (`*.server.test.ts` next to source).
+
+- **Black-box testing**: assert on return values and thrown errors, not mock call counts
+- **Mocking**: use `vi.mock()` for external dependencies (`db.server`, `redis.server`, `crypto.server`)
+- Run `pnpm test:unit` before submitting a PR
+
+### Key Patterns
+
+- **Route actions must call `verifySession(request)`** and use the returned `congregation` object for `congregationId`. Do not use `congregationContext.getStore()` in actions — AsyncLocalStorage context can be lost after Prisma queries.
+- **Service functions that create records** should accept `congregationId` as an explicit parameter. Do not use `congregationId: 0 as number`.
+- **File storage** works with both S3 and local filesystem — the driver is selected automatically based on `S3_ENDPOINT`.
 
 ### Commits
 
@@ -88,6 +103,7 @@ docs: update deployment guide
    pnpm build:format
    pnpm test:typecheck
    pnpm test:lint
+   pnpm test:unit
    pnpm build
    ```
 5. **Open a pull request** with a clear description of your changes

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Open-source web application for managing Jehovah's Witnesses congregations. Mana
 
 ## Tech Stack
 
-React Router v7 · TypeScript · PostgreSQL · Prisma 7 · TailwindCSS 4 · Redis · BullMQ · S3-compatible storage
+React Router v7 · TypeScript · PostgreSQL · Prisma 7 · TailwindCSS 4 · Redis · BullMQ · Vitest · S3 or local file storage
 
 ## Quick Start
 
@@ -81,6 +81,9 @@ pnpm start:worker
 | `pnpm build:format` | Format and lint (Biome) |
 | `pnpm test:lint` | Check linting |
 | `pnpm test:typecheck` | TypeScript type checking |
+| `pnpm test:unit` | Run unit tests |
+| `pnpm test:unit:watch` | Run unit tests in watch mode |
+| `pnpm test:unit:coverage` | Run unit tests with coverage |
 | `pnpm prisma migrate deploy` | Apply database migrations |
 | `pnpm prisma db seed` | Seed initial data |
 
@@ -99,11 +102,12 @@ pnpm start:worker
 | `COOKIE_DOMAIN` | No | — | Session cookie domain (set in production) |
 | `LOG_LEVEL` | No | `info` | Winston log level |
 | `RESEND_API_KEY` | No | — | Resend API key for emails |
-| `S3_ENDPOINT` | No | — | S3-compatible storage endpoint |
+| `S3_ENDPOINT` | No | — | S3-compatible storage endpoint. When absent, local filesystem is used |
 | `S3_REGION` | No | `auto` | S3 region |
 | `S3_BUCKET` | No | `unitae` | S3 bucket for file uploads |
 | `S3_ACCESS_KEY` | No | — | S3 access key |
 | `S3_SECRET_KEY` | No | — | S3 secret key |
+| `LOCAL_STORAGE_PATH` | No | `content/uploads` | Local file storage path (used when `S3_ENDPOINT` is absent) |
 
 See [`.env.example`](.env.example) for a complete annotated template.
 
@@ -205,6 +209,7 @@ Before submitting:
 pnpm build:format    # Format code
 pnpm test:typecheck  # Check types
 pnpm test:lint       # Check linting
+pnpm test:unit       # Run unit tests
 ```
 
 ## License

--- a/app/database/migrations/20260408_make_deputy_optional/migration.sql
+++ b/app/database/migrations/20260408_make_deputy_optional/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "PublisherGroup" DROP CONSTRAINT "PublisherGroup_deputyId_fkey";
+
+-- AlterTable
+ALTER TABLE "PublisherGroup" ALTER COLUMN "deputyId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "PublisherGroup" ADD CONSTRAINT "PublisherGroup_deputyId_fkey" FOREIGN KEY ("deputyId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -239,8 +239,8 @@ model PublisherGroup {
   members       User[] @relation("group")
   responsible   User   @relation("groupResponsible", fields: [responsibleId], references: [id])
   responsibleId Int    @unique
-  deputy        User   @relation("groupDeputy", fields: [deputyId], references: [id])
-  deputyId      Int    @unique
+  deputy        User?  @relation("groupDeputy", fields: [deputyId], references: [id])
+  deputyId      Int?   @unique
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int

--- a/app/features/authentication/routes/login.tsx
+++ b/app/features/authentication/routes/login.tsx
@@ -1,5 +1,6 @@
 import { data, Form, Link, redirect } from 'react-router'
 
+import { getBrandingName } from '~/shared/libs/congregation.server'
 import { needSetupProcess } from '~/features/authentication/server/need-setup-process.server'
 import {
   checkLoginRateLimit,
@@ -31,8 +32,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  const brandingName = await getBrandingName(request)
+
   return data(
-    { error: session.get('error') },
+    { error: session.get('error'), brandingName },
     {
       headers: {
         'Set-Cookie': await commitSession(session),
@@ -42,14 +45,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function LoginPage({ loaderData }: Route.ComponentProps) {
-  const { error } = loaderData
+  const { error, brandingName } = loaderData
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md overflow-hidden shadow-md">
         <div className="h-1 bg-primary" />
         <CardHeader className="items-center space-y-2 text-center">
-          <h1 className="font-bold font-display text-2xl tracking-tight">Unitae</h1>
+          <h1 className="font-bold font-display text-2xl tracking-tight">{brandingName}</h1>
         </CardHeader>
         <CardContent>
           {error && (

--- a/app/features/authentication/routes/password-forgot.tsx
+++ b/app/features/authentication/routes/password-forgot.tsx
@@ -3,7 +3,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { createPasswordResetToken } from '~/features/authentication/server/invalidate-user-password.server'
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
-import { resolveCongregation } from '~/shared/libs/congregation.server'
+import { getBrandingName, resolveCongregation } from '~/shared/libs/congregation.server'
 import { unscopedDb as db } from '~/shared/libs/db.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -19,9 +19,10 @@ export const meta: Route.MetaFunction = () => {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const session = await getSession(request.headers.get('Cookie'))
+  const brandingName = await getBrandingName(request)
 
   return data(
-    { error: session.get('error'), success: session.get('success') },
+    { error: session.get('error'), success: session.get('success'), brandingName },
     {
       headers: {
         'Set-Cookie': await commitSession(session),
@@ -31,14 +32,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function ForgotPassword({ loaderData }: Route.ComponentProps) {
-  const { error, success } = loaderData
+  const { error, success, brandingName } = loaderData
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md overflow-hidden shadow-md">
         <div className="h-1 bg-primary" />
         <CardHeader className="items-center space-y-2 text-center">
-          <h1 className="font-bold font-display text-2xl tracking-tight">Unitae</h1>
+          <h1 className="font-bold font-display text-2xl tracking-tight">{brandingName}</h1>
           <p className="text-muted-foreground text-sm">Indiquez votre adresse email pour retrouver votre compte</p>
         </CardHeader>
         <CardContent>

--- a/app/features/authentication/routes/password-reset.tsx
+++ b/app/features/authentication/routes/password-reset.tsx
@@ -1,5 +1,6 @@
 import { Form, redirect } from 'react-router'
 
+import { getBrandingName } from '~/shared/libs/congregation.server'
 import {
   consumePasswordResetToken,
   verifyPasswordResetToken,
@@ -17,12 +18,14 @@ export const meta: Route.MetaFunction = () => {
   return [{ title: 'Réinitialiser le mot de passe - Unitae' }]
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export async function loader({ request, params }: Route.LoaderArgs) {
   const user = await verifyPasswordResetToken(params.userHash ?? '')
 
   if (user == null) {
     throw redirect('/')
   }
+
+  const brandingName = await getBrandingName(request)
 
   return {
     email: user.email,
@@ -30,18 +33,19 @@ export async function loader({ params }: Route.LoaderArgs) {
     active: user.active,
     firstname: user.firstname,
     lastname: user.lastname,
+    brandingName,
   }
 }
 
 export default function PasswordResetPage({ loaderData }: Route.ComponentProps) {
-  const user = loaderData
+  const { brandingName, ...user } = loaderData
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md overflow-hidden shadow-md">
         <div className="h-1 bg-primary" />
         <CardHeader className="items-center space-y-2 text-center">
-          <h1 className="font-bold font-display text-2xl tracking-tight">Unitae</h1>
+          <h1 className="font-bold font-display text-2xl tracking-tight">{brandingName}</h1>
           <p className="text-muted-foreground text-sm">Réinitialiser votre mot de passe</p>
         </CardHeader>
         <CardContent>

--- a/app/features/authentication/routes/register.tsx
+++ b/app/features/authentication/routes/register.tsx
@@ -10,7 +10,7 @@ import { Label } from '~/shared/ui/label'
 import type { Route } from './+types/register'
 
 export const meta: Route.MetaFunction = () => {
-  return [{ title: 'Créer une congrégation - Unitae' }]
+  return [{ title: 'Créer une assemblée locale - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -44,7 +44,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
         <div className="h-1 bg-primary" />
         <CardHeader className="items-center space-y-2 text-center">
           <h1 className="font-bold font-display text-2xl tracking-tight">Unitae</h1>
-          <p className="text-muted-foreground text-sm">Créer un espace pour votre congrégation</p>
+          <p className="text-muted-foreground text-sm">Créer un espace pour votre assemblée locale</p>
         </CardHeader>
         <CardContent>
           {error && (
@@ -59,7 +59,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
           )}
           <Form method="post" className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
-              <Label htmlFor="congregation-name">Nom de la congrégation</Label>
+              <Label htmlFor="congregation-name">Nom de l'assemblée locale</Label>
               <Input
                 id="congregation-name"
                 name="congregation-name"
@@ -85,7 +85,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
             </div>
 
             <Button type="submit" className="mt-4 w-full">
-              Créer la congrégation
+              Créer l'assemblée locale
             </Button>
           </Form>
         </CardContent>
@@ -112,7 +112,7 @@ export async function action({ request }: Route.ActionArgs) {
   const repeatPassword = String(form.get('repeat-password'))
 
   if (congregationName.length < 2) {
-    session.flash('error', 'Le nom de la congrégation doit faire au moins 2 caractères.')
+    session.flash('error', 'Le nom de l\'assemblée locale doit faire au moins 2 caractères.')
     return redirect('/register', { headers: { 'Set-Cookie': await commitSession(session) } })
   }
 
@@ -133,7 +133,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const slug = slugify(congregationName)
   if (slug.length < 2) {
-    session.flash('error', 'Le nom de la congrégation génère un identifiant invalide.')
+    session.flash('error', 'Le nom de l\'assemblée locale génère un identifiant invalide.')
     return redirect('/register', { headers: { 'Set-Cookie': await commitSession(session) } })
   }
 

--- a/app/features/authentication/server/change-user-password.server.test.ts
+++ b/app/features/authentication/server/change-user-password.server.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { findFirst: vi.fn(), update: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/crypto.server', () => ({
+  compare: vi.fn(),
+  hash: vi.fn(),
+}))
+
+vi.mock('./reset-user-password.server', () => ({
+  resetUserPassword: vi.fn(),
+}))
+
+const { changeUserPassword } = await import('./change-user-password.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+const { compare } = await import('~/shared/libs/crypto.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('changeUserPassword', () => {
+  const fakeUser = { id: 1, password: 'old.hashed' }
+
+  it('retourne true quand le mot de passe actuel est correct', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockResolvedValue(true)
+
+    const result = await changeUserPassword(1, 'ancien', 'nouveau')
+    expect(result).toBe(true)
+  })
+
+  it('retourne false quand l\'utilisateur n\'existe pas', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+
+    const result = await changeUserPassword(999, 'ancien', 'nouveau')
+    expect(result).toBe(false)
+  })
+
+  it('retourne false quand le mot de passe actuel est incorrect', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockResolvedValue(false)
+
+    const result = await changeUserPassword(1, 'mauvais', 'nouveau')
+    expect(result).toBe(false)
+  })
+
+  it('retourne false quand compare lance une erreur', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockRejectedValue(new Error('crypto error'))
+
+    const result = await changeUserPassword(1, 'ancien', 'nouveau')
+    expect(result).toBe(false)
+  })
+})

--- a/app/features/authentication/server/change-user-password.server.test.ts
+++ b/app/features/authentication/server/change-user-password.server.test.ts
@@ -27,30 +27,30 @@ describe('changeUserPassword', () => {
   const fakeUser = { id: 1, password: 'old.hashed' }
 
   it('retourne true quand le mot de passe actuel est correct', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
-    vi.mocked(compare).mockResolvedValue(true)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(true as never)
 
     const result = await changeUserPassword(1, 'ancien', 'nouveau')
     expect(result).toBe(true)
   })
 
   it('retourne false quand l\'utilisateur n\'existe pas', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+    vi.mocked(db.user.findFirst).mockResolvedValue(null as never)
 
     const result = await changeUserPassword(999, 'ancien', 'nouveau')
     expect(result).toBe(false)
   })
 
   it('retourne false quand le mot de passe actuel est incorrect', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
-    vi.mocked(compare).mockResolvedValue(false)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(false as never)
 
     const result = await changeUserPassword(1, 'mauvais', 'nouveau')
     expect(result).toBe(false)
   })
 
   it('retourne false quand compare lance une erreur', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
     vi.mocked(compare).mockRejectedValue(new Error('crypto error'))
 
     const result = await changeUserPassword(1, 'ancien', 'nouveau')

--- a/app/features/authentication/server/invalidate-user-password.server.test.ts
+++ b/app/features/authentication/server/invalidate-user-password.server.test.ts
@@ -28,8 +28,8 @@ afterEach(() => {
 
 describe('createPasswordResetToken', () => {
   it('retourne un token non vide', async () => {
-    vi.mocked(db.passwordResetToken.deleteMany).mockResolvedValue({ count: 0 })
-    vi.mocked(db.passwordResetToken.create).mockResolvedValue({ id: 1, token: 'abc', userId: 42, expiresAt: new Date() })
+    vi.mocked(db.passwordResetToken.deleteMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(db.passwordResetToken.create).mockResolvedValue({ id: 1, token: 'abc', userId: 42, expiresAt: new Date() } as never)
 
     const token = await createPasswordResetToken(42)
     expect(token).toBeTruthy()
@@ -50,14 +50,14 @@ describe('verifyPasswordResetToken', () => {
       userId: 42,
       expiresAt: futureDate,
       user: fakeUser,
-    })
+    } as never)
 
     const result = await verifyPasswordResetToken('valid-token')
     expect(result).toEqual(fakeUser)
   })
 
   it('retourne null pour un token inexistant', async () => {
-    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null)
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null as never)
 
     const result = await verifyPasswordResetToken('inexistant')
     expect(result).toBeNull()
@@ -73,7 +73,7 @@ describe('verifyPasswordResetToken', () => {
       userId: 42,
       expiresAt: pastDate,
       user: { id: 42 },
-    })
+    } as never)
     vi.mocked(db.passwordResetToken.delete).mockResolvedValue({} as never)
 
     const result = await verifyPasswordResetToken('expired-token')
@@ -88,14 +88,14 @@ describe('consumePasswordResetToken', () => {
       token: 'to-consume',
       userId: 42,
       expiresAt: new Date(),
-    })
+    } as never)
     vi.mocked(db.passwordResetToken.delete).mockResolvedValue({} as never)
 
     await expect(consumePasswordResetToken('to-consume')).resolves.toBeUndefined()
   })
 
   it('ne lance pas d\'erreur pour un token inexistant', async () => {
-    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null)
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null as never)
 
     await expect(consumePasswordResetToken('inexistant')).resolves.toBeUndefined()
   })

--- a/app/features/authentication/server/invalidate-user-password.server.test.ts
+++ b/app/features/authentication/server/invalidate-user-password.server.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    passwordResetToken: {
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+const { createPasswordResetToken, verifyPasswordResetToken, consumePasswordResetToken } = await import(
+  './invalidate-user-password.server'
+)
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 3, 8, 12, 0, 0)) // 8 avril 2025, midi
+  vi.resetAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createPasswordResetToken', () => {
+  it('retourne un token non vide', async () => {
+    vi.mocked(db.passwordResetToken.deleteMany).mockResolvedValue({ count: 0 })
+    vi.mocked(db.passwordResetToken.create).mockResolvedValue({ id: 1, token: 'abc', userId: 42, expiresAt: new Date() })
+
+    const token = await createPasswordResetToken(42)
+    expect(token).toBeTruthy()
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(0)
+  })
+})
+
+describe('verifyPasswordResetToken', () => {
+  it('retourne l\'utilisateur pour un token valide non expiré', async () => {
+    const futureDate = new Date()
+    futureDate.setHours(futureDate.getHours() + 12) // expire dans 12h
+
+    const fakeUser = { id: 42, email: 'test@example.com' }
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue({
+      id: 1,
+      token: 'valid-token',
+      userId: 42,
+      expiresAt: futureDate,
+      user: fakeUser,
+    })
+
+    const result = await verifyPasswordResetToken('valid-token')
+    expect(result).toEqual(fakeUser)
+  })
+
+  it('retourne null pour un token inexistant', async () => {
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null)
+
+    const result = await verifyPasswordResetToken('inexistant')
+    expect(result).toBeNull()
+  })
+
+  it('retourne null et supprime un token expiré', async () => {
+    const pastDate = new Date()
+    pastDate.setHours(pastDate.getHours() - 1) // expiré il y a 1h
+
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue({
+      id: 1,
+      token: 'expired-token',
+      userId: 42,
+      expiresAt: pastDate,
+      user: { id: 42 },
+    })
+    vi.mocked(db.passwordResetToken.delete).mockResolvedValue({} as never)
+
+    const result = await verifyPasswordResetToken('expired-token')
+    expect(result).toBeNull()
+  })
+})
+
+describe('consumePasswordResetToken', () => {
+  it('ne lance pas d\'erreur pour un token existant', async () => {
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue({
+      id: 1,
+      token: 'to-consume',
+      userId: 42,
+      expiresAt: new Date(),
+    })
+    vi.mocked(db.passwordResetToken.delete).mockResolvedValue({} as never)
+
+    await expect(consumePasswordResetToken('to-consume')).resolves.toBeUndefined()
+  })
+
+  it('ne lance pas d\'erreur pour un token inexistant', async () => {
+    vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null)
+
+    await expect(consumePasswordResetToken('inexistant')).resolves.toBeUndefined()
+  })
+})

--- a/app/features/authentication/server/need-setup-process.server.test.ts
+++ b/app/features/authentication/server/need-setup-process.server.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { count: vi.fn() },
+  },
+}))
+
+const { needSetupProcess } = await import('./need-setup-process.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('needSetupProcess', () => {
+  it('retourne true quand il n\'y a aucun utilisateur', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(0)
+
+    expect(await needSetupProcess()).toBe(true)
+  })
+
+  it('retourne false quand il y a des utilisateurs', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(1)
+
+    expect(await needSetupProcess()).toBe(false)
+  })
+
+  it('retourne false quand il y a plusieurs utilisateurs', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(50)
+
+    expect(await needSetupProcess()).toBe(false)
+  })
+})

--- a/app/features/authentication/server/rate-limit.server.test.ts
+++ b/app/features/authentication/server/rate-limit.server.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/redis.server', () => ({
+  redis: {
+    get: vi.fn(),
+    incr: vi.fn(),
+    expire: vi.fn(),
+    del: vi.fn(),
+  },
+}))
+
+vi.mock('~/shared/libs/logger.server', () => ({
+  default: {
+    warn: vi.fn(),
+  },
+}))
+
+const { checkLoginRateLimit, recordLoginAttempt, clearLoginAttempts } = await import('./rate-limit.server')
+const { redis } = await import('~/shared/libs/redis.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('checkLoginRateLimit', () => {
+  it('retourne true quand aucune tentative n\'a été enregistrée', async () => {
+    vi.mocked(redis.get).mockResolvedValue(null)
+
+    const result = await checkLoginRateLimit('test@example.com')
+    expect(result).toBe(true)
+  })
+
+  it('retourne true quand le nombre de tentatives est sous la limite', async () => {
+    vi.mocked(redis.get).mockResolvedValue('4')
+
+    const result = await checkLoginRateLimit('test@example.com')
+    expect(result).toBe(true)
+  })
+
+  it('retourne false quand la limite est atteinte (5 tentatives)', async () => {
+    vi.mocked(redis.get).mockResolvedValue('5')
+
+    const result = await checkLoginRateLimit('test@example.com')
+    expect(result).toBe(false)
+  })
+
+  it('retourne false quand la limite est dépassée', async () => {
+    vi.mocked(redis.get).mockResolvedValue('10')
+
+    const result = await checkLoginRateLimit('test@example.com')
+    expect(result).toBe(false)
+  })
+
+  it('retourne true en cas d\'erreur Redis (dégradation gracieuse)', async () => {
+    vi.mocked(redis.get).mockRejectedValue(new Error('Redis down'))
+
+    const result = await checkLoginRateLimit('test@example.com')
+    expect(result).toBe(true)
+  })
+
+  it('normalise l\'email en minuscules', async () => {
+    vi.mocked(redis.get).mockResolvedValue('4')
+
+    // Les deux doivent retourner le même résultat car la clé est normalisée
+    const result1 = await checkLoginRateLimit('TEST@EXAMPLE.COM')
+    const result2 = await checkLoginRateLimit('test@example.com')
+    expect(result1).toBe(result2)
+  })
+})
+
+describe('recordLoginAttempt', () => {
+  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+    vi.mocked(redis.incr).mockResolvedValue(1)
+    vi.mocked(redis.expire).mockResolvedValue(1)
+
+    await expect(recordLoginAttempt('test@example.com')).resolves.toBeUndefined()
+  })
+
+  it('ne lance pas d\'erreur en cas d\'erreur Redis', async () => {
+    vi.mocked(redis.incr).mockRejectedValue(new Error('Redis down'))
+
+    await expect(recordLoginAttempt('test@example.com')).resolves.toBeUndefined()
+  })
+})
+
+describe('clearLoginAttempts', () => {
+  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+    vi.mocked(redis.del).mockResolvedValue(1)
+
+    await expect(clearLoginAttempts('test@example.com')).resolves.toBeUndefined()
+  })
+
+  it('ne lance pas d\'erreur en cas d\'erreur Redis', async () => {
+    vi.mocked(redis.del).mockRejectedValue(new Error('Redis down'))
+
+    await expect(clearLoginAttempts('test@example.com')).resolves.toBeUndefined()
+  })
+})

--- a/app/features/authentication/server/register-congregation.server.test.ts
+++ b/app/features/authentication/server/register-congregation.server.test.ts
@@ -11,7 +11,7 @@ vi.mock('~/shared/libs/db.server', () => ({
 }))
 
 vi.mock('~/shared/libs/crypto.server', () => ({
-  hash: vi.fn().mockResolvedValue('hashed-password'),
+  hash: vi.fn().mockResolvedValue('hashed-password' as never),
 }))
 
 const { registerCongregation } = await import('./register-congregation.server')
@@ -19,13 +19,13 @@ const { unscopedDb: db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.congregation.findUnique).mockResolvedValue(null)
-  vi.mocked(db.user.findUnique).mockResolvedValue(null)
-  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test-congre' })
-  vi.mocked(db.user.create).mockResolvedValue({ id: 10 })
-  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' })
-  vi.mocked(db.congregationUserRole.create).mockResolvedValue({})
-  vi.mocked(db.eventKind.create).mockResolvedValue({})
+  vi.mocked(db.congregation.findUnique).mockResolvedValue(null as never)
+  vi.mocked(db.user.findUnique).mockResolvedValue(null as never)
+  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test-congre' } as never)
+  vi.mocked(db.user.create).mockResolvedValue({ id: 10 } as never)
+  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' } as never)
+  vi.mocked(db.congregationUserRole.create).mockResolvedValue({} as never)
+  vi.mocked(db.eventKind.create).mockResolvedValue({} as never)
 })
 
 describe('registerCongregation', () => {
@@ -36,7 +36,7 @@ describe('registerCongregation', () => {
   })
 
   it('retourne une erreur si le slug est déjà pris', async () => {
-    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 99, slug: 'test-congre' })
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 99, slug: 'test-congre' } as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
 
@@ -45,7 +45,7 @@ describe('registerCongregation', () => {
   })
 
   it('retourne une erreur si l\'email existe déjà', async () => {
-    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' })
+    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' } as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
 
@@ -55,7 +55,7 @@ describe('registerCongregation', () => {
 
   it('normalise l\'email en minuscules pour la vérification', async () => {
     // Simule un utilisateur existant avec l'email en minuscules
-    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' })
+    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' } as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'ADMIN@TEST.COM', 'motdepasse')
 
@@ -63,7 +63,7 @@ describe('registerCongregation', () => {
   })
 
   it('fonctionne même si le rôle admin n\'existe pas', async () => {
-    vi.mocked(db.userRole.findUnique).mockResolvedValue(null)
+    vi.mocked(db.userRole.findUnique).mockResolvedValue(null as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
 

--- a/app/features/authentication/server/register-congregation.server.test.ts
+++ b/app/features/authentication/server/register-congregation.server.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    congregation: { findUnique: vi.fn(), create: vi.fn() },
+    user: { findUnique: vi.fn(), create: vi.fn() },
+    userRole: { findUnique: vi.fn() },
+    congregationUserRole: { create: vi.fn() },
+    eventKind: { create: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/crypto.server', () => ({
+  hash: vi.fn().mockResolvedValue('hashed-password'),
+}))
+
+const { registerCongregation } = await import('./register-congregation.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.congregation.findUnique).mockResolvedValue(null)
+  vi.mocked(db.user.findUnique).mockResolvedValue(null)
+  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test-congre' })
+  vi.mocked(db.user.create).mockResolvedValue({ id: 10 })
+  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' })
+  vi.mocked(db.congregationUserRole.create).mockResolvedValue({})
+  vi.mocked(db.eventKind.create).mockResolvedValue({})
+})
+
+describe('registerCongregation', () => {
+  it('retourne le slug et userId en cas de succès', async () => {
+    const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
+
+    expect(result).toEqual({ congregationSlug: 'test-congre', userId: 10 })
+  })
+
+  it('retourne une erreur si le slug est déjà pris', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 99, slug: 'test-congre' })
+
+    const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
+
+    expect(result).toHaveProperty('error')
+    expect(result.error).toContain('déjà pris')
+  })
+
+  it('retourne une erreur si l\'email existe déjà', async () => {
+    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' })
+
+    const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
+
+    expect(result).toHaveProperty('error')
+    expect(result.error).toContain('email')
+  })
+
+  it('normalise l\'email en minuscules pour la vérification', async () => {
+    // Simule un utilisateur existant avec l'email en minuscules
+    vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' })
+
+    const result = await registerCongregation('Ma Congrégation', 'test-congre', 'ADMIN@TEST.COM', 'motdepasse')
+
+    expect(result).toHaveProperty('error')
+  })
+
+  it('fonctionne même si le rôle admin n\'existe pas', async () => {
+    vi.mocked(db.userRole.findUnique).mockResolvedValue(null)
+
+    const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
+
+    // Ne doit pas planter, juste ne pas assigner de rôle
+    expect(result).toEqual({ congregationSlug: 'test-congre', userId: 10 })
+  })
+})

--- a/app/features/authentication/server/register-congregation.server.ts
+++ b/app/features/authentication/server/register-congregation.server.ts
@@ -10,7 +10,7 @@ export async function registerCongregation(
 ) {
   const existingCongregation = await db.congregation.findUnique({ where: { slug: congregationSlug } })
   if (existingCongregation) {
-    return { error: 'Ce nom de congrégation est déjà pris.' }
+    return { error: 'Ce nom d\'assemblée locale est déjà pris.' }
   }
 
   const existingUser = await db.user.findUnique({ where: { email: adminEmail.toLowerCase() } })

--- a/app/features/authentication/server/reset-user-password.server.test.ts
+++ b/app/features/authentication/server/reset-user-password.server.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { update: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/crypto.server', () => ({
+  hash: vi.fn().mockResolvedValue('new-hashed-password'),
+}))
+
+const { resetUserPassword } = await import('./reset-user-password.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.user.update).mockResolvedValue({})
+})
+
+describe('resetUserPassword', () => {
+  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+    await expect(resetUserPassword(1, 'nouveau-mdp')).resolves.toBeUndefined()
+  })
+})

--- a/app/features/authentication/server/reset-user-password.server.test.ts
+++ b/app/features/authentication/server/reset-user-password.server.test.ts
@@ -7,7 +7,7 @@ vi.mock('~/shared/libs/db.server', () => ({
 }))
 
 vi.mock('~/shared/libs/crypto.server', () => ({
-  hash: vi.fn().mockResolvedValue('new-hashed-password'),
+  hash: vi.fn().mockResolvedValue('new-hashed-password' as never),
 }))
 
 const { resetUserPassword } = await import('./reset-user-password.server')
@@ -15,7 +15,7 @@ const { unscopedDb: db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.user.update).mockResolvedValue({})
+  vi.mocked(db.user.update).mockResolvedValue({} as never)
 })
 
 describe('resetUserPassword', () => {

--- a/app/features/authentication/server/sanitize-user.server.test.ts
+++ b/app/features/authentication/server/sanitize-user.server.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeUser } from './sanitize-user.server'
+
+describe('sanitizeUser', () => {
+  it('supprime le mot de passe de l\'objet utilisateur', () => {
+    const user = {
+      id: 1,
+      email: 'test@example.com',
+      password: 'secret-hash',
+      firstname: 'Jean',
+      lastname: 'Dupont',
+    }
+
+    const result = sanitizeUser(user as never)
+    expect(result).not.toHaveProperty('password')
+    expect(result).toHaveProperty('id', 1)
+    expect(result).toHaveProperty('email', 'test@example.com')
+    expect(result).toHaveProperty('firstname', 'Jean')
+    expect(result).toHaveProperty('lastname', 'Dupont')
+  })
+
+  it('conserve toutes les autres propriétés', () => {
+    const user = {
+      id: 42,
+      email: 'a@b.com',
+      password: 'hash',
+      active: true,
+      isPublisher: false,
+      congregationId: 5,
+    }
+
+    const result = sanitizeUser(user as never)
+    expect(result).toEqual({
+      id: 42,
+      email: 'a@b.com',
+      active: true,
+      isPublisher: false,
+      congregationId: 5,
+    })
+  })
+})

--- a/app/features/authentication/server/send-reset-user-password-email.server.test.ts
+++ b/app/features/authentication/server/send-reset-user-password-email.server.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/congregation.server', () => ({
+  resolveCongregation: vi.fn(),
+}))
+
+vi.mock('~/shared/libs/mailer.server', () => ({
+  mailer: {
+    emails: { send: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/logger.server', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}))
+
+const { sendResetUserPasswordEmail } = await import('./send-reset-user-password-email.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+const { resolveCongregation } = await import('~/shared/libs/congregation.server')
+const { mailer } = await import('~/shared/libs/mailer.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('sendResetUserPasswordEmail', () => {
+  it('retourne false quand l\'utilisateur n\'existe pas', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+
+    const result = await sendResetUserPasswordEmail(999, 'email-template' as never)
+    expect(result).toBe(false)
+  })
+
+  it('envoie l\'email quand l\'utilisateur existe', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 })
+    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' })
+    vi.mocked(mailer.emails.send).mockResolvedValue({})
+
+    // Ne doit pas retourner false
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await sendResetUserPasswordEmail(1, 'email-template' as never)
+    // La fonction ne retourne rien (undefined) en cas de succès
+    expect(result).not.toBe(false)
+  })
+
+  it('ne lance pas d\'erreur quand l\'envoi d\'email échoue', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 })
+    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' })
+    vi.mocked(mailer.emails.send).mockRejectedValue(new Error('SMTP error'))
+
+    await expect(sendResetUserPasswordEmail(1, 'email-template' as never)).resolves.not.toThrow()
+  })
+})

--- a/app/features/authentication/server/send-reset-user-password-email.server.test.ts
+++ b/app/features/authentication/server/send-reset-user-password-email.server.test.ts
@@ -33,16 +33,16 @@ beforeEach(() => {
 
 describe('sendResetUserPasswordEmail', () => {
   it('retourne false quand l\'utilisateur n\'existe pas', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+    vi.mocked(db.user.findFirst).mockResolvedValue(null as never)
 
     const result = await sendResetUserPasswordEmail(999, 'email-template' as never)
     expect(result).toBe(false)
   })
 
   it('envoie l\'email quand l\'utilisateur existe', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 })
-    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' })
-    vi.mocked(mailer.emails.send).mockResolvedValue({})
+    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 } as never)
+    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' } as never)
+    vi.mocked(mailer.emails.send).mockResolvedValue({} as never)
 
     // Ne doit pas retourner false
     const sentinel = Symbol('sentinel')
@@ -53,8 +53,8 @@ describe('sendResetUserPasswordEmail', () => {
   })
 
   it('ne lance pas d\'erreur quand l\'envoi d\'email échoue', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 })
-    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' })
+    vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 } as never)
+    vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' } as never)
     vi.mocked(mailer.emails.send).mockRejectedValue(new Error('SMTP error'))
 
     await expect(sendResetUserPasswordEmail(1, 'email-template' as never)).resolves.not.toThrow()

--- a/app/features/authentication/server/setup-first-user.server.test.ts
+++ b/app/features/authentication/server/setup-first-user.server.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/shared/libs/db.server', () => ({
 }))
 
 vi.mock('~/shared/libs/crypto.server', () => ({
-  hash: vi.fn().mockResolvedValue('hashed-password'),
+  hash: vi.fn().mockResolvedValue('hashed-password' as never),
 }))
 
 const { setupFirstUser } = await import('./setup-first-user.server')
@@ -18,10 +18,10 @@ const { unscopedDb: db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test' })
-  vi.mocked(db.user.create).mockResolvedValue({ id: 42 })
-  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' })
-  vi.mocked(db.congregationUserRole.create).mockResolvedValue({})
+  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test' } as never)
+  vi.mocked(db.user.create).mockResolvedValue({ id: 42 } as never)
+  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' } as never)
+  vi.mocked(db.congregationUserRole.create).mockResolvedValue({} as never)
 })
 
 describe('setupFirstUser', () => {
@@ -31,7 +31,7 @@ describe('setupFirstUser', () => {
   })
 
   it('fonctionne même si le rôle admin n\'existe pas', async () => {
-    vi.mocked(db.userRole.findUnique).mockResolvedValue(null)
+    vi.mocked(db.userRole.findUnique).mockResolvedValue(null as never)
 
     const result = await setupFirstUser('admin@test.com', 'motdepasse', 'Ma Congré', 'ma-congre')
     expect(result).toBe(42)

--- a/app/features/authentication/server/setup-first-user.server.test.ts
+++ b/app/features/authentication/server/setup-first-user.server.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    congregation: { create: vi.fn() },
+    user: { create: vi.fn() },
+    userRole: { findUnique: vi.fn() },
+    congregationUserRole: { create: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/crypto.server', () => ({
+  hash: vi.fn().mockResolvedValue('hashed-password'),
+}))
+
+const { setupFirstUser } = await import('./setup-first-user.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test' })
+  vi.mocked(db.user.create).mockResolvedValue({ id: 42 })
+  vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' })
+  vi.mocked(db.congregationUserRole.create).mockResolvedValue({})
+})
+
+describe('setupFirstUser', () => {
+  it('retourne l\'id de l\'utilisateur créé', async () => {
+    const result = await setupFirstUser('admin@test.com', 'motdepasse', 'Ma Congré', 'ma-congre')
+    expect(result).toBe(42)
+  })
+
+  it('fonctionne même si le rôle admin n\'existe pas', async () => {
+    vi.mocked(db.userRole.findUnique).mockResolvedValue(null)
+
+    const result = await setupFirstUser('admin@test.com', 'motdepasse', 'Ma Congré', 'ma-congre')
+    expect(result).toBe(42)
+  })
+})

--- a/app/features/authentication/server/validate-credentials.server.test.ts
+++ b/app/features/authentication/server/validate-credentials.server.test.ts
@@ -22,23 +22,23 @@ describe('validateCredentials', () => {
   const fakeUser = { id: 42, email: 'test@example.com', password: 'hashed.password', active: true }
 
   it('retourne l\'id de l\'utilisateur pour des identifiants valides', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
-    vi.mocked(compare).mockResolvedValue(true)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(true as never)
 
     const result = await validateCredentials('test@example.com', 'motdepasse')
     expect(result).toBe(42)
   })
 
   it('normalise l\'email en minuscules', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
-    vi.mocked(compare).mockResolvedValue(true)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(true as never)
 
     const result = await validateCredentials('TEST@EXAMPLE.COM', 'motdepasse')
     expect(result).toBe(42)
   })
 
   it('retourne undefined pour un utilisateur inexistant', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+    vi.mocked(db.user.findFirst).mockResolvedValue(null as never)
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
@@ -48,7 +48,7 @@ describe('validateCredentials', () => {
   })
 
   it('retourne undefined pour un utilisateur inactif', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue({ ...fakeUser, active: false })
+    vi.mocked(db.user.findFirst).mockResolvedValue({ ...fakeUser, active: false } as never)
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
@@ -58,8 +58,8 @@ describe('validateCredentials', () => {
   })
 
   it('retourne undefined pour un mauvais mot de passe', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
-    vi.mocked(compare).mockResolvedValue(false)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(false as never)
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
@@ -69,7 +69,7 @@ describe('validateCredentials', () => {
   })
 
   it('retourne undefined si compare lance une erreur', async () => {
-    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
     vi.mocked(compare).mockRejectedValue(new Error('crypto error'))
 
     const sentinel = Symbol('sentinel')

--- a/app/features/authentication/server/validate-credentials.server.test.ts
+++ b/app/features/authentication/server/validate-credentials.server.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { findFirst: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/crypto.server', () => ({
+  compare: vi.fn(),
+}))
+
+const { validateCredentials } = await import('./validate-credentials.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
+const { compare } = await import('~/shared/libs/crypto.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('validateCredentials', () => {
+  const fakeUser = { id: 42, email: 'test@example.com', password: 'hashed.password', active: true }
+
+  it('retourne l\'id de l\'utilisateur pour des identifiants valides', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockResolvedValue(true)
+
+    const result = await validateCredentials('test@example.com', 'motdepasse')
+    expect(result).toBe(42)
+  })
+
+  it('normalise l\'email en minuscules', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockResolvedValue(true)
+
+    const result = await validateCredentials('TEST@EXAMPLE.COM', 'motdepasse')
+    expect(result).toBe(42)
+  })
+
+  it('retourne undefined pour un utilisateur inexistant', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(null)
+
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await validateCredentials('inconnu@example.com', 'motdepasse')
+    expect(result).toBeUndefined()
+    expect(result).not.toBe(sentinel) // prouve que le code a bien tourné
+  })
+
+  it('retourne undefined pour un utilisateur inactif', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue({ ...fakeUser, active: false })
+
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await validateCredentials('test@example.com', 'motdepasse')
+    expect(result).toBeUndefined()
+    expect(result).not.toBe(sentinel)
+  })
+
+  it('retourne undefined pour un mauvais mot de passe', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockResolvedValue(false)
+
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await validateCredentials('test@example.com', 'mauvais')
+    expect(result).toBeUndefined()
+    expect(result).not.toBe(sentinel)
+  })
+
+  it('retourne undefined si compare lance une erreur', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser)
+    vi.mocked(compare).mockRejectedValue(new Error('crypto error'))
+
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await validateCredentials('test@example.com', 'motdepasse')
+    expect(result).toBeUndefined()
+    expect(result).not.toBe(sentinel)
+  })
+})

--- a/app/features/authorization/server/verify-role.server.test.ts
+++ b/app/features/authorization/server/verify-role.server.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/features/authentication/server/session.server', () => ({
+  getSession: vi.fn(),
+}))
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { findUnique: vi.fn() },
+    congregationUserRole: { findFirst: vi.fn() },
+  },
+  congregationContext: {
+    getStore: vi.fn(),
+  },
+}))
+
+const { verifyRole } = await import('./verify-role.server')
+const { getSession } = await import('~/features/authentication/server/session.server')
+const { unscopedDb, congregationContext } = await import('~/shared/libs/db.server')
+
+function makeRequest() {
+  return new Request('http://localhost/', {
+    // biome-ignore lint/style/useNamingConvention: HTTP header name
+    headers: { Cookie: 'session=abc' },
+  })
+}
+
+function makeSession(userId: string | undefined) {
+  return {
+    get: vi.fn((key: string) => (key === 'userId' ? userId : undefined)),
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('verifyRole', () => {
+  it('retourne false quand userId n\'est pas dans la session', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession(undefined))
+
+    const result = await verifyRole(makeRequest(), 'board-uploader')
+    expect(result).toBe(false)
+  })
+
+  it('retourne false quand userId n\'est pas un nombre', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('abc'))
+
+    const result = await verifyRole(makeRequest(), 'board-uploader')
+    expect(result).toBe(false)
+  })
+
+  it('retourne true quand l\'utilisateur a le rôle admin', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
+    // Premier findFirst: admin role → trouvé
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 1 })
+
+    const result = await verifyRole(makeRequest(), 'board-uploader')
+    expect(result).toBe(true)
+  })
+
+  it('retourne true quand l\'utilisateur a le rôle demandé (pas admin)', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
+    // Premier findFirst: admin role → pas trouvé
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null)
+    // Deuxième findFirst: rôle demandé → trouvé
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 2 })
+
+    const result = await verifyRole(makeRequest(), 'board-uploader')
+    expect(result).toBe(true)
+  })
+
+  it('retourne false quand l\'utilisateur n\'a ni admin ni le rôle demandé', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValue(null)
+
+    const result = await verifyRole(makeRequest(), 'board-uploader')
+    expect(result).toBe(false)
+  })
+
+  it('fait un fallback sur la base quand le contexte AsyncLocalStorage est vide', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 5 })
+    // admin check → non, role check → oui
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 3 })
+
+    const result = await verifyRole(makeRequest(), 'territories-manager')
+    expect(result).toBe(true)
+  })
+
+  it('retourne false quand le fallback ne trouve pas l\'utilisateur', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null)
+
+    const result = await verifyRole(makeRequest(), 'territories-manager')
+    expect(result).toBe(false)
+  })
+})

--- a/app/features/authorization/server/verify-role.server.test.ts
+++ b/app/features/authorization/server/verify-role.server.test.ts
@@ -37,67 +37,67 @@ beforeEach(() => {
 
 describe('verifyRole', () => {
   it('retourne false quand userId n\'est pas dans la session', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession(undefined))
+    vi.mocked(getSession).mockResolvedValue(makeSession(undefined) as never)
 
-    const result = await verifyRole(makeRequest(), 'board-uploader')
+    const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
   it('retourne false quand userId n\'est pas un nombre', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('abc'))
+    vi.mocked(getSession).mockResolvedValue(makeSession('abc') as never)
 
-    const result = await verifyRole(makeRequest(), 'board-uploader')
+    const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
   it('retourne true quand l\'utilisateur a le rôle admin', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → trouvé
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 1 })
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 1 } as never)
 
-    const result = await verifyRole(makeRequest(), 'board-uploader')
+    const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(true)
   })
 
   it('retourne true quand l\'utilisateur a le rôle demandé (pas admin)', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → pas trouvé
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null)
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null as never)
     // Deuxième findFirst: rôle demandé → trouvé
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 2 })
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 2 } as never)
 
-    const result = await verifyRole(makeRequest(), 'board-uploader')
+    const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(true)
   })
 
   it('retourne false quand l\'utilisateur n\'a ni admin ni le rôle demandé', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 })
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValue(null)
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValue(null as never)
 
-    const result = await verifyRole(makeRequest(), 'board-uploader')
+    const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
   it('fait un fallback sur la base quand le contexte AsyncLocalStorage est vide', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
-    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 5 })
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 5 } as never)
     // admin check → non, role check → oui
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 3 })
+    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null as never).mockResolvedValueOnce({ id: 3 } as never)
 
-    const result = await verifyRole(makeRequest(), 'territories-manager')
+    const result = await verifyRole(makeRequest(), 'territories-manager' as never)
     expect(result).toBe(true)
   })
 
   it('retourne false quand le fallback ne trouve pas l\'utilisateur', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
-    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null)
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null as never)
 
-    const result = await verifyRole(makeRequest(), 'territories-manager')
+    const result = await verifyRole(makeRequest(), 'territories-manager' as never)
     expect(result).toBe(false)
   })
 })

--- a/app/features/board/routes/documents/edit.tsx
+++ b/app/features/board/routes/documents/edit.tsx
@@ -188,11 +188,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
       visibleFrom: visibleFrom.getTime() > 0 ? visibleFrom : canManageBoard ? null : undefined,
       visibleUntil: visibleUntil.getTime() > 0 ? visibleUntil : canManageBoard ? null : undefined,
-      ...(form.has('hightlighted')
-        ? {
-            isHighlighted: isHighlighted,
-          }
-        : {}),
+      isHighlighted,
     },
   })
 

--- a/app/features/board/routes/documents/new.tsx
+++ b/app/features/board/routes/documents/new.tsx
@@ -5,7 +5,6 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { saveFile } from '~/features/board/server/document'
 import { sendNewDocumentNotificationEmail } from '~/features/board/server/notifications'
-import { requireCongregation } from '~/shared/libs/congregation.server'
 import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import logger from '~/shared/libs/logger.server'
@@ -133,7 +132,7 @@ export default function NewDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session } = await verifySession(request)
+  const { currentUser, session, congregation } = await verifySession(request)
 
   const canUploadDocument = await verifyRole(request, Role.BoardUploader)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
@@ -190,7 +189,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/documents/new')
   }
 
-  const congregation = requireCongregation()
   const limits = new LimitService(congregation)
   await limits.errorIfWouldGoOverLimit('boardDocuments')
 
@@ -203,7 +201,7 @@ export async function action({ request }: Route.ActionArgs) {
       uri: storageKey,
       sectionId: sectionId,
       order: 0,
-      congregationId: 0 as number,
+      congregationId: congregation.id,
       ...(visibleFrom.getTime() > 0
         ? {
             visibleFrom,

--- a/app/features/board/routes/sections/new.tsx
+++ b/app/features/board/routes/sections/new.tsx
@@ -49,7 +49,7 @@ export default function NewSectionPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, congregation } = await verifySession(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -61,7 +61,7 @@ export async function action({ request }: Route.ActionArgs) {
   const section = await db.boardSection.create({
     data: {
       name: String(name),
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -75,14 +75,14 @@ export default function DaysOffPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session } = await verifySession(request)
+  const { currentUser, session, congregation } = await verifySession(request)
   const formData = await request.formData()
   const startDate = new Date(String(formData.get('start_date')))
   const endDate = new Date(String(formData.get('end_date')))
 
   logger.info(`Creating new days off. User ID: ${currentUser.id}.`)
 
-  const event = createDayOff(currentUser.id, startDate, endDate)
+  const event = createDayOff(currentUser.id, startDate, endDate, congregation.id)
   if (event == null) {
     session.flash('error', `Impossible d'ajouter cette absence. Les dates sont invalides.`)
     logger.info(`Failed to creating new days off. User ID: ${currentUser.id}.`)

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -82,7 +82,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   logger.info(`Creating new days off. User ID: ${currentUser.id}.`)
 
-  const event = createDayOff(currentUser.id, startDate, endDate, congregation.id)
+  const event = await createDayOff(currentUser.id, startDate, endDate, congregation.id)
   if (event == null) {
     session.flash('error', `Impossible d'ajouter cette absence. Les dates sont invalides.`)
     logger.info(`Failed to creating new days off. User ID: ${currentUser.id}.`)

--- a/app/features/events/server/days-off.server.test.ts
+++ b/app/features/events/server/days-off.server.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    event: { findMany: vi.fn(), create: vi.fn() },
+    eventKind: { findFirst: vi.fn() },
+  },
+}))
+
+const { createDayOff } = await import('./days-off.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('createDayOff', () => {
+  it('retourne null quand startDate est null', async () => {
+    const result = await createDayOff(1, null, new Date(2025, 3, 10))
+    expect(result).toBeNull()
+  })
+
+  it('retourne null quand endDate est null', async () => {
+    const result = await createDayOff(1, new Date(2025, 3, 8), null)
+    expect(result).toBeNull()
+  })
+
+  it('retourne null quand startDate est undefined', async () => {
+    const result = await createDayOff(1, undefined, new Date(2025, 3, 10))
+    expect(result).toBeNull()
+  })
+
+  it('retourne null quand startDate > endDate', async () => {
+    const result = await createDayOff(1, new Date(2025, 3, 15), new Date(2025, 3, 10))
+    expect(result).toBeNull()
+  })
+
+  it('crée un événement quand les dates sont valides', async () => {
+    const fakeEvent = { id: 1, name: 'Absence' }
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+
+    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10))
+    expect(result).toEqual(fakeEvent)
+  })
+
+  it('crée un événement même quand startDate == endDate', async () => {
+    const sameDate = new Date(2025, 3, 8)
+    const fakeEvent = { id: 2, name: 'Absence' }
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+
+    const result = await createDayOff(1, sameDate, sameDate)
+    expect(result).toEqual(fakeEvent)
+  })
+
+  it('crée l\'événement même sans eventKind trouvé', async () => {
+    const fakeEvent = { id: 3, name: 'Absence' }
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue(null)
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+
+    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10))
+    expect(result).toEqual(fakeEvent)
+  })
+})

--- a/app/features/events/server/days-off.server.test.ts
+++ b/app/features/events/server/days-off.server.test.ts
@@ -37,8 +37,8 @@ describe('createDayOff', () => {
 
   it('crée un événement quand les dates sont valides', async () => {
     const fakeEvent = { id: 1, name: 'Absence' }
-    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
-    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' } as never)
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
     const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)
@@ -47,8 +47,8 @@ describe('createDayOff', () => {
   it('crée un événement même quand startDate == endDate', async () => {
     const sameDate = new Date(2025, 3, 8)
     const fakeEvent = { id: 2, name: 'Absence' }
-    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
-    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' } as never)
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
     const result = await createDayOff(1, sameDate, sameDate, 1)
     expect(result).toEqual(fakeEvent)
@@ -56,8 +56,8 @@ describe('createDayOff', () => {
 
   it('crée l\'événement même sans eventKind trouvé', async () => {
     const fakeEvent = { id: 3, name: 'Absence' }
-    vi.mocked(db.eventKind.findFirst).mockResolvedValue(null)
-    vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
+    vi.mocked(db.eventKind.findFirst).mockResolvedValue(null as never)
+    vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
     const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)

--- a/app/features/events/server/days-off.server.test.ts
+++ b/app/features/events/server/days-off.server.test.ts
@@ -16,22 +16,22 @@ beforeEach(() => {
 
 describe('createDayOff', () => {
   it('retourne null quand startDate est null', async () => {
-    const result = await createDayOff(1, null, new Date(2025, 3, 10))
+    const result = await createDayOff(1, null, new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand endDate est null', async () => {
-    const result = await createDayOff(1, new Date(2025, 3, 8), null)
+    const result = await createDayOff(1, new Date(2025, 3, 8), null, 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand startDate est undefined', async () => {
-    const result = await createDayOff(1, undefined, new Date(2025, 3, 10))
+    const result = await createDayOff(1, undefined, new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand startDate > endDate', async () => {
-    const result = await createDayOff(1, new Date(2025, 3, 15), new Date(2025, 3, 10))
+    const result = await createDayOff(1, new Date(2025, 3, 15), new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
@@ -40,7 +40,7 @@ describe('createDayOff', () => {
     vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
 
-    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10))
+    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)
   })
 
@@ -50,7 +50,7 @@ describe('createDayOff', () => {
     vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' })
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
 
-    const result = await createDayOff(1, sameDate, sameDate)
+    const result = await createDayOff(1, sameDate, sameDate, 1)
     expect(result).toEqual(fakeEvent)
   })
 
@@ -59,7 +59,7 @@ describe('createDayOff', () => {
     vi.mocked(db.eventKind.findFirst).mockResolvedValue(null)
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent)
 
-    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10))
+    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)
   })
 })

--- a/app/features/events/server/days-off.server.ts
+++ b/app/features/events/server/days-off.server.ts
@@ -17,7 +17,12 @@ export function getNextDaysOffs(userId: number) {
   })
 }
 
-export async function createDayOff(userId: number, startDate?: Date | null, endDate?: Date | null) {
+export async function createDayOff(
+  userId: number,
+  startDate: Date | null | undefined,
+  endDate: Date | null | undefined,
+  congregationId: number,
+) {
   if (startDate == null || endDate == null) {
     return null
   }
@@ -35,7 +40,7 @@ export async function createDayOff(userId: number, startDate?: Date | null, endD
       endDate,
       createdBy: { connect: { id: userId } },
       name: 'Absence',
-      congregation: { connect: { id: 0 as number } },
+      congregation: { connect: { id: congregationId } },
     },
   })
 }

--- a/app/features/events/server/event-filters.server.test.ts
+++ b/app/features/events/server/event-filters.server.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computeFilters } from './event-filters.server'
+
+describe('computeFilters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 3, 8, 12, 0, 0))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retourne un filtre sur la date courante par défaut', () => {
+    const params = new URLSearchParams()
+    const result = computeFilters(params)
+
+    expect(result.startDate).toEqual({ lte: expect.any(Date) })
+    expect(result.endDate).toEqual({ gte: expect.any(Date) })
+  })
+
+  it('utilise la date fournie dans les paramètres', () => {
+    const params = new URLSearchParams({ date: '2025-06-15' })
+    const result = computeFilters(params)
+
+    const expectedDate = new Date('2025-06-15')
+    expect(result.startDate).toEqual({ lte: expectedDate })
+    expect(result.endDate).toEqual({ gte: expectedDate })
+  })
+
+  it('retourne le filtre par défaut quand date=none', () => {
+    const params = new URLSearchParams({ date: 'none' })
+    const result = computeFilters(params)
+
+    // Doit utiliser la date courante, pas "none"
+    expect(result.startDate).toEqual({ lte: expect.any(Date) })
+    expect(result.endDate).toEqual({ gte: expect.any(Date) })
+  })
+})

--- a/app/features/events/server/event-kind.server.test.ts
+++ b/app/features/events/server/event-kind.server.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    eventKind: { findMany: vi.fn() },
+  },
+}))
+
+const { getAllEventType } = await import('./event-kind.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getAllEventType', () => {
+  it('retourne tous les types d\'événements', async () => {
+    const fakeEventKinds = [
+      { id: 1, key: 'off', name: 'Absence' },
+      { id: 2, key: 'meeting', name: 'Réunion' },
+    ]
+    vi.mocked(db.eventKind.findMany).mockResolvedValue(fakeEventKinds)
+
+    const result = await getAllEventType()
+    expect(result).toEqual(fakeEventKinds)
+  })
+
+  it('retourne un tableau vide quand il n\'y a pas de types', async () => {
+    vi.mocked(db.eventKind.findMany).mockResolvedValue([])
+
+    const result = await getAllEventType()
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/events/server/event-kind.server.test.ts
+++ b/app/features/events/server/event-kind.server.test.ts
@@ -19,14 +19,14 @@ describe('getAllEventType', () => {
       { id: 1, key: 'off', name: 'Absence' },
       { id: 2, key: 'meeting', name: 'Réunion' },
     ]
-    vi.mocked(db.eventKind.findMany).mockResolvedValue(fakeEventKinds)
+    vi.mocked(db.eventKind.findMany).mockResolvedValue(fakeEventKinds as never)
 
     const result = await getAllEventType()
     expect(result).toEqual(fakeEventKinds)
   })
 
   it('retourne un tableau vide quand il n\'y a pas de types', async () => {
-    vi.mocked(db.eventKind.findMany).mockResolvedValue([])
+    vi.mocked(db.eventKind.findMany).mockResolvedValue([] as never)
 
     const result = await getAllEventType()
     expect(result).toEqual([])

--- a/app/features/platform-admin/routes/congregations.tsx
+++ b/app/features/platform-admin/routes/congregations.tsx
@@ -12,7 +12,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~
 import type { Route } from './+types/congregations'
 
 export const meta: Route.MetaFunction = () => {
-  return [{ title: 'Congregations - Unitae Admin' }]
+  return [{ title: 'Assemblées locales - Unitae Admin' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -46,7 +46,7 @@ export default function CongregationsPage({ loaderData }: Route.ComponentProps) 
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Congregations" subtitle={`${congregations.length} congregation(s)`} />
+      <PageHeader title="Assemblées locales" subtitle={`${congregations.length} assemblée(s) locale(s)`} />
 
       <div className="overflow-hidden rounded-xl border">
         <Table>

--- a/app/features/platform-admin/routes/edit-congregation.tsx
+++ b/app/features/platform-admin/routes/edit-congregation.tsx
@@ -14,7 +14,7 @@ import { Separator } from '~/shared/ui/separator'
 import type { Route } from './+types/edit-congregation'
 
 export const meta: Route.MetaFunction = () => {
-  return [{ title: 'Modifier une congregation - Unitae Admin' }]
+  return [{ title: 'Modifier une assemblée locale - Unitae Admin' }]
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {

--- a/app/features/platform-admin/routes/users.tsx
+++ b/app/features/platform-admin/routes/users.tsx
@@ -49,7 +49,7 @@ export default function UsersPage({ loaderData }: Route.ComponentProps) {
             <TableRow>
               <TableHead>Nom</TableHead>
               <TableHead>Email</TableHead>
-              <TableHead>Congregation</TableHead>
+              <TableHead>Assemblée locale</TableHead>
               <TableHead className="text-center">Statut</TableHead>
               <TableHead className="text-center">Admin plateforme</TableHead>
             </TableRow>

--- a/app/features/platform-admin/server/verify-platform-admin.server.test.ts
+++ b/app/features/platform-admin/server/verify-platform-admin.server.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/features/authentication/server/session.server', () => ({
+  getSession: vi.fn(),
+}))
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    user: { findUnique: vi.fn() },
+  },
+}))
+
+const { verifyPlatformAdmin } = await import('./verify-platform-admin.server')
+const { getSession } = await import('~/features/authentication/server/session.server')
+const { unscopedDb } = await import('~/shared/libs/db.server')
+
+function makeRequest() {
+  return new Request('http://localhost/', {
+    // biome-ignore lint/style/useNamingConvention: HTTP header name
+    headers: { Cookie: 'session=abc' },
+  })
+}
+
+function makeSession(userId: string | undefined) {
+  return {
+    get: vi.fn((key: string) => (key === 'userId' ? userId : undefined)),
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('verifyPlatformAdmin', () => {
+  it('retourne userId et email pour un admin plateforme', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({
+      id: 42,
+      email: 'admin@unitae.app',
+      platformAdmin: true,
+    })
+
+    const result = await verifyPlatformAdmin(makeRequest())
+    expect(result).toEqual({ userId: 42, email: 'admin@unitae.app' })
+  })
+
+  it('lance une redirection vers /login quand le userId est invalide', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession(undefined))
+
+    try {
+      await verifyPlatformAdmin(makeRequest())
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/login')
+    }
+  })
+
+  it('lance une redirection vers / quand l\'utilisateur n\'est pas admin plateforme', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({
+      id: 42,
+      email: 'user@test.com',
+      platformAdmin: false,
+    })
+
+    try {
+      await verifyPlatformAdmin(makeRequest())
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/')
+    }
+  })
+
+  it('lance une redirection vers / quand l\'utilisateur n\'existe pas', async () => {
+    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null)
+
+    try {
+      await verifyPlatformAdmin(makeRequest())
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/')
+    }
+  })
+})

--- a/app/features/platform-admin/server/verify-platform-admin.server.test.ts
+++ b/app/features/platform-admin/server/verify-platform-admin.server.test.ts
@@ -33,19 +33,19 @@ beforeEach(() => {
 
 describe('verifyPlatformAdmin', () => {
   it('retourne userId et email pour un admin plateforme', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({
       id: 42,
       email: 'admin@unitae.app',
       platformAdmin: true,
-    })
+    } as never)
 
     const result = await verifyPlatformAdmin(makeRequest())
     expect(result).toEqual({ userId: 42, email: 'admin@unitae.app' })
   })
 
   it('lance une redirection vers /login quand le userId est invalide', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession(undefined))
+    vi.mocked(getSession).mockResolvedValue(makeSession(undefined) as never)
 
     try {
       await verifyPlatformAdmin(makeRequest())
@@ -58,12 +58,12 @@ describe('verifyPlatformAdmin', () => {
   })
 
   it('lance une redirection vers / quand l\'utilisateur n\'est pas admin plateforme', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({
       id: 42,
       email: 'user@test.com',
       platformAdmin: false,
-    })
+    } as never)
 
     try {
       await verifyPlatformAdmin(makeRequest())
@@ -76,8 +76,8 @@ describe('verifyPlatformAdmin', () => {
   })
 
   it('lance une redirection vers / quand l\'utilisateur n\'existe pas', async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42'))
-    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null)
+    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null as never)
 
     try {
       await verifyPlatformAdmin(makeRequest())

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -273,7 +273,7 @@ export default function NewActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session } = await verifySession(request)
+  const { currentUser, session, congregation } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
   const canManageMyGroupActivity =
     currentUser.responsibleFor?.id === currentUser.publisherGroupId ||
@@ -323,7 +323,7 @@ export async function action({ request }: Route.ActionArgs) {
       hours,
       studies,
       notes: observations,
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -134,6 +134,7 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -110,10 +110,9 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
                   id="deputy"
                   className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
                   name="deputy"
-                  required
-                  defaultValue={group.deputyId}
+                  defaultValue={group.deputyId ?? ''}
                 >
-                  <option disabled>Choisir un frère adjoint au responsable de groupe</option>
+                  <option value="">Aucun adjoint</option>
                   {brothers.map(brother => (
                     <option key={brother.id} value={brother.id}>
                       {brother.firstname} {brother.lastname?.toLocaleUpperCase()}
@@ -146,10 +145,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const name = form.get('name')
   const address = form.get('address')
   const responsibleId = Number(form.get('responsible'))
-  const deputyId = Number(form.get('deputy'))
+  const deputyRaw = form.get('deputy')
+  const deputyId = deputyRaw ? Number(deputyRaw) : null
 
   const session = await getSession(request.headers.get('Cookie'))
-  if (name == null || address == null || Number.isNaN(responsibleId) || Number.isNaN(deputyId)) {
+  if (name == null || address == null || Number.isNaN(responsibleId)) {
     session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -158,7 +158,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
   }
 
-  if (responsibleId === deputyId) {
+  if (deputyId != null && responsibleId === deputyId) {
     session.flash('error', 'Le responsable de groupe et son adjoint ne peuvent pas être la même personne')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -166,6 +166,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     })
   }
+
+  const membersToConnect = [{ id: responsibleId }]
+  if (deputyId != null) membersToConnect.push({ id: deputyId })
 
   const group = await db.publisherGroup.update({
     where: {
@@ -176,14 +179,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       adress: String(address),
       deputyId,
       responsibleId,
-      members: {
-        connect: [
-          {
-            id: responsibleId,
-          },
-          { id: deputyId },
-        ],
-      },
+      members: { connect: membersToConnect },
     },
   })
 

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -91,6 +91,7 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  await verifySession(request)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -116,9 +116,13 @@ export default function GroupListPage({ loaderData }: Route.ComponentProps) {
                   </Link>
                 </TableCell>
                 <TableCell className="text-center max-sm:hidden">
-                  <Link to={`/congregation/publishers/${group.deputyId}/view`} className="hover:text-primary">
-                    {group.deputy.firstname} {group.deputy.lastname?.toLocaleUpperCase()}
-                  </Link>
+                  {group.deputy ? (
+                    <Link to={`/congregation/publishers/${group.deputyId}/view`} className="hover:text-primary">
+                      {group.deputy.firstname} {group.deputy.lastname?.toLocaleUpperCase()}
+                    </Link>
+                  ) : (
+                    '—'
+                  )}
                 </TableCell>
                 <TableCell className="text-center max-sm:hidden">{group.adress}</TableCell>
                 <TableCell className="text-center">{group._count.members}</TableCell>

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -225,6 +225,7 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -35,7 +35,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       canManagePublisher,
       canViewPublishers,
       canManageActivity:
-        canManageActivity || group.responsible.id === currentUser.id || group.deputy.id === currentUser.id,
+        canManageActivity || group.responsible.id === currentUser.id || group.deputy?.id === currentUser.id,
     },
   }
 }
@@ -80,13 +80,17 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
           </p>
           <p className="text-muted-foreground text-sm">
             Adjoint au responsable :{' '}
-            <Link
-              to={`../../../publishers/${group.deputy.id}/view`}
-              relative="path"
-              className="font-medium text-primary hover:underline"
-            >
-              {group.deputy.firstname} {group.deputy.lastname?.toLocaleUpperCase()}
-            </Link>
+            {group.deputy ? (
+              <Link
+                to={`../../../publishers/${group.deputy.id}/view`}
+                relative="path"
+                className="font-medium text-primary hover:underline"
+              >
+                {group.deputy.firstname} {group.deputy.lastname?.toLocaleUpperCase()}
+              </Link>
+            ) : (
+              <span className="font-medium text-foreground">Aucun</span>
+            )}
           </p>
           <p className="text-muted-foreground text-sm">
             Adresse : <span className="font-medium text-foreground">{group.address}</span>
@@ -237,10 +241,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const name = form.get('name')
   const address = form.get('address')
   const responsibleId = Number(form.get('responsible'))
-  const deputyId = Number(form.get('deputy'))
+  const deputyRaw = form.get('deputy')
+  const deputyId = deputyRaw ? Number(deputyRaw) : null
 
   const session = await getSession(request.headers.get('Cookie'))
-  if (name == null || address == null || Number.isNaN(responsibleId) || Number.isNaN(deputyId)) {
+  if (name == null || address == null || Number.isNaN(responsibleId)) {
     session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -249,7 +254,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
   }
 
-  if (responsibleId === deputyId) {
+  if (deputyId != null && responsibleId === deputyId) {
     session.flash('error', 'Le responsable de groupe et son adjoint ne peuvent pas être la même personne')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -257,6 +262,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     })
   }
+
+  const membersToConnect = [{ id: responsibleId }]
+  if (deputyId != null) membersToConnect.push({ id: deputyId })
 
   const group = await db.publisherGroup.update({
     where: {
@@ -267,14 +275,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       adress: String(address),
       deputyId,
       responsibleId,
-      members: {
-        connect: [
-          {
-            id: responsibleId,
-          },
-          { id: deputyId },
-        ],
-      },
+      members: { connect: membersToConnect },
     },
   })
 

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -86,9 +86,8 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
                   id="deputy"
                   className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
                   name="deputy"
-                  required
                 >
-                  <option>Choisir un frère adjoint au responsable de groupe</option>
+                  <option value="">Aucun adjoint</option>
                   {brothers.map(brother => (
                     <option key={brother.id} value={brother.id}>
                       {brother.firstname} {brother.lastname?.toLocaleUpperCase()}
@@ -121,10 +120,11 @@ export async function action({ request }: Route.ActionArgs) {
   const name = form.get('name')
   const address = form.get('address')
   const responsibleId = Number(form.get('responsible'))
-  const deputyId = Number(form.get('deputy'))
+  const deputyRaw = form.get('deputy')
+  const deputyId = deputyRaw ? Number(deputyRaw) : null
 
   const session = await getSession(request.headers.get('Cookie'))
-  if (name == null || address == null || Number.isNaN(responsibleId) || Number.isNaN(deputyId)) {
+  if (name == null || address == null || Number.isNaN(responsibleId)) {
     session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -133,7 +133,7 @@ export async function action({ request }: Route.ActionArgs) {
     })
   }
 
-  if (responsibleId === deputyId) {
+  if (deputyId != null && responsibleId === deputyId) {
     session.flash('error', 'Le responsable de groupe et son adjoint ne peuvent pas être la même personne')
     throw redirect(previousPage ?? '/congregation/publisher-groups', {
       headers: {
@@ -142,20 +142,16 @@ export async function action({ request }: Route.ActionArgs) {
     })
   }
 
+  const membersToConnect = [{ id: responsibleId }]
+  if (deputyId != null) membersToConnect.push({ id: deputyId })
+
   const group = await db.publisherGroup.create({
     data: {
       name: String(name),
       adress: String(address),
       deputyId,
       responsibleId,
-      members: {
-        connect: [
-          {
-            id: responsibleId,
-          },
-          { id: deputyId },
-        ],
-      },
+      members: { connect: membersToConnect },
       congregationId: congregation.id,
     },
   })

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -109,6 +109,7 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  const { congregation } = await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
@@ -155,7 +156,7 @@ export async function action({ request }: Route.ActionArgs) {
           { id: deputyId },
         ],
       },
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -5,7 +5,6 @@ import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
-import { requireCongregation } from '~/shared/libs/congregation.server'
 import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
@@ -51,7 +50,7 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -69,7 +68,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/congregation/publishers/new')
   }
 
-  const congregation = requireCongregation()
   const limits = new LimitService(congregation)
   await limits.errorIfWouldGoOverLimit('publishers')
 
@@ -90,7 +88,7 @@ export async function action({ request }: Route.ActionArgs) {
       isAnointed: Boolean(isAnointed),
       publisherGroupId: Number.isNaN(groupId) ? null : groupId,
       type: String(type),
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -51,6 +51,7 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  await verifySession(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))

--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -85,7 +85,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       canManageActivity:
         canManageActivity ||
         publisher.publisherGroup?.responsible.id === currentUser.id ||
-        publisher.publisherGroup?.deputy.id === currentUser.id,
+        publisher.publisherGroup?.deputy?.id === currentUser.id,
     },
   }
 }

--- a/app/features/publishers/server/get-publisher-stats.server.test.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PublisherType } from '~/shared/types/publisher-type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    user: { count: vi.fn() },
+    publisherActivity: { groupBy: vi.fn() },
+  },
+}))
+
+const { getPublisherStats } = await import('./get-publisher-stats.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+function makeFigure(type: PublisherType, count: number, hours: number, studies: number) {
+  return {
+    type,
+    _count: { _all: count },
+    _sum: { hours, studies },
+  }
+}
+
+describe('getPublisherStats', () => {
+  it('agrège les statistiques par type de proclamateur', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(25)
+    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([
+      makeFigure(PublisherType.Normal, 15, 0, 5),
+      makeFigure(PublisherType.PionnierPermanant, 3, 210, 8),
+      makeFigure(PublisherType.PionnierAuxiliaires, 7, 350, 3),
+    ])
+
+    const result = await getPublisherStats(3, 2025)
+
+    // all: total
+    expect(result.all.count).toBe(25)
+    expect(result.all.active).toBe(15 + 3 + 7) // 25
+    expect(result.all.hours).toBe(210 + 350) // 560 (heures seulement pour les pionniers)
+    expect(result.all.studies).toBe(5 + 8 + 3) // 16
+
+    // par type
+    expect(result.publishers.count).toBe(15)
+    expect(result.publishers.hours).toBe(0)
+    expect(result.publishers.studies).toBe(5)
+
+    expect(result.permanentPionneer.count).toBe(3)
+    expect(result.permanentPionneer.hours).toBe(210)
+    expect(result.permanentPionneer.studies).toBe(8)
+
+    expect(result.auxiliaryPionneer.count).toBe(7)
+    expect(result.auxiliaryPionneer.hours).toBe(350)
+    expect(result.auxiliaryPionneer.studies).toBe(3)
+  })
+
+  it('gère le cas sans activité (données vides)', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(0)
+    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([])
+
+    const result = await getPublisherStats(1, 2025)
+
+    expect(result.all.count).toBe(0)
+    expect(result.all.active).toBe(0)
+    expect(result.all.hours).toBe(0)
+    expect(result.all.studies).toBe(0)
+
+    expect(result.publishers.count).toBe(0)
+    expect(result.permanentPionneer.count).toBe(0)
+    expect(result.auxiliaryPionneer.count).toBe(0)
+  })
+
+  it('gère le cas où seuls certains types ont des activités', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(10)
+    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([
+      makeFigure(PublisherType.Normal, 10, 0, 2),
+    ])
+
+    const result = await getPublisherStats(6, 2025)
+
+    expect(result.all.active).toBe(10)
+    expect(result.all.hours).toBe(0) // pas de pionniers
+    expect(result.permanentPionneer.count).toBe(0)
+    expect(result.auxiliaryPionneer.count).toBe(0)
+  })
+
+  it('note: all.hours ne compte pas les heures des proclamateurs normaux', async () => {
+    vi.mocked(db.user.count).mockResolvedValue(5)
+    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([
+      makeFigure(PublisherType.Normal, 5, 100, 0), // 100 heures pour les normaux
+      makeFigure(PublisherType.PionnierPermanant, 2, 50, 0),
+    ])
+
+    const result = await getPublisherStats(1, 2025)
+
+    // all.hours n'inclut que les pionniers permanents et auxiliaires
+    expect(result.all.hours).toBe(50)
+    // mais publishers.hours contient bien les heures des normaux
+    expect(result.publishers.hours).toBe(100)
+  })
+})

--- a/app/features/publishers/server/get-publisher-with-activities.server.test.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    user: { findMany: vi.fn() },
+  },
+}))
+
+const { getPublisherWithActivities } = await import('./get-publisher-with-activities.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getPublisherWithActivities', () => {
+  it('retourne les proclamateurs avec leurs activités du mois', async () => {
+    const fakeResult = [
+      { id: 1, isPublisher: true, activities: [{ month: 3, year: 2025 }] },
+    ]
+    vi.mocked(db.user.findMany).mockResolvedValue(fakeResult)
+
+    const result = await getPublisherWithActivities(3, 2025)
+    expect(result).toEqual(fakeResult)
+  })
+
+  it('retourne un tableau vide quand il n\'y a pas de résultats', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([])
+
+    const result = await getPublisherWithActivities(1, 2025)
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/publishers/server/get-publisher-with-activities.server.test.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.test.ts
@@ -18,14 +18,14 @@ describe('getPublisherWithActivities', () => {
     const fakeResult = [
       { id: 1, isPublisher: true, activities: [{ month: 3, year: 2025 }] },
     ]
-    vi.mocked(db.user.findMany).mockResolvedValue(fakeResult)
+    vi.mocked(db.user.findMany).mockResolvedValue(fakeResult as never)
 
     const result = await getPublisherWithActivities(3, 2025)
     expect(result).toEqual(fakeResult)
   })
 
   it('retourne un tableau vide quand il n\'y a pas de résultats', async () => {
-    vi.mocked(db.user.findMany).mockResolvedValue([])
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
     const result = await getPublisherWithActivities(1, 2025)
     expect(result).toEqual([])

--- a/app/features/publishers/server/publishers.server.test.ts
+++ b/app/features/publishers/server/publishers.server.test.ts
@@ -6,7 +6,7 @@ vi.mock('~/shared/libs/db.server', () => ({
   },
 }))
 
-const { getPublishers, getPublishersWithGroup } = await import('./publishers.ts')
+const { getPublishers, getPublishersWithGroup } = await import('./publishers')
 const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
@@ -16,21 +16,21 @@ beforeEach(() => {
 describe('getPublishers', () => {
   it('retourne les proclamateurs', async () => {
     const fakePublishers = [{ id: 1, firstname: 'Jean' }, { id: 2, firstname: 'Marie' }]
-    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers)
+    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
     const result = await getPublishers()
     expect(result).toEqual(fakePublishers)
   })
 
   it('retourne un tableau vide quand il n\'y a pas de proclamateurs', async () => {
-    vi.mocked(db.user.findMany).mockResolvedValue([])
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
     const result = await getPublishers()
     expect(result).toEqual([])
   })
 
   it('accepte un filtre par groupId', async () => {
-    vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1 }])
+    vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1 }] as never)
 
     const result = await getPublishers({ groupId: 3 })
     expect(result).toHaveLength(1)
@@ -40,7 +40,7 @@ describe('getPublishers', () => {
 describe('getPublishersWithGroup', () => {
   it('retourne les proclamateurs avec leur groupe', async () => {
     const fakePublishers = [{ id: 1, publisherGroup: { name: 'Groupe 1' } }]
-    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers)
+    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
     const result = await getPublishersWithGroup()
     expect(result).toEqual(fakePublishers)

--- a/app/features/publishers/server/publishers.server.test.ts
+++ b/app/features/publishers/server/publishers.server.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    user: { findMany: vi.fn() },
+  },
+}))
+
+const { getPublishers, getPublishersWithGroup } = await import('./publishers.ts')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getPublishers', () => {
+  it('retourne les proclamateurs', async () => {
+    const fakePublishers = [{ id: 1, firstname: 'Jean' }, { id: 2, firstname: 'Marie' }]
+    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers)
+
+    const result = await getPublishers()
+    expect(result).toEqual(fakePublishers)
+  })
+
+  it('retourne un tableau vide quand il n\'y a pas de proclamateurs', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([])
+
+    const result = await getPublishers()
+    expect(result).toEqual([])
+  })
+
+  it('accepte un filtre par groupId', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1 }])
+
+    const result = await getPublishers({ groupId: 3 })
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('getPublishersWithGroup', () => {
+  it('retourne les proclamateurs avec leur groupe', async () => {
+    const fakePublishers = [{ id: 1, publisherGroup: { name: 'Groupe 1' } }]
+    vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers)
+
+    const result = await getPublishersWithGroup()
+    expect(result).toEqual(fakePublishers)
+  })
+})

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -4,12 +4,13 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting, setSetting } from '~/features/settings/server/settings'
-import { db } from '~/shared/libs/db.server'
+import { db, unscopedDb } from '~/shared/libs/db.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Checkbox } from '~/shared/ui/checkbox'
+import { Input } from '~/shared/ui/input'
 import { Label } from '~/shared/ui/label'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/settings'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const canManageSettings = await verifyRole(request, Role.Admin)
 
   if (!canManageSettings) {
@@ -30,17 +31,39 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   return {
     auxiliaryPioneerProfileActivated: auxiliaryPioneerProfileActivated ?? false,
+    congregationDisplayName: congregation.displayName,
   }
 }
 
 export default function BuildingSettingsPage({ loaderData }: Route.ComponentProps) {
-  const { auxiliaryPioneerProfileActivated } = loaderData
+  const { auxiliaryPioneerProfileActivated, congregationDisplayName } = loaderData
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader title="Assemblée" subtitle='Paramètres du module "Assemblée"' />
 
       <Form method="post" className="flex flex-col gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Congrégation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <Label htmlFor="displayName">Nom affiché</Label>
+              <Input
+                id="displayName"
+                name="displayName"
+                type="text"
+                placeholder="Nom affiché de la congrégation"
+                defaultValue={congregationDisplayName}
+              />
+              <p className="text-muted-foreground text-xs">
+                Ce nom est utilisé dans l'interface et dans les emails envoyés par l'application.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
         <Card>
           <CardHeader>
             <CardTitle>Proclamateurs</CardTitle>
@@ -92,9 +115,15 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   const form = await request.formData()
+  const displayName = form.get('displayName')
   const auxiliaryPioneerProfileActivated = String(
     Boolean(form.get(CongregationSettingKey.AuxiliaryPioneerProfileActivated)),
   )
+
+  await unscopedDb.congregation.update({
+    where: { id: congregation.id },
+    data: { displayName: displayName ? String(displayName) : null },
+  })
 
   await setSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated, auxiliaryPioneerProfileActivated, congregation.id)
   if (auxiliaryPioneerProfileActivated === 'false') {

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -45,7 +45,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
       <Form method="post" className="flex flex-col gap-6">
         <Card>
           <CardHeader>
-            <CardTitle>Congrégation</CardTitle>
+            <CardTitle>Assemblée locale</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
@@ -54,7 +54,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
                 id="displayName"
                 name="displayName"
                 type="text"
-                placeholder="Nom affiché de la congrégation"
+                placeholder="Nom affiché de l'assemblée locale"
                 defaultValue={congregationDisplayName}
               />
               <p className="text-muted-foreground text-xs">

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -84,7 +84,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const canManageSettings = await verifyRole(request, Role.Admin)
 
   if (!canManageSettings) {
@@ -96,7 +96,7 @@ export async function action({ request }: Route.ActionArgs) {
     Boolean(form.get(CongregationSettingKey.AuxiliaryPioneerProfileActivated)),
   )
 
-  await setSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated, auxiliaryPioneerProfileActivated)
+  await setSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated, auxiliaryPioneerProfileActivated, congregation.id)
   if (auxiliaryPioneerProfileActivated === 'false') {
     await db.user.updateMany({
       where: {

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -169,7 +169,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -185,13 +185,13 @@ export async function action({ request }: Route.ActionArgs) {
   const apiKey = String(form.get('api-google-map'))
   const phoneTypeActivated = String(Boolean(form.get('phone-territory-active')))
 
-  await setSetting(TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory))
-  await setSetting(TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips))
-  await setSetting(TerritorySettingKey.BanoUrl, banoUrl)
-  await setSetting(TerritorySettingKey.ProspectionValidity, prospectionValidity)
-  await setSetting(TerritorySettingKey.GoogleMapsApiKey, apiKey)
-  await setSetting(TerritorySettingKey.GoogleMapsMapId, mapId)
-  await setSetting(TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated)
+  await setSetting(TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregation.id)
+  await setSetting(TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregation.id)
+  await setSetting(TerritorySettingKey.BanoUrl, banoUrl, congregation.id)
+  await setSetting(TerritorySettingKey.ProspectionValidity, prospectionValidity, congregation.id)
+  await setSetting(TerritorySettingKey.GoogleMapsApiKey, apiKey, congregation.id)
+  await setSetting(TerritorySettingKey.GoogleMapsMapId, mapId, congregation.id)
+  await setSetting(TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregation.id)
 
   return redirect('/settings')
 }

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -3,7 +3,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { congregationContext, db } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -210,6 +210,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
+  const { congregation } = await verifySession(request)
   const canManageUser = await verifyRole(request, Role.SettingsUserManager)
 
   if (!canManageUser) {
@@ -224,8 +225,6 @@ export async function action({ request, params }: Route.ActionArgs) {
   const roles = form.getAll('roles')
 
   const userId = requireParamId(params.userId, '/settings/users')
-  const ctx = congregationContext.getStore()
-  if (!ctx) throw redirect('/')
 
   await db.user.update({
     where: { id: userId },
@@ -239,7 +238,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   // Update congregation-scoped roles: delete existing, create new
   await db.congregationUserRole.deleteMany({
-    where: { userId, congregationId: ctx.congregationId },
+    where: { userId, congregationId: congregation.id },
   })
 
   const roleRecords = await db.userRole.findMany({
@@ -251,7 +250,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       data: roleRecords.map(role => ({
         userId,
         roleId: role.id,
-        congregationId: ctx.congregationId,
+        congregationId: congregation.id,
       })),
     })
   }

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -174,7 +174,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
             <div className="flex flex-wrap gap-4 max-sm:flex-col">
               {publisherNotUser ? (
                 <p className="text-center text-muted-foreground text-sm">
-                  Cette personne n'est pas utilisatrice de Unitae. Vous ne pouvez donner des droits qu'à des
+                  Cette personne n'est pas utilisatrice de l'application. Vous ne pouvez donner des droits qu'à des
                   utilisateurs.
                   <br />
                   Pour transformer ce proclamateur en utilisateur, ajoutez lui une adresse email et réinitialisez son

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -4,7 +4,6 @@ import { sendResetUserPasswordEmail } from '~/features/authentication/server/sen
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { requireCongregation } from '~/shared/libs/congregation.server'
 import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
@@ -62,6 +61,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  const { congregation } = await verifySession(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -81,7 +81,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/settings/users/new')
   }
 
-  const congregation = requireCongregation()
   const limits = new LimitService(congregation)
   await limits.errorIfWouldGoOverLimit('users')
 
@@ -92,7 +91,7 @@ export async function action({ request }: Route.ActionArgs) {
       email: String(email).toLocaleLowerCase(),
       active: true,
       password: 'password',
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/settings/routes/users/user-list.tsx
+++ b/app/features/settings/routes/users/user-list.tsx
@@ -74,7 +74,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Utilisateurs"
-        subtitle="Liste de tous les utilisateurs de Unitae"
+        subtitle="Liste de tous les utilisateurs"
         actions={
           <Button asChild>
             <Link to="./new">Nouvel utilisateur</Link>

--- a/app/features/settings/server/settings.ts
+++ b/app/features/settings/server/settings.ts
@@ -16,7 +16,7 @@ export async function getBoolSetting(key: SettingKey): Promise<boolean | undefin
   return settingValue === 'true'
 }
 
-export async function setSetting(key: SettingKey, value: string) {
+export async function setSetting(key: SettingKey, value: string, congregationId: number) {
   if (key == null || value.length < 1) {
     return
   }
@@ -33,7 +33,7 @@ export async function setSetting(key: SettingKey, value: string) {
       data: {
         key,
         value,
-        congregationId: 0 as number,
+        congregationId,
       },
     })
   }

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -124,7 +124,7 @@ export default function CreateAttributionPage({ loaderData }: Route.ComponentPro
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -153,7 +153,7 @@ export async function action({ request }: Route.ActionArgs) {
       type,
       startDate: new Date(startDateText),
       lateDate: lateDate,
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -29,11 +29,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = await getSetting(TerritorySettingKey.ProspectionValidity)
-  const staleDate = new Date()
-  staleDate.setMonth(staleDate.getMonth() - Number(prospectionValidity ?? '0'))
-  const inactiveStaleDate = new Date()
-  inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - Number(prospectionValidity ?? '0') * 2)
+  const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
+  const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+  if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
+  const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+  if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
   const warningDate = new Date()
   warningDate.setMonth(warningDate.getMonth() - 3)
 

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -124,7 +124,7 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, congregation } = await verifySession(request)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
@@ -148,7 +148,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     if (currentEntranceIdsSerialized !== entranceIdsSerialized) {
       try {
-        await updateBuildingsInEntrance(Number(building.entrance?.id), entranceIds)
+        await updateBuildingsInEntrance(Number(building.entrance?.id), entranceIds, congregation.id)
         session.flash('success', 'Le batiment a été correctement modifié')
       } catch (e) {
         logger.error('Error updating building', { error: e, buildingId: params.buildingId })

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -30,11 +30,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = await getSetting(TerritorySettingKey.ProspectionValidity)
-  const staleDate = new Date()
-  staleDate.setMonth(staleDate.getMonth() - Number(prospectionValidity ?? '0'))
-  const inactiveStaleDate = new Date()
-  inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - Number(prospectionValidity ?? '0') * 2)
+  const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
+  const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+  if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
+  const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+  if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
   const warningDate = new Date()
   warningDate.setMonth(warningDate.getMonth() - 3)
 

--- a/app/features/territories/routes/prospection/new-building.tsx
+++ b/app/features/territories/routes/prospection/new-building.tsx
@@ -67,7 +67,7 @@ export default function CreateBuildingPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, congregation } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
@@ -95,6 +95,7 @@ export async function action({ request }: Route.ActionArgs) {
       latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
       longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,
     },
+    congregationId: congregation.id,
   })
 
   if (building == null) {

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -4,7 +4,6 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { requireCongregation } from '~/shared/libs/congregation.server'
 import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 
@@ -15,7 +14,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, congregation } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -48,7 +47,6 @@ export async function action({ request }: Route.ActionArgs) {
 
   const number = `${prefix}${String(count + 1).padStart(3, '0')}`
 
-  const congregation = requireCongregation()
   const limits = new LimitService(congregation)
   await limits.errorIfWouldGoOverLimit('territories')
 
@@ -61,7 +59,7 @@ export async function action({ request }: Route.ActionArgs) {
           .split(',')
           .map(el => ({ id: Number(el) })),
       },
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -1,3 +1,4 @@
+import { Info } from 'lucide-react'
 import { redirect } from 'react-router'
 import { Cell, Pie, PieChart } from 'recharts'
 import { verifySession } from '~/features/authentication/server/session.server'
@@ -15,6 +16,7 @@ import { computeTerritoryCoverageTotal } from '~/features/territories/server/ter
 import { getCurrentTheocraticYear } from '~/features/territories/server/theocratic-year.server'
 import StatsFilters from '~/features/territories/ui/StatsFilters'
 import { Card, CardContent } from '~/shared/ui/card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/shared/ui/tooltip'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import S13ExportButton from '~/shared/ui/S13ExportButton'
 import type { Route } from './+types/index'
@@ -80,6 +82,24 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042']
 
+function StatLabel({ label, help }: { label: string; help: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-muted-foreground text-sm">
+      {label}
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Info className="size-3.5 cursor-help text-muted-foreground/60" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-64">
+            {help}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </span>
+  )
+}
+
 export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps) {
   const { stats, theocraticYear, groups } = loaderData
 
@@ -105,13 +125,19 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-7xl max-sm:text-5xl">{stats.total}</span>
-              <span className="text-muted-foreground text-sm">Territoires existants</span>
+              <StatLabel
+                label="Territoires existants"
+                help="Nombre total de territoires enregistrés, qu'ils soient disponibles, sortis ou en repos."
+              />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-7xl max-sm:text-5xl">{stats.available}</span>
-              <span className="text-muted-foreground text-sm">Territoires disponibles</span>
+              <StatLabel
+                label="Territoires disponibles"
+                help="Territoires qui ne sont ni sortis, ni en période de repos. Ils peuvent être attribués à un proclamateur."
+              />
             </CardContent>
           </Card>
         </div>
@@ -119,19 +145,28 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">{stats.working}</span>
-              <span className="text-muted-foreground text-sm">Territoires sortis</span>
+              <StatLabel
+                label="Territoires sortis"
+                help="Territoires actuellement attribués à un proclamateur (en cours + en retard)."
+              />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">{stats.delayed}</span>
-              <span className="text-muted-foreground text-sm">Territoires en retard</span>
+              <StatLabel
+                label="Territoires en retard"
+                help="Territoires sortis dont la date de retour prévue est dépassée."
+              />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">{stats.resting}</span>
-              <span className="text-muted-foreground text-sm">Territoires en repos</span>
+              <StatLabel
+                label="Territoires en repos"
+                help="Territoires rendus récemment et en période de repos (90 jours pour le porte-à-porte, 15 jours pour les campagnes et le téléphone)."
+              />
             </CardContent>
           </Card>
         </div>
@@ -144,7 +179,10 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">{stats.coverage.toFixed(2)} %</span>
-              <span className="text-muted-foreground text-sm">Couverture du territoire</span>
+              <StatLabel
+                label="Couverture du territoire"
+                help="Nombre d'attributions ayant touché la période sélectionnée, rapporté au nombre total de territoires. Peut dépasser 100 % si un territoire a été attribué plusieurs fois."
+              />
             </CardContent>
           </Card>
           <Card>
@@ -152,19 +190,28 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
               <span className="font-black font-display text-5xl max-sm:text-3xl">
                 {stats.totalCoverage.toFixed(2)} %
               </span>
-              <span className="text-muted-foreground text-sm">Couverture complète du territoire</span>
+              <StatLabel
+                label="Couverture complète du territoire"
+                help="Pourcentage de territoires ayant eu au moins une attribution durant la période sélectionnée. Maximum 100 %."
+              />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">-</span>
-              <span className="text-muted-foreground text-sm">Territoire le plus travaillé</span>
+              <StatLabel
+                label="Territoire le plus travaillé"
+                help="Territoire ayant reçu le plus d'attributions sur la période. Pas encore implémenté."
+              />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">-</span>
-              <span className="text-muted-foreground text-sm">Territoire le moins travaillé</span>
+              <StatLabel
+                label="Territoire le moins travaillé"
+                help="Territoire ayant reçu le moins d'attributions sur la période. Pas encore implémenté."
+              />
             </CardContent>
           </Card>
         </div>
@@ -186,7 +233,10 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
                 ))}
               </Pie>
             </PieChart>
-            <span className="text-muted-foreground text-sm">État du territoire</span>
+            <StatLabel
+              label="État du territoire"
+              help="Répartition visuelle des territoires entre disponibles, sortis, en retard et en repos."
+            />
           </CardContent>
         </Card>
       </div>

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -9,7 +9,6 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
-import { requireCongregation } from '~/shared/libs/congregation.server'
 import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
@@ -156,7 +155,7 @@ export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  await verifySession(request)
+  const { congregation } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -172,7 +171,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/territory/new')
   }
 
-  const congregation = requireCongregation()
   const limits = new LimitService(congregation)
   await limits.errorIfWouldGoOverLimit('territories')
 
@@ -183,7 +181,7 @@ export async function action({ request }: Route.ActionArgs) {
       entrances: {
         connect: entrances.map(el => ({ id: Number(el) })),
       },
-      congregationId: 0 as number,
+      congregationId: congregation.id,
     },
   })
 

--- a/app/features/territories/server/active-working-territories.server.test.ts
+++ b/app/features/territories/server/active-working-territories.server.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+  },
+}))
+
+const { countActiveWorkingTerritories } = await import('./active-working-territories.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 3, 8))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('countActiveWorkingTerritories', () => {
+  it('retourne le nombre de territoires en cours de travail', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(5)
+
+    const result = await countActiveWorkingTerritories()
+    expect(result).toBe(5)
+  })
+
+  it('retourne 0 quand aucun territoire n\'est actif', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+
+    const result = await countActiveWorkingTerritories()
+    expect(result).toBe(0)
+  })
+})

--- a/app/features/territories/server/available-territories.server.test.ts
+++ b/app/features/territories/server/available-territories.server.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+  },
+}))
+
+const { countAvailableTerritories } = await import('./available-territories.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 3, 8)) // 8 avril 2025
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('countAvailableTerritories', () => {
+  it('retourne le nombre de territoires disponibles', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(12)
+
+    const result = await countAvailableTerritories()
+    expect(result).toBe(12)
+  })
+
+  it('retourne 0 quand aucun territoire n\'est disponible', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+
+    const result = await countAvailableTerritories()
+    expect(result).toBe(0)
+  })
+})

--- a/app/features/territories/server/buildings.server.test.ts
+++ b/app/features/territories/server/buildings.server.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    setting: { findFirst: vi.fn() },
+  },
+}))
+
+const { getProspectionStaleDate } = await import('./buildings')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 3, 8)) // 8 avril 2026
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('getProspectionStaleDate', () => {
+  it('retourne epoch (1970) quand le setting n\'est pas configuré', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+
+    const result = await getProspectionStaleDate()
+    expect(result.getTime()).toBe(0)
+  })
+
+  it('retourne epoch quand la valeur est "0"', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '0' })
+
+    const result = await getProspectionStaleDate()
+    expect(result.getTime()).toBe(0)
+  })
+
+  it('retourne une date dans le passé quand la valeur est positive', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+
+    const result = await getProspectionStaleDate()
+    // 8 avril 2026 - 6 mois = 8 octobre 2025
+    expect(result.getFullYear()).toBe(2025)
+    expect(result.getMonth()).toBe(9) // octobre
+  })
+
+  it('ne considère jamais une date du jour comme périmée quand non configuré', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+
+    const staleDate = await getProspectionStaleDate()
+    const today = new Date(2026, 3, 8)
+
+    // Une date d'aujourd'hui ne doit PAS être < staleDate
+    expect(today < staleDate).toBe(false)
+  })
+
+  it('considère une date ancienne comme périmée quand configuré à 6 mois', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+
+    const staleDate = await getProspectionStaleDate()
+    const sevenMonthsAgo = new Date(2025, 8, 1) // 1er septembre 2025
+
+    expect(sevenMonthsAgo < staleDate).toBe(true)
+  })
+
+  it('ne considère pas une date récente comme périmée quand configuré à 6 mois', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+
+    const staleDate = await getProspectionStaleDate()
+    const twoMonthsAgo = new Date(2026, 1, 8) // 8 février 2026
+
+    expect(twoMonthsAgo < staleDate).toBe(false)
+  })
+})

--- a/app/features/territories/server/buildings.server.test.ts
+++ b/app/features/territories/server/buildings.server.test.ts
@@ -21,21 +21,21 @@ afterEach(() => {
 
 describe('getProspectionStaleDate', () => {
   it('retourne epoch (1970) quand le setting n\'est pas configuré', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
     const result = await getProspectionStaleDate()
     expect(result.getTime()).toBe(0)
   })
 
   it('retourne epoch quand la valeur est "0"', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '0' })
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '0' } as never)
 
     const result = await getProspectionStaleDate()
     expect(result.getTime()).toBe(0)
   })
 
   it('retourne une date dans le passé quand la valeur est positive', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
     const result = await getProspectionStaleDate()
     // 8 avril 2026 - 6 mois = 8 octobre 2025
@@ -44,7 +44,7 @@ describe('getProspectionStaleDate', () => {
   })
 
   it('ne considère jamais une date du jour comme périmée quand non configuré', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
     const staleDate = await getProspectionStaleDate()
     const today = new Date(2026, 3, 8)
@@ -54,7 +54,7 @@ describe('getProspectionStaleDate', () => {
   })
 
   it('considère une date ancienne comme périmée quand configuré à 6 mois', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
     const staleDate = await getProspectionStaleDate()
     const sevenMonthsAgo = new Date(2025, 8, 1) // 1er septembre 2025
@@ -63,7 +63,7 @@ describe('getProspectionStaleDate', () => {
   })
 
   it('ne considère pas une date récente comme périmée quand configuré à 6 mois', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' })
+    vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
     const staleDate = await getProspectionStaleDate()
     const twoMonthsAgo = new Date(2026, 1, 8) // 8 février 2026

--- a/app/features/territories/server/buildings.ts
+++ b/app/features/territories/server/buildings.ts
@@ -79,9 +79,12 @@ export async function findEntrancesPaginated(selectors: Prisma.BuildingWhereInpu
 }
 
 export async function getProspectionStaleDate(): Promise<Date> {
-  const prospectionValidity = await db.setting.findFirst({ where: { key: 'prospection-validity' } })
+  const prospectionValidity = Number(
+    (await db.setting.findFirst({ where: { key: 'prospection-validity' } }))?.value ?? '0',
+  )
+  if (prospectionValidity <= 0) return new Date(0)
   const staleDate = new Date()
-  staleDate.setMonth(staleDate.getMonth() - Number(prospectionValidity?.value ?? '0'))
+  staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
   return staleDate
 }
 

--- a/app/features/territories/server/create-building.server.test.ts
+++ b/app/features/territories/server/create-building.server.test.ts
@@ -25,13 +25,17 @@ beforeEach(() => {
 })
 
 describe('createBuilding', () => {
-  it('crée un bâtiment sans coordonnées (inTerritory = false)', async () => {
+  it('crée un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
+    vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: true })
+
     const result = await createBuilding({
       address: { number: '12', street: 'Rue Test', zip: '75001' },
       congregationId: 1,
     })
 
-    expect(result).toEqual({ id: 1, inTerritory: false })
+    expect(result.inTerritory).toBe(true)
+    const callArgs = vi.mocked(db.building.create).mock.calls[0][0]
+    expect(callArgs.data.inTerritory).toBe(true)
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
@@ -68,6 +72,20 @@ describe('createBuilding', () => {
     })
 
     expect(vi.mocked(db.building.create)).toBeDefined()
+  })
+
+  it('considère le bâtiment dans le territoire quand le polygone est vide (non configuré)', async () => {
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([])
+    vi.mocked(db.building.create).mockResolvedValue({ id: 4, inTerritory: true })
+
+    await createBuilding({
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5, longitude: 5 },
+      congregationId: 1,
+    })
+
+    const callArgs = vi.mocked(db.building.create).mock.calls[0][0]
+    expect(callArgs.data.inTerritory).toBe(true)
   })
 
   it('marque inTerritory false quand le point est hors du polygone', async () => {

--- a/app/features/territories/server/create-building.server.test.ts
+++ b/app/features/territories/server/create-building.server.test.ts
@@ -28,6 +28,7 @@ describe('createBuilding', () => {
   it('crée un bâtiment sans coordonnées (inTerritory = false)', async () => {
     const result = await createBuilding({
       address: { number: '12', street: 'Rue Test', zip: '75001' },
+      congregationId: 1,
     })
 
     expect(result).toEqual({ id: 1, inTerritory: false })
@@ -41,6 +42,7 @@ describe('createBuilding', () => {
     const result = await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5, longitude: 5 },
+      congregationId: 1,
     })
 
     expect(result.inTerritory).toBe(true)
@@ -50,6 +52,7 @@ describe('createBuilding', () => {
     await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5 },
+      congregationId: 1,
     })
 
     // getTerritoryPolygon ne devrait pas être appelé car longitude manque
@@ -61,6 +64,7 @@ describe('createBuilding', () => {
     await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { longitude: 5 },
+      congregationId: 1,
     })
 
     expect(vi.mocked(db.building.create)).toBeDefined()
@@ -74,6 +78,7 @@ describe('createBuilding', () => {
     const result = await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 50, longitude: 50 },
+      congregationId: 1,
     })
 
     expect(result.inTerritory).toBe(false)

--- a/app/features/territories/server/create-building.server.test.ts
+++ b/app/features/territories/server/create-building.server.test.ts
@@ -21,12 +21,12 @@ const { getTerritoryPolygon } = await import('./get-territory-polygon.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: false })
+  vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: false } as never)
 })
 
 describe('createBuilding', () => {
   it('crée un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
-    vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: true })
+    vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
     const result = await createBuilding({
       address: { number: '12', street: 'Rue Test', zip: '75001' },
@@ -39,9 +39,9 @@ describe('createBuilding', () => {
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
-    vi.mocked(pointInPolygon).mockReturnValue(true)
-    vi.mocked(db.building.create).mockResolvedValue({ id: 2, inTerritory: true })
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(pointInPolygon).mockReturnValue(true as never)
+    vi.mocked(db.building.create).mockResolvedValue({ id: 2, inTerritory: true } as never)
 
     const result = await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
@@ -75,8 +75,8 @@ describe('createBuilding', () => {
   })
 
   it('considère le bâtiment dans le territoire quand le polygone est vide (non configuré)', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([])
-    vi.mocked(db.building.create).mockResolvedValue({ id: 4, inTerritory: true })
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([] as never)
+    vi.mocked(db.building.create).mockResolvedValue({ id: 4, inTerritory: true } as never)
 
     await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },
@@ -89,9 +89,9 @@ describe('createBuilding', () => {
   })
 
   it('marque inTerritory false quand le point est hors du polygone', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
-    vi.mocked(pointInPolygon).mockReturnValue(false)
-    vi.mocked(db.building.create).mockResolvedValue({ id: 3, inTerritory: false })
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(pointInPolygon).mockReturnValue(false as never)
+    vi.mocked(db.building.create).mockResolvedValue({ id: 3, inTerritory: false } as never)
 
     const result = await createBuilding({
       address: { number: '5', street: 'Rue Test', zip: '75001' },

--- a/app/features/territories/server/create-building.server.test.ts
+++ b/app/features/territories/server/create-building.server.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { create: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/point-in-polygon.server', () => ({
+  pointInPolygon: vi.fn(),
+}))
+
+vi.mock('./get-territory-polygon.server', () => ({
+  getTerritoryPolygon: vi.fn(),
+}))
+
+const { createBuilding } = await import('./create-building.server')
+const { db } = await import('~/shared/libs/db.server')
+const { pointInPolygon } = await import('~/shared/libs/point-in-polygon.server')
+const { getTerritoryPolygon } = await import('./get-territory-polygon.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: false })
+})
+
+describe('createBuilding', () => {
+  it('crée un bâtiment sans coordonnées (inTerritory = false)', async () => {
+    const result = await createBuilding({
+      address: { number: '12', street: 'Rue Test', zip: '75001' },
+    })
+
+    expect(result).toEqual({ id: 1, inTerritory: false })
+  })
+
+  it('vérifie les coordonnées contre le polygone du territoire', async () => {
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
+    vi.mocked(pointInPolygon).mockReturnValue(true)
+    vi.mocked(db.building.create).mockResolvedValue({ id: 2, inTerritory: true })
+
+    const result = await createBuilding({
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5, longitude: 5 },
+    })
+
+    expect(result.inTerritory).toBe(true)
+  })
+
+  it('ne vérifie pas le polygone quand seulement latitude est fournie', async () => {
+    await createBuilding({
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5 },
+    })
+
+    // getTerritoryPolygon ne devrait pas être appelé car longitude manque
+    // On vérifie via le résultat: inTerritory reste false
+    expect(vi.mocked(db.building.create)).toBeDefined()
+  })
+
+  it('ne vérifie pas le polygone quand seulement longitude est fournie', async () => {
+    await createBuilding({
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { longitude: 5 },
+    })
+
+    expect(vi.mocked(db.building.create)).toBeDefined()
+  })
+
+  it('marque inTerritory false quand le point est hors du polygone', async () => {
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
+    vi.mocked(pointInPolygon).mockReturnValue(false)
+    vi.mocked(db.building.create).mockResolvedValue({ id: 3, inTerritory: false })
+
+    const result = await createBuilding({
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 50, longitude: 50 },
+    })
+
+    expect(result.inTerritory).toBe(false)
+  })
+})

--- a/app/features/territories/server/create-building.server.ts
+++ b/app/features/territories/server/create-building.server.ts
@@ -12,10 +12,12 @@ export async function createBuilding({
   coordinates?: { latitude?: number; longitude?: number }
   congregationId: number
 }): Promise<DetailedBuilding> {
-  let isInTerritory = false
+  let isInTerritory = true
   if (coordinates.latitude != null && coordinates.longitude != null) {
     const polygon = await getTerritoryPolygon()
-    isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
+    if (polygon.length > 0) {
+      isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
+    }
   }
 
   return db.building.create({

--- a/app/features/territories/server/create-building.server.ts
+++ b/app/features/territories/server/create-building.server.ts
@@ -6,9 +6,11 @@ import { getTerritoryPolygon } from './get-territory-polygon.server'
 export async function createBuilding({
   address,
   coordinates = {},
+  congregationId,
 }: {
   address: { number: string; street: string; zip: string }
   coordinates?: { latitude?: number; longitude?: number }
+  congregationId: number
 }): Promise<DetailedBuilding> {
   let isInTerritory = false
   if (coordinates.latitude != null && coordinates.longitude != null) {
@@ -24,8 +26,8 @@ export async function createBuilding({
       latitude: coordinates.latitude,
       longitude: coordinates.longitude,
       inTerritory: isInTerritory,
-      entrance: { create: { congregation: { connect: { id: 0 as number } } } },
-      congregation: { connect: { id: 0 as number } },
+      entrance: { create: { congregation: { connect: { id: congregationId } } } },
+      congregation: { connect: { id: congregationId } },
     },
     include: {
       entrance: { include: { buildings: true, territories: true } },

--- a/app/features/territories/server/delayed-working-territories.server.test.ts
+++ b/app/features/territories/server/delayed-working-territories.server.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+  },
+}))
+
+const { countDelayedWorkingTerritories } = await import('./delayed-working-territories.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 3, 8))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('countDelayedWorkingTerritories', () => {
+  it('retourne le nombre de territoires en retard', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(3)
+
+    const result = await countDelayedWorkingTerritories()
+    expect(result).toBe(3)
+  })
+
+  it('retourne 0 quand aucun territoire n\'est en retard', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+
+    const result = await countDelayedWorkingTerritories()
+    expect(result).toBe(0)
+  })
+})

--- a/app/features/territories/server/edit-building.server.test.ts
+++ b/app/features/territories/server/edit-building.server.test.ts
@@ -21,12 +21,12 @@ const { getTerritoryPolygon } = await import('./get-territory-polygon.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: false })
+  vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: false } as never)
 })
 
 describe('editBuilding', () => {
   it('met à jour un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
-    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
     await editBuilding(1, {
       address: { number: '12', street: 'Rue Test', zip: '75001' },
@@ -37,9 +37,9 @@ describe('editBuilding', () => {
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
-    vi.mocked(pointInPolygon).mockReturnValue(true)
-    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(pointInPolygon).mockReturnValue(true as never)
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
     const result = await editBuilding(1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
@@ -50,7 +50,7 @@ describe('editBuilding', () => {
   })
 
   it('ne vérifie pas le polygone avec coordonnées partielles', async () => {
-    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
     await editBuilding(1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
@@ -62,8 +62,8 @@ describe('editBuilding', () => {
   })
 
   it('considère le bâtiment dans le territoire quand le polygone est vide (non configuré)', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([])
-    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([] as never)
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
     await editBuilding(1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },

--- a/app/features/territories/server/edit-building.server.test.ts
+++ b/app/features/territories/server/edit-building.server.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { update: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/point-in-polygon.server', () => ({
+  pointInPolygon: vi.fn(),
+}))
+
+vi.mock('./get-territory-polygon.server', () => ({
+  getTerritoryPolygon: vi.fn(),
+}))
+
+const { editBuilding } = await import('./edit-building.server')
+const { db } = await import('~/shared/libs/db.server')
+const { pointInPolygon } = await import('~/shared/libs/point-in-polygon.server')
+const { getTerritoryPolygon } = await import('./get-territory-polygon.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: false })
+})
+
+describe('editBuilding', () => {
+  it('met à jour un bâtiment sans coordonnées', async () => {
+    const result = await editBuilding(1, {
+      address: { number: '12', street: 'Rue Test', zip: '75001' },
+    })
+
+    expect(result).toEqual({ id: 1, inTerritory: false })
+  })
+
+  it('vérifie les coordonnées contre le polygone du territoire', async () => {
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]])
+    vi.mocked(pointInPolygon).mockReturnValue(true)
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+
+    const result = await editBuilding(1, {
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5, longitude: 5 },
+    })
+
+    expect(result.inTerritory).toBe(true)
+  })
+
+  it('ne vérifie pas le polygone avec coordonnées partielles', async () => {
+    await editBuilding(1, {
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5 },
+    })
+
+    // inTerritory reste false car la vérification n'est pas faite
+    expect(db.building.update).toBeDefined()
+  })
+})

--- a/app/features/territories/server/edit-building.server.test.ts
+++ b/app/features/territories/server/edit-building.server.test.ts
@@ -25,12 +25,15 @@ beforeEach(() => {
 })
 
 describe('editBuilding', () => {
-  it('met à jour un bâtiment sans coordonnées', async () => {
-    const result = await editBuilding(1, {
+  it('met à jour un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+
+    await editBuilding(1, {
       address: { number: '12', street: 'Rue Test', zip: '75001' },
     })
 
-    expect(result).toEqual({ id: 1, inTerritory: false })
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.inTerritory).toBe(true)
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
@@ -47,12 +50,27 @@ describe('editBuilding', () => {
   })
 
   it('ne vérifie pas le polygone avec coordonnées partielles', async () => {
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+
     await editBuilding(1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5 },
     })
 
-    // inTerritory reste false car la vérification n'est pas faite
-    expect(db.building.update).toBeDefined()
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.inTerritory).toBe(true)
+  })
+
+  it('considère le bâtiment dans le territoire quand le polygone est vide (non configuré)', async () => {
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([])
+    vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true })
+
+    await editBuilding(1, {
+      address: { number: '5', street: 'Rue Test', zip: '75001' },
+      coordinates: { latitude: 5, longitude: 5 },
+    })
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.inTerritory).toBe(true)
   })
 })

--- a/app/features/territories/server/edit-building.server.ts
+++ b/app/features/territories/server/edit-building.server.ts
@@ -15,10 +15,12 @@ export async function editBuilding(
     coordinates?: { latitude?: number; longitude?: number }
   },
 ): Promise<Building> {
-  let isInTerritory = false
+  let isInTerritory = true
   if (coordinates.latitude != null && coordinates.longitude != null) {
     const polygon = await getTerritoryPolygon()
-    isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
+    if (polygon.length > 0) {
+      isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
+    }
   }
 
   return db.building.update({

--- a/app/features/territories/server/get-building-details.server.test.ts
+++ b/app/features/territories/server/get-building-details.server.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { findUnique: vi.fn() },
+  },
+}))
+
+const { getBuildingDetails } = await import('./get-building-details.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getBuildingDetails', () => {
+  it('retourne les détails du bâtiment', async () => {
+    const fakeBuilding = { id: 1, number: '12', entrance: { buildings: [], territories: [] } }
+    vi.mocked(db.building.findUnique).mockResolvedValue(fakeBuilding)
+
+    const result = await getBuildingDetails(1)
+    expect(result).toEqual(fakeBuilding)
+  })
+
+  it('retourne null quand le bâtiment n\'existe pas', async () => {
+    vi.mocked(db.building.findUnique).mockResolvedValue(null)
+
+    const result = await getBuildingDetails(999)
+    expect(result).toBeNull()
+  })
+})

--- a/app/features/territories/server/get-building-details.server.test.ts
+++ b/app/features/territories/server/get-building-details.server.test.ts
@@ -16,14 +16,14 @@ beforeEach(() => {
 describe('getBuildingDetails', () => {
   it('retourne les détails du bâtiment', async () => {
     const fakeBuilding = { id: 1, number: '12', entrance: { buildings: [], territories: [] } }
-    vi.mocked(db.building.findUnique).mockResolvedValue(fakeBuilding)
+    vi.mocked(db.building.findUnique).mockResolvedValue(fakeBuilding as never)
 
     const result = await getBuildingDetails(1)
     expect(result).toEqual(fakeBuilding)
   })
 
   it('retourne null quand le bâtiment n\'existe pas', async () => {
-    vi.mocked(db.building.findUnique).mockResolvedValue(null)
+    vi.mocked(db.building.findUnique).mockResolvedValue(null as never)
 
     const result = await getBuildingDetails(999)
     expect(result).toBeNull()

--- a/app/features/territories/server/get-buildings.server.test.ts
+++ b/app/features/territories/server/get-buildings.server.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { findMany: vi.fn() },
+  },
+}))
+
+const { getBuildings } = await import('./get-buildings.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getBuildings', () => {
+  it('retourne les bâtiments filtrés par code postal et rue', async () => {
+    const fakeBuildings = [{ id: 1, zip: '75001', street: 'Rue Test' }]
+    vi.mocked(db.building.findMany).mockResolvedValue(fakeBuildings)
+
+    const result = await getBuildings('75001', 'Rue Test')
+    expect(result).toEqual(fakeBuildings)
+  })
+
+  it('retourne un tableau vide quand aucun bâtiment ne correspond', async () => {
+    vi.mocked(db.building.findMany).mockResolvedValue([])
+
+    const result = await getBuildings('00000', 'Rue Inexistante')
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/territories/server/get-buildings.server.test.ts
+++ b/app/features/territories/server/get-buildings.server.test.ts
@@ -16,14 +16,14 @@ beforeEach(() => {
 describe('getBuildings', () => {
   it('retourne les bâtiments filtrés par code postal et rue', async () => {
     const fakeBuildings = [{ id: 1, zip: '75001', street: 'Rue Test' }]
-    vi.mocked(db.building.findMany).mockResolvedValue(fakeBuildings)
+    vi.mocked(db.building.findMany).mockResolvedValue(fakeBuildings as never)
 
     const result = await getBuildings('75001', 'Rue Test')
     expect(result).toEqual(fakeBuildings)
   })
 
   it('retourne un tableau vide quand aucun bâtiment ne correspond', async () => {
-    vi.mocked(db.building.findMany).mockResolvedValue([])
+    vi.mocked(db.building.findMany).mockResolvedValue([] as never)
 
     const result = await getBuildings('00000', 'Rue Inexistante')
     expect(result).toEqual([])

--- a/app/features/territories/server/get-territory-polygon.server.test.ts
+++ b/app/features/territories/server/get-territory-polygon.server.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 describe('getTerritoryPolygon', () => {
   it('retourne un tableau vide quand le setting n\'existe pas', async () => {
-    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
     const result = await getTerritoryPolygon()
     expect(result).toEqual([])
@@ -26,7 +26,7 @@ describe('getTerritoryPolygon', () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue({
       key: 'territory',
       value: JSON.stringify(polygon),
-    })
+    } as never)
 
     const result = await getTerritoryPolygon()
     expect(result).toEqual(polygon)

--- a/app/features/territories/server/get-territory-polygon.server.test.ts
+++ b/app/features/territories/server/get-territory-polygon.server.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    setting: { findFirst: vi.fn() },
+  },
+}))
+
+const { getTerritoryPolygon } = await import('./get-territory-polygon.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getTerritoryPolygon', () => {
+  it('retourne un tableau vide quand le setting n\'existe pas', async () => {
+    vi.mocked(db.setting.findFirst).mockResolvedValue(null)
+
+    const result = await getTerritoryPolygon()
+    expect(result).toEqual([])
+  })
+
+  it('parse le JSON du setting en polygone', async () => {
+    const polygon = [[48.8566, 2.3522], [48.8567, 2.3523], [48.8568, 2.3524]]
+    vi.mocked(db.setting.findFirst).mockResolvedValue({
+      key: 'territory',
+      value: JSON.stringify(polygon),
+    })
+
+    const result = await getTerritoryPolygon()
+    expect(result).toEqual(polygon)
+  })
+})

--- a/app/features/territories/server/handle-sync-work.server.ts
+++ b/app/features/territories/server/handle-sync-work.server.ts
@@ -19,7 +19,7 @@ export async function handleSyncWork(job: Job<SyncJobData>): Promise<void> {
     await job.updateProgress(0)
     logger.info(`Starting sync job ${job.id}`, { userEmail, congregationId })
 
-    await importOpenData((percent: number) => {
+    await importOpenData(congregationId, (percent: number) => {
       logger.info(`Sync job ${job.id} progress: ${percent}%`, { userEmail })
       if (percent < 99) {
         job.updateProgress(percent)

--- a/app/features/territories/server/import-open-data.server.ts
+++ b/app/features/territories/server/import-open-data.server.ts
@@ -41,7 +41,7 @@ export async function importOpenData(congregationId: number, progressCallback: (
           return
         }
 
-        const isActive = pointInPolygon([Number(lat), Number(long)], territory)
+        const isActive = territory.length > 0 ? pointInPolygon([Number(lat), Number(long)], territory) : true
         await db.building.upsert({
           where: {
             address: {

--- a/app/features/territories/server/import-open-data.server.ts
+++ b/app/features/territories/server/import-open-data.server.ts
@@ -5,7 +5,7 @@ import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 import { fetchOpenData } from './fetch-open-data.server'
 import { getTerritoryPolygon } from './get-territory-polygon.server'
 
-export async function importOpenData(progressCallback: (percent: number) => void = () => {}) {
+export async function importOpenData(congregationId: number, progressCallback: (percent: number) => void = () => {}) {
   const wantedZips = await getAllowedZips()
   const territory = await getTerritoryPolygon()
   await db.building.updateMany({
@@ -48,7 +48,7 @@ export async function importOpenData(progressCallback: (percent: number) => void
               number,
               street,
               zip,
-              congregationId: 0 as number,
+              congregationId,
             },
           },
           create: {
@@ -60,8 +60,8 @@ export async function importOpenData(progressCallback: (percent: number) => void
             inOpenData: true,
             active: isActive,
             inTerritory: isActive,
-            entrance: { create: { congregation: { connect: { id: 0 as number } } } },
-            congregation: { connect: { id: 0 as number } },
+            entrance: { create: { congregation: { connect: { id: congregationId } } } },
+            congregation: { connect: { id: congregationId } },
           },
           update: {
             inTerritory: isActive,

--- a/app/features/territories/server/resting-territories.server.test.ts
+++ b/app/features/territories/server/resting-territories.server.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+  },
+}))
+
+const { countRestingTerritories } = await import('./resting-territories.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2025, 3, 8)) // 8 avril 2025
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('countRestingTerritories', () => {
+  it('retourne le nombre de territoires au repos', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(7)
+
+    const result = await countRestingTerritories()
+    expect(result).toBe(7)
+  })
+
+  it('retourne 0 quand aucun territoire ne se repose', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+
+    const result = await countRestingTerritories()
+    expect(result).toBe(0)
+  })
+})

--- a/app/features/territories/server/serialize-shared-entrance-from-building.server.test.ts
+++ b/app/features/territories/server/serialize-shared-entrance-from-building.server.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { serializeSharedEntranceFromBuilding } from './serialize-shared-entrance-from-building.server'
+
+describe('serializeSharedEntranceFromBuilding', () => {
+  it('retourne les ids des bâtiments séparés par des virgules', () => {
+    const building = {
+      entrance: {
+        buildings: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      },
+    }
+
+    expect(serializeSharedEntranceFromBuilding(building as never)).toBe('1,2,3')
+  })
+
+  it('retourne un seul id pour un bâtiment unique', () => {
+    const building = {
+      entrance: {
+        buildings: [{ id: 42 }],
+      },
+    }
+
+    expect(serializeSharedEntranceFromBuilding(building as never)).toBe('42')
+  })
+
+  it('retourne une chaîne vide pour un building null', () => {
+    expect(serializeSharedEntranceFromBuilding(null)).toBe('')
+  })
+
+  it('retourne une chaîne vide quand entrance est null', () => {
+    const building = { entrance: null }
+    expect(serializeSharedEntranceFromBuilding(building as never)).toBe('')
+  })
+
+  it('retourne une chaîne vide pour une liste de bâtiments vide', () => {
+    const building = { entrance: { buildings: [] } }
+    expect(serializeSharedEntranceFromBuilding(building as never)).toBe('')
+  })
+})

--- a/app/features/territories/server/set-building-notes.server.test.ts
+++ b/app/features/territories/server/set-building-notes.server.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 describe('setBuildingNotes', () => {
   it('met à jour les notes du bâtiment', async () => {
     const fakeBuilding = { id: 1, notes: 'Nouvelle note', importantNotes: 'Important!' }
-    vi.mocked(db.building.update).mockResolvedValue(fakeBuilding)
+    vi.mocked(db.building.update).mockResolvedValue(fakeBuilding as never)
 
     const result = await setBuildingNotes(1, { notes: 'Nouvelle note', importantNotes: 'Important!' })
     expect(result).toEqual(fakeBuilding)

--- a/app/features/territories/server/set-building-notes.server.test.ts
+++ b/app/features/territories/server/set-building-notes.server.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { update: vi.fn() },
+  },
+}))
+
+const { setBuildingNotes } = await import('./set-building-notes.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('setBuildingNotes', () => {
+  it('met à jour les notes du bâtiment', async () => {
+    const fakeBuilding = { id: 1, notes: 'Nouvelle note', importantNotes: 'Important!' }
+    vi.mocked(db.building.update).mockResolvedValue(fakeBuilding)
+
+    const result = await setBuildingNotes(1, { notes: 'Nouvelle note', importantNotes: 'Important!' })
+    expect(result).toEqual(fakeBuilding)
+  })
+})

--- a/app/features/territories/server/set-building-prospection-data.server.test.ts
+++ b/app/features/territories/server/set-building-prospection-data.server.test.ts
@@ -11,7 +11,7 @@ const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.building.update).mockResolvedValue({ id: 1 })
+  vi.mocked(db.building.update).mockResolvedValue({ id: 1 } as never)
 })
 
 function makeFormData(entries: Record<string, string>) {

--- a/app/features/territories/server/set-building-prospection-data.server.test.ts
+++ b/app/features/territories/server/set-building-prospection-data.server.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    building: { update: vi.fn() },
+  },
+}))
+
+const { setBuildingProspectionData } = await import('./set-building-prospection-data.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.building.update).mockResolvedValue({ id: 1 })
+})
+
+function makeFormData(entries: Record<string, string>) {
+  const fd = new FormData()
+  for (const [key, value] of Object.entries(entries)) {
+    fd.append(key, value)
+  }
+  return fd
+}
+
+describe('setBuildingProspectionData', () => {
+  it('parse les champs numériques du formulaire', async () => {
+    const formData = makeFormData({
+      homes: '15',
+      phones: '3',
+      liberals: '2',
+    })
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.homes).toBe(15)
+    expect(callArgs.data.phones).toBe(3)
+    expect(callArgs.data.liberals).toBe(2)
+  })
+
+  it('retourne null pour les champs numériques vides', async () => {
+    const formData = makeFormData({})
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.homes).toBeNull()
+    expect(callArgs.data.phones).toBeNull()
+    expect(callArgs.data.liberals).toBeNull()
+  })
+
+  it('parse les champs booléens', async () => {
+    const formData = makeFormData({
+      shops: 'on',
+      campus: 'on',
+      hotel: 'on',
+      landromat: 'on',
+    })
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.hasShops).toBe(true)
+    expect(callArgs.data.hasCampus).toBe(true)
+    expect(callArgs.data.hasHotel).toBe(true)
+    expect(callArgs.data.hasLandromat).toBe(true)
+  })
+
+  it('les champs booléens sont false par défaut', async () => {
+    const formData = makeFormData({})
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.hasShops).toBe(false)
+    expect(callArgs.data.hasCampus).toBe(false)
+    expect(callArgs.data.hasHotel).toBe(false)
+    expect(callArgs.data.hasLandromat).toBe(false)
+  })
+
+  it('parse le shopKind', async () => {
+    const formData = makeFormData({
+      shopkinds: 'boulangerie',
+    })
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.shopKind).toBe('boulangerie')
+  })
+
+  it('shopKind est une chaîne vide par défaut', async () => {
+    const formData = makeFormData({})
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.shopKind).toBe('')
+  })
+
+  it('parse la date de prospection', async () => {
+    const formData = makeFormData({
+      'prospection-date': '2025-04-08',
+    })
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.prospectionDate).toBeInstanceOf(Date)
+  })
+
+  it('la date de prospection est null par défaut', async () => {
+    const formData = makeFormData({})
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    expect(callArgs.data.prospectionDate).toBeNull()
+  })
+
+  it('parse les données d\'entrée (access, PMR, portes, boîtes aux lettres)', async () => {
+    const formData = makeFormData({
+      access: '3',
+      pmr: 'on',
+      doors: 'on',
+      mailboxes: 'on',
+    })
+
+    await setBuildingProspectionData(1, formData)
+
+    const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
+    const entrance = callArgs.data.entrance as { update: Record<string, unknown> }
+    expect(entrance.update.access).toBe(3)
+    expect(entrance.update.isPMR).toBe(true)
+    expect(entrance.update.isOpenEarly).toBe(true)
+    expect(entrance.update.isMailboxOpen).toBe(true)
+  })
+})

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('./theocratic-year.server', () => ({
+  getBeginingDateOfTheocraticYear: vi.fn(),
+  getEndDateOfTheocraticYear: vi.fn(),
+}))
+
+const { getTerritoriesExportData } = await import('./territories-export-data.server')
+const { db } = await import('~/shared/libs/db.server')
+const { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } = await import('./theocratic-year.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(getBeginingDateOfTheocraticYear).mockReturnValue(new Date(2025, 8, 1))
+  vi.mocked(getEndDateOfTheocraticYear).mockReturnValue(new Date(2026, 7, 31))
+  vi.mocked(db.territory.findMany).mockResolvedValue([])
+})
+
+describe('getTerritoriesExportData', () => {
+  it('retourne les territoires avec leurs attributions', async () => {
+    const fakeTerritories = [{ id: 1, attributions: [] }]
+    vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories)
+
+    const result = await getTerritoriesExportData(2025)
+    expect(result).toEqual(fakeTerritories)
+  })
+
+  it('retourne un tableau vide quand il n\'y a pas de territoires', async () => {
+    const result = await getTerritoriesExportData(2025)
+    expect(result).toEqual([])
+  })
+
+  it('passe l\'année théocratique aux fonctions de date', async () => {
+    await getTerritoriesExportData(2024)
+
+    // Vérifier que les fonctions de date ont été utilisées (via le résultat)
+    expect(vi.mocked(getBeginingDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
+    expect(vi.mocked(getEndDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
+  })
+})

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -17,15 +17,15 @@ const { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } = await im
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(getBeginingDateOfTheocraticYear).mockReturnValue(new Date(2025, 8, 1))
-  vi.mocked(getEndDateOfTheocraticYear).mockReturnValue(new Date(2026, 7, 31))
-  vi.mocked(db.territory.findMany).mockResolvedValue([])
+  vi.mocked(getBeginingDateOfTheocraticYear).mockReturnValue(new Date(2025, 8, 1) as never)
+  vi.mocked(getEndDateOfTheocraticYear).mockReturnValue(new Date(2026, 7, 31) as never)
+  vi.mocked(db.territory.findMany).mockResolvedValue([] as never)
 })
 
 describe('getTerritoriesExportData', () => {
   it('retourne les territoires avec leurs attributions', async () => {
     const fakeTerritories = [{ id: 1, attributions: [] }]
-    vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories)
+    vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories as never)
 
     const result = await getTerritoriesExportData(2025)
     expect(result).toEqual(fakeTerritories)

--- a/app/features/territories/server/territories.server.test.ts
+++ b/app/features/territories/server/territories.server.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn(), findMany: vi.fn() },
+  },
+}))
+
+const { findTerritoriesWithDetailsPaginated, findAvailableTerritoriesPaginated } = await import('./territories.ts')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('findTerritoriesWithDetailsPaginated', () => {
+  it('retourne les territoires avec pagination', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(50)
+    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 1 }, { id: 2 }])
+
+    const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/?page=1&pageSize=25'))
+
+    expect(result.territories).toHaveLength(2)
+    expect(result.pagination.total).toBe(50)
+    expect(result.pagination.pages).toBe(2)
+  })
+
+  it('retourne un résultat vide quand il n\'y a pas de territoires', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+    vi.mocked(db.territory.findMany).mockResolvedValue([])
+
+    const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/'))
+
+    expect(result.territories).toEqual([])
+    expect(result.pagination.total).toBe(0)
+  })
+})
+
+describe('findAvailableTerritoriesPaginated', () => {
+  it('retourne les territoires disponibles avec pagination', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3 }])
+
+    const result = await findAvailableTerritoriesPaginated({}, new URL('http://localhost/'))
+
+    expect(result.territories).toHaveLength(1)
+    expect(result.pagination.total).toBe(10)
+  })
+})

--- a/app/features/territories/server/territories.server.test.ts
+++ b/app/features/territories/server/territories.server.test.ts
@@ -6,7 +6,7 @@ vi.mock('~/shared/libs/db.server', () => ({
   },
 }))
 
-const { findTerritoriesWithDetailsPaginated, findAvailableTerritoriesPaginated } = await import('./territories.ts')
+const { findTerritoriesWithDetailsPaginated, findAvailableTerritoriesPaginated } = await import('./territories')
 const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
@@ -15,8 +15,8 @@ beforeEach(() => {
 
 describe('findTerritoriesWithDetailsPaginated', () => {
   it('retourne les territoires avec pagination', async () => {
-    vi.mocked(db.territory.count).mockResolvedValue(50)
-    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 1 }, { id: 2 }])
+    vi.mocked(db.territory.count).mockResolvedValue(50 as never)
+    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
 
     const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/?page=1&pageSize=25'))
 
@@ -26,8 +26,8 @@ describe('findTerritoriesWithDetailsPaginated', () => {
   })
 
   it('retourne un résultat vide quand il n\'y a pas de territoires', async () => {
-    vi.mocked(db.territory.count).mockResolvedValue(0)
-    vi.mocked(db.territory.findMany).mockResolvedValue([])
+    vi.mocked(db.territory.count).mockResolvedValue(0 as never)
+    vi.mocked(db.territory.findMany).mockResolvedValue([] as never)
 
     const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/'))
 
@@ -38,8 +38,8 @@ describe('findTerritoriesWithDetailsPaginated', () => {
 
 describe('findAvailableTerritoriesPaginated', () => {
   it('retourne les territoires disponibles avec pagination', async () => {
-    vi.mocked(db.territory.count).mockResolvedValue(10)
-    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3 }])
+    vi.mocked(db.territory.count).mockResolvedValue(10 as never)
+    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3 }] as never)
 
     const result = await findAvailableTerritoriesPaginated({}, new URL('http://localhost/'))
 

--- a/app/features/territories/server/territory-coverage-total.server.test.ts
+++ b/app/features/territories/server/territory-coverage-total.server.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+  },
+}))
+
+const { computeTerritoryCoverageTotal } = await import('./territory-coverage-total.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('computeTerritoryCoverageTotal', () => {
+  it('calcule le pourcentage de territoires ayant au moins une attribution', async () => {
+    // Premier appel: total, deuxième appel: territoires avec attributions
+    vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(4)
+
+    const result = await computeTerritoryCoverageTotal()
+    expect(result).toBe(40)
+  })
+
+  it('retourne 0 quand il n\'y a aucun territoire', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+
+    const result = await computeTerritoryCoverageTotal()
+    expect(result).toBe(0)
+  })
+
+  it('retourne 100 quand tous les territoires ont des attributions', async () => {
+    vi.mocked(db.territory.count).mockResolvedValueOnce(5).mockResolvedValueOnce(5)
+
+    const result = await computeTerritoryCoverageTotal()
+    expect(result).toBe(100)
+  })
+
+  it('ne dépasse jamais 100% (contrairement à coverage par attributions)', async () => {
+    // Chaque territoire ne peut être compté qu'une fois
+    vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(10)
+
+    const result = await computeTerritoryCoverageTotal()
+    expect(result).toBe(100)
+  })
+
+  it('accepte un filtre startDate', async () => {
+    vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(3)
+
+    const startDate = new Date(2025, 0, 1)
+    const result = await computeTerritoryCoverageTotal(undefined, undefined, startDate)
+    expect(result).toBe(30)
+  })
+
+  it('accepte startDate et endDate combinés', async () => {
+    vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(7)
+
+    const startDate = new Date(2025, 0, 1)
+    const endDate = new Date(2025, 11, 31)
+    const result = await computeTerritoryCoverageTotal(undefined, undefined, startDate, endDate)
+    expect(result).toBe(70)
+  })
+})

--- a/app/features/territories/server/territory-coverage-total.server.ts
+++ b/app/features/territories/server/territory-coverage-total.server.ts
@@ -9,12 +9,19 @@ export async function computeTerritoryCoverageTotal(
   startDate?: Date,
   endDate?: Date,
 ) {
+  // Filtre les attributions qui chevauchent la période [startDate, endDate]
   let whereDate: Prisma.AttributionWhereInput = {}
-  if (startDate != null) {
-    whereDate = { ...whereDate, startDate: { gte: startDate }, endDate: null }
-  }
-  if (endDate != null) {
-    whereDate = { ...whereDate, endDate: { lte: endDate } }
+  if (startDate != null && endDate != null) {
+    whereDate = {
+      startDate: { lte: endDate },
+      // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+      OR: [{ endDate: null }, { endDate: { gte: startDate } }],
+    }
+  } else if (startDate != null) {
+    // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+    whereDate = { OR: [{ endDate: null }, { endDate: { gte: startDate } }] }
+  } else if (endDate != null) {
+    whereDate = { startDate: { lte: endDate } }
   }
 
   // Count total territories of the specified kind

--- a/app/features/territories/server/territory-coverage.server.test.ts
+++ b/app/features/territories/server/territory-coverage.server.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { count: vi.fn() },
+    attribution: { count: vi.fn() },
+  },
+}))
+
+// Import après le mock
+const { computeTerritoryCoverage } = await import('./territory-coverage.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('computeTerritoryCoverage', () => {
+  it('calcule le pourcentage de couverture', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.attribution.count).mockResolvedValue(3)
+
+    const result = await computeTerritoryCoverage()
+    expect(result).toBe(30)
+  })
+
+  it('retourne 0 quand il n\'y a aucun territoire', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(0)
+    vi.mocked(db.attribution.count).mockResolvedValue(0)
+
+    const result = await computeTerritoryCoverage()
+    expect(result).toBe(0)
+  })
+
+  it('retourne 100 quand toutes les attributions couvrent tous les territoires', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(5)
+    vi.mocked(db.attribution.count).mockResolvedValue(5)
+
+    const result = await computeTerritoryCoverage()
+    expect(result).toBe(100)
+  })
+
+  it('peut retourner plus de 100% (plusieurs attributions par territoire)', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(5)
+    vi.mocked(db.attribution.count).mockResolvedValue(10)
+
+    const result = await computeTerritoryCoverage()
+    expect(result).toBe(200)
+  })
+
+  it('accepte des paramètres de type de territoire personnalisés', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(20)
+    vi.mocked(db.attribution.count).mockResolvedValue(5)
+
+    const result = await computeTerritoryCoverage(
+      [TerritoryKind.Phone, TerritoryKind.Classical],
+      [TerritoryAttributionKind.Phone],
+    )
+    expect(result).toBe(25)
+  })
+
+  it('utilise les valeurs par défaut Classical et Default', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.attribution.count).mockResolvedValue(2)
+
+    await computeTerritoryCoverage()
+
+    // On vérifie le résultat, pas l'appel au mock
+    // Les valeurs par défaut sont testées implicitement via le résultat correct
+    expect(await computeTerritoryCoverage()).toBe(20)
+  })
+
+  it('accepte un filtre startDate', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.attribution.count).mockResolvedValue(4)
+
+    const startDate = new Date(2025, 0, 1)
+    const result = await computeTerritoryCoverage(undefined, undefined, startDate)
+    expect(result).toBe(40)
+  })
+
+  it('accepte un filtre endDate', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.attribution.count).mockResolvedValue(6)
+
+    const endDate = new Date(2025, 11, 31)
+    const result = await computeTerritoryCoverage(undefined, undefined, undefined, endDate)
+    expect(result).toBe(60)
+  })
+
+  it('accepte startDate et endDate combinés', async () => {
+    vi.mocked(db.territory.count).mockResolvedValue(10)
+    vi.mocked(db.attribution.count).mockResolvedValue(8)
+
+    const startDate = new Date(2025, 0, 1)
+    const endDate = new Date(2025, 11, 31)
+    const result = await computeTerritoryCoverage(undefined, undefined, startDate, endDate)
+    expect(result).toBe(80)
+  })
+})

--- a/app/features/territories/server/territory-coverage.server.ts
+++ b/app/features/territories/server/territory-coverage.server.ts
@@ -9,12 +9,20 @@ export async function computeTerritoryCoverage(
   startDate?: Date,
   endDate?: Date,
 ) {
+  // Filtre les attributions qui chevauchent la période [startDate, endDate]
+  // Une attribution chevauche si : elle commence avant la fin ET (elle est en cours OU se termine après le début)
   let whereDate: Prisma.AttributionWhereInput = {}
-  if (startDate != null) {
-    whereDate = { ...whereDate, startDate: { gte: startDate }, endDate: null }
-  }
-  if (endDate != null) {
-    whereDate = { ...whereDate, endDate: { lte: endDate } }
+  if (startDate != null && endDate != null) {
+    whereDate = {
+      startDate: { lte: endDate },
+      // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+      OR: [{ endDate: null }, { endDate: { gte: startDate } }],
+    }
+  } else if (startDate != null) {
+    // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+    whereDate = { OR: [{ endDate: null }, { endDate: { gte: startDate } }] }
+  } else if (endDate != null) {
+    whereDate = { startDate: { lte: endDate } }
   }
 
   // Count total territories of the specified kind

--- a/app/features/territories/server/theocratic-year.server.test.ts
+++ b/app/features/territories/server/theocratic-year.server.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getBeginingDateOfTheocraticYear,
+  getCurrentTheocraticYear,
+  getEndDateOfTheocraticYear,
+  getNextTheocraticYear,
+  getPreviousTheocraticYear,
+} from './theocratic-year.server'
+
+describe('getBeginingDateOfTheocraticYear', () => {
+  it('retourne le 1er septembre de l\'année donnée', () => {
+    const result = getBeginingDateOfTheocraticYear(2025)
+    // theocraticYear=2025 → new Date(2025, 10, 1) → novembre 2025 → month > 7 → new Date(2025, 8, 1)
+    expect(result.getFullYear()).toBe(2025)
+    expect(result.getMonth()).toBe(8) // septembre
+    expect(result.getDate()).toBe(1)
+  })
+
+  it('retourne le 1er septembre pour différentes années', () => {
+    const result = getBeginingDateOfTheocraticYear(2023)
+    expect(result.getFullYear()).toBe(2023)
+    expect(result.getMonth()).toBe(8)
+    expect(result.getDate()).toBe(1)
+  })
+
+  describe('sans paramètre (date courante)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retourne septembre de l\'année courante si on est après août', () => {
+      // Octobre 2025
+      vi.setSystemTime(new Date(2025, 9, 15))
+      const result = getBeginingDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(8)
+    })
+
+    it('retourne septembre de l\'année précédente si on est avant septembre', () => {
+      // Mars 2025
+      vi.setSystemTime(new Date(2025, 2, 15))
+      const result = getBeginingDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(8)
+    })
+
+    it('retourne septembre de l\'année précédente en août (month 7, pas > 7)', () => {
+      // Août 2025 → month=7, pas > 7 → année précédente
+      vi.setSystemTime(new Date(2025, 7, 15))
+      const result = getBeginingDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2024)
+      expect(result.getMonth()).toBe(8)
+    })
+
+    it('retourne septembre de l\'année courante en septembre (month 8, > 7)', () => {
+      // Septembre 2025 → month=8, > 7 → année courante
+      vi.setSystemTime(new Date(2025, 8, 15))
+      const result = getBeginingDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(8)
+    })
+  })
+})
+
+describe('getEndDateOfTheocraticYear', () => {
+  it('retourne le 31 août de l\'année suivante pour l\'année donnée', () => {
+    const result = getEndDateOfTheocraticYear(2025)
+    // theocraticYear=2025 → new Date(2025, 10, 1) → novembre → month > 7 → new Date(2026, 7, 31)
+    expect(result.getFullYear()).toBe(2026)
+    expect(result.getMonth()).toBe(7) // août
+    expect(result.getDate()).toBe(31)
+  })
+
+  describe('sans paramètre (date courante)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retourne août de l\'année suivante si on est après août', () => {
+      // Octobre 2025
+      vi.setSystemTime(new Date(2025, 9, 15))
+      const result = getEndDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2026)
+      expect(result.getMonth()).toBe(7)
+      expect(result.getDate()).toBe(31)
+    })
+
+    it('retourne août de l\'année courante si on est avant septembre', () => {
+      // Mars 2025
+      vi.setSystemTime(new Date(2025, 2, 15))
+      const result = getEndDateOfTheocraticYear()
+
+      expect(result.getFullYear()).toBe(2025)
+      expect(result.getMonth()).toBe(7)
+      expect(result.getDate()).toBe(31)
+    })
+  })
+})
+
+describe('getCurrentTheocraticYear', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retourne l\'année courante après septembre', () => {
+    vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
+    expect(getCurrentTheocraticYear()).toBe(2025)
+  })
+
+  it('retourne l\'année précédente avant septembre', () => {
+    vi.setSystemTime(new Date(2025, 2, 15)) // mars 2025
+    expect(getCurrentTheocraticYear()).toBe(2024)
+  })
+})
+
+describe('getNextTheocraticYear', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retourne l\'année théocratique suivante', () => {
+    vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
+    expect(getNextTheocraticYear()).toBe(2026)
+  })
+})
+
+describe('getPreviousTheocraticYear', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retourne l\'année théocratique précédente', () => {
+    vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
+    expect(getPreviousTheocraticYear()).toBe(2024)
+  })
+})

--- a/app/features/territories/server/unserialize-shared-entrance-form-value.server.test.ts
+++ b/app/features/territories/server/unserialize-shared-entrance-form-value.server.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { unserializeSharedEntranceFormValue } from './unserialize-shared-entrance-form-value.server'
+
+describe('unserializeSharedEntranceFormValue', () => {
+  it('parse une chaîne de ids séparés par des virgules', () => {
+    expect(unserializeSharedEntranceFormValue('1,2,3', 99)).toEqual([1, 2, 3])
+  })
+
+  it('parse un seul id', () => {
+    expect(unserializeSharedEntranceFormValue('42', 99)).toEqual([42])
+  })
+
+  it('retourne le defaultBuildingId quand la valeur est null', () => {
+    expect(unserializeSharedEntranceFormValue(null, 7)).toEqual([7])
+  })
+
+  it('retourne le defaultBuildingId quand la valeur est une chaîne vide', () => {
+    expect(unserializeSharedEntranceFormValue('', 7)).toEqual([7])
+  })
+})

--- a/app/features/territories/server/update-buildings-in-entrance.server.test.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    buildingEntrance: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}))
+
+vi.mock('~/shared/libs/logger.server', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const { updateBuildingsInEntrance } = await import('./update-buildings-in-entrance.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.buildingEntrance.deleteMany).mockResolvedValue({ count: 0 })
+})
+
+describe('updateBuildingsInEntrance', () => {
+  it('ne fait rien si l\'entrée n\'existe pas', async () => {
+    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue(null)
+
+    const sentinel = Symbol('sentinel')
+    let result: unknown = sentinel
+    result = await updateBuildingsInEntrance(999, [1, 2])
+    expect(result).toBeUndefined()
+    expect(result).not.toBe(sentinel)
+  })
+
+  it('exécute la transaction pour connecter/déconnecter les bâtiments', async () => {
+    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue({
+      id: 10,
+      access: 1,
+      isMailboxOpen: false,
+      // biome-ignore lint/style/useNamingConvention: Prisma model field
+      isPMR: false,
+      isOpenEarly: false,
+      buildings: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    })
+
+    // $transaction exécute le callback
+    vi.mocked(db.$transaction).mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        buildingEntrance: {
+          update: vi.fn().mockResolvedValue({}),
+          createMany: vi.fn().mockResolvedValue({}),
+        },
+      }
+      await fn(tx)
+    })
+
+    // buildingIds [1, 4] → ajouter 4, déconnecter 2 et 3
+    await updateBuildingsInEntrance(10, [1, 4])
+
+    // La transaction a été exécutée
+    expect(vi.mocked(db.$transaction).mock.calls).toHaveLength(1)
+  })
+
+  it('nettoie les entrées vides après la mise à jour', async () => {
+    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue({
+      id: 10,
+      access: 1,
+      isMailboxOpen: false,
+      // biome-ignore lint/style/useNamingConvention: Prisma model field
+      isPMR: false,
+      isOpenEarly: false,
+      buildings: [{ id: 1 }],
+    })
+
+    vi.mocked(db.$transaction).mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+      const tx = {
+        buildingEntrance: {
+          update: vi.fn().mockResolvedValue({}),
+          createMany: vi.fn().mockResolvedValue({}),
+        },
+      }
+      await fn(tx)
+    })
+
+    await updateBuildingsInEntrance(10, [1])
+
+    // deleteMany est toujours appelé pour nettoyer les entrées vides
+    expect(vi.mocked(db.buildingEntrance.deleteMany).mock.calls).toHaveLength(1)
+  })
+
+  it('gère les erreurs de transaction sans planter', async () => {
+    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue({
+      id: 10,
+      access: 1,
+      isMailboxOpen: false,
+      // biome-ignore lint/style/useNamingConvention: Prisma model field
+      isPMR: false,
+      isOpenEarly: false,
+      buildings: [{ id: 1 }],
+    })
+
+    vi.mocked(db.$transaction).mockRejectedValue(new Error('Transaction failed'))
+
+    // Ne doit pas lancer d'erreur
+    await expect(updateBuildingsInEntrance(10, [1, 2])).resolves.toBeUndefined()
+  })
+})

--- a/app/features/territories/server/update-buildings-in-entrance.server.test.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.test.ts
@@ -33,7 +33,7 @@ describe('updateBuildingsInEntrance', () => {
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
-    result = await updateBuildingsInEntrance(999, [1, 2])
+    result = await updateBuildingsInEntrance(999, [1, 2], 1)
     expect(result).toBeUndefined()
     expect(result).not.toBe(sentinel)
   })
@@ -61,7 +61,7 @@ describe('updateBuildingsInEntrance', () => {
     })
 
     // buildingIds [1, 4] → ajouter 4, déconnecter 2 et 3
-    await updateBuildingsInEntrance(10, [1, 4])
+    await updateBuildingsInEntrance(10, [1, 4], 1)
 
     // La transaction a été exécutée
     expect(vi.mocked(db.$transaction).mock.calls).toHaveLength(1)
@@ -88,7 +88,7 @@ describe('updateBuildingsInEntrance', () => {
       await fn(tx)
     })
 
-    await updateBuildingsInEntrance(10, [1])
+    await updateBuildingsInEntrance(10, [1], 1)
 
     // deleteMany est toujours appelé pour nettoyer les entrées vides
     expect(vi.mocked(db.buildingEntrance.deleteMany).mock.calls).toHaveLength(1)
@@ -108,6 +108,6 @@ describe('updateBuildingsInEntrance', () => {
     vi.mocked(db.$transaction).mockRejectedValue(new Error('Transaction failed'))
 
     // Ne doit pas lancer d'erreur
-    await expect(updateBuildingsInEntrance(10, [1, 2])).resolves.toBeUndefined()
+    await expect(updateBuildingsInEntrance(10, [1, 2], 1)).resolves.toBeUndefined()
   })
 })

--- a/app/features/territories/server/update-buildings-in-entrance.server.test.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.test.ts
@@ -24,12 +24,12 @@ const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
-  vi.mocked(db.buildingEntrance.deleteMany).mockResolvedValue({ count: 0 })
+  vi.mocked(db.buildingEntrance.deleteMany).mockResolvedValue({ count: 0 } as never)
 })
 
 describe('updateBuildingsInEntrance', () => {
   it('ne fait rien si l\'entrée n\'existe pas', async () => {
-    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue(null)
+    vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue(null as never)
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
@@ -47,18 +47,18 @@ describe('updateBuildingsInEntrance', () => {
       isPMR: false,
       isOpenEarly: false,
       buildings: [{ id: 1 }, { id: 2 }, { id: 3 }],
-    })
+    } as never)
 
     // $transaction exécute le callback
-    vi.mocked(db.$transaction).mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+    vi.mocked(db.$transaction).mockImplementation((async (fn: (tx: unknown) => Promise<void>) => {
       const tx = {
         buildingEntrance: {
-          update: vi.fn().mockResolvedValue({}),
-          createMany: vi.fn().mockResolvedValue({}),
+          update: vi.fn().mockResolvedValue({} as never),
+          createMany: vi.fn().mockResolvedValue({} as never),
         },
       }
       await fn(tx)
-    })
+    }) as never)
 
     // buildingIds [1, 4] → ajouter 4, déconnecter 2 et 3
     await updateBuildingsInEntrance(10, [1, 4], 1)
@@ -76,17 +76,17 @@ describe('updateBuildingsInEntrance', () => {
       isPMR: false,
       isOpenEarly: false,
       buildings: [{ id: 1 }],
-    })
+    } as never)
 
-    vi.mocked(db.$transaction).mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+    vi.mocked(db.$transaction).mockImplementation((async (fn: (tx: unknown) => Promise<void>) => {
       const tx = {
         buildingEntrance: {
-          update: vi.fn().mockResolvedValue({}),
-          createMany: vi.fn().mockResolvedValue({}),
+          update: vi.fn().mockResolvedValue({} as never),
+          createMany: vi.fn().mockResolvedValue({} as never),
         },
       }
       await fn(tx)
-    })
+    }) as never)
 
     await updateBuildingsInEntrance(10, [1], 1)
 
@@ -103,7 +103,7 @@ describe('updateBuildingsInEntrance', () => {
       isPMR: false,
       isOpenEarly: false,
       buildings: [{ id: 1 }],
-    })
+    } as never)
 
     vi.mocked(db.$transaction).mockRejectedValue(new Error('Transaction failed'))
 

--- a/app/features/territories/server/update-buildings-in-entrance.server.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.ts
@@ -1,7 +1,7 @@
 import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
-export async function updateBuildingsInEntrance(entranceId: number, buildingIds: number[]) {
+export async function updateBuildingsInEntrance(entranceId: number, buildingIds: number[], congregationId: number) {
   const entrance = await db.buildingEntrance.findUnique({
     where: { id: entranceId },
     include: { buildings: true },
@@ -53,7 +53,7 @@ export async function updateBuildingsInEntrance(entranceId: number, buildingIds:
             buildings: {
               connect: { id: disconnectBuildingId },
             },
-            congregationId: 0 as number,
+            congregationId,
           })),
         })
       }

--- a/app/routes/suspended.tsx
+++ b/app/routes/suspended.tsx
@@ -24,8 +24,8 @@ export default function SuspendedPage({ loaderData }: Route.ComponentProps) {
       <div className="mx-auto max-w-md text-center">
         <h1 className="mb-4 font-bold text-2xl text-gray-900">Compte suspendu</h1>
         <p className="mb-6 text-gray-600">
-          L'accès à votre congrégation a été temporairement suspendu. Si vous pensez qu'il s'agit d'une erreur, veuillez
-          contacter l'administrateur.
+          L'accès à votre assemblée locale a été temporairement suspendu. Si vous pensez qu'il s'agit d'une erreur,
+          veuillez contacter l'administrateur.
         </p>
         <div className="flex flex-col gap-3">
           {billingUrl && (

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  unscopedDb: {
+    congregation: { findUnique: vi.fn() },
+  },
+  congregationContext: {
+    getStore: vi.fn(),
+  },
+}))
+
+const { resolveCongregation, getCongregationFromContext, requireCongregation, getPlatformName } = await import(
+  './congregation.server'
+)
+const { unscopedDb: db, congregationContext } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+const baseCongregation = {
+  id: 1,
+  name: 'Congrégation Test',
+  slug: 'test',
+  displayName: null,
+  emailFromName: null,
+  emailFromAddress: null,
+  baseUrl: null,
+  plan: null,
+  maxPublishers: null,
+  maxTerritories: null,
+  maxUsers: null,
+  maxStorageBytes: null,
+  maxBoardDocuments: null,
+  suspendedAt: null,
+  suspendedReason: null,
+}
+
+describe('resolveCongregation', () => {
+  it('lance une erreur si la congrégation n\'existe pas', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(null)
+
+    await expect(resolveCongregation(999)).rejects.toThrow('Congregation 999 not found')
+  })
+
+  it('utilise le nom comme displayName par défaut', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+
+    const result = await resolveCongregation(1)
+    expect(result.displayName).toBe('Congrégation Test')
+  })
+
+  it('utilise displayName quand il est défini', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      displayName: 'Nom affiché',
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.displayName).toBe('Nom affiché')
+  })
+
+  it('utilise l\'email par défaut quand emailFromAddress est null', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+
+    const result = await resolveCongregation(1)
+    expect(result.emailFrom).toBe('Unitae <noreply@unitae.app>')
+  })
+
+  it('construit l\'emailFrom à partir de emailFromAddress et emailFromName', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      emailFromName: 'Ma Congré',
+      emailFromAddress: 'contact@congregation.org',
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.emailFrom).toBe('Ma Congré <contact@congregation.org>')
+  })
+
+  it('utilise le nom de congrégation quand emailFromName est null', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      emailFromAddress: 'contact@test.org',
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.emailFrom).toBe('Congrégation Test <contact@test.org>')
+  })
+
+  it('construit le baseUrl à partir du slug quand baseUrl est null', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+
+    const result = await resolveCongregation(1)
+    expect(result.baseUrl).toBe('https://test.unitae.app')
+  })
+
+  it('utilise le baseUrl personnalisé quand il est défini', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      baseUrl: 'https://custom.example.com',
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.baseUrl).toBe('https://custom.example.com')
+  })
+
+  it('transmet les champs de plan et limites', async () => {
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      plan: 'pro',
+      maxPublishers: 100,
+      maxTerritories: 50,
+      maxUsers: 10,
+      maxStorageBytes: 1000000n,
+      maxBoardDocuments: 25,
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.plan).toBe('pro')
+    expect(result.maxPublishers).toBe(100)
+    expect(result.maxTerritories).toBe(50)
+    expect(result.maxUsers).toBe(10)
+    expect(result.maxStorageBytes).toBe(1000000n)
+    expect(result.maxBoardDocuments).toBe(25)
+  })
+
+  it('transmet les champs de suspension', async () => {
+    const suspendedDate = new Date(2025, 3, 1)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({
+      ...baseCongregation,
+      suspendedAt: suspendedDate,
+      suspendedReason: 'Impayé',
+    })
+
+    const result = await resolveCongregation(1)
+    expect(result.suspendedAt).toBe(suspendedDate)
+    expect(result.suspendedReason).toBe('Impayé')
+  })
+})
+
+describe('getCongregationFromContext', () => {
+  it('retourne null quand le contexte n\'est pas défini', () => {
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+
+    expect(getCongregationFromContext()).toBeNull()
+  })
+
+  it('retourne la congrégation du contexte', () => {
+    const fakeCongregation = { id: 1, name: 'Test' }
+    vi.mocked(congregationContext.getStore).mockReturnValue({
+      congregationId: 1,
+      congregation: fakeCongregation,
+    })
+
+    expect(getCongregationFromContext()).toBe(fakeCongregation)
+  })
+
+  it('retourne null quand le contexte existe mais sans congrégation', () => {
+    vi.mocked(congregationContext.getStore).mockReturnValue({
+      congregationId: 1,
+    })
+
+    expect(getCongregationFromContext()).toBeNull()
+  })
+})
+
+describe('requireCongregation', () => {
+  it('lance une erreur quand le contexte n\'est pas défini', () => {
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+
+    expect(() => requireCongregation()).toThrow('Congregation context is required but not set')
+  })
+
+  it('retourne la congrégation quand le contexte est défini', () => {
+    const fakeCongregation = { id: 1, name: 'Test' }
+    vi.mocked(congregationContext.getStore).mockReturnValue({
+      congregationId: 1,
+      congregation: fakeCongregation,
+    })
+
+    expect(requireCongregation()).toBe(fakeCongregation)
+  })
+})
+
+describe('getPlatformName', () => {
+  it('retourne "Unitae"', () => {
+    expect(getPlatformName()).toBe('Unitae')
+  })
+})

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -38,13 +38,13 @@ const baseCongregation = {
 
 describe('resolveCongregation', () => {
   it('lance une erreur si la congrégation n\'existe pas', async () => {
-    vi.mocked(db.congregation.findUnique).mockResolvedValue(null)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(null as never)
 
     await expect(resolveCongregation(999)).rejects.toThrow('Congregation 999 not found')
   })
 
   it('utilise le nom comme displayName par défaut', async () => {
-    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
 
     const result = await resolveCongregation(1)
     expect(result.displayName).toBe('Congrégation Test')
@@ -54,14 +54,14 @@ describe('resolveCongregation', () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue({
       ...baseCongregation,
       displayName: 'Nom affiché',
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.displayName).toBe('Nom affiché')
   })
 
   it('utilise l\'email par défaut quand emailFromAddress est null', async () => {
-    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
 
     const result = await resolveCongregation(1)
     expect(result.emailFrom).toBe('Unitae <noreply@unitae.app>')
@@ -72,7 +72,7 @@ describe('resolveCongregation', () => {
       ...baseCongregation,
       emailFromName: 'Ma Congré',
       emailFromAddress: 'contact@congregation.org',
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.emailFrom).toBe('Ma Congré <contact@congregation.org>')
@@ -82,14 +82,14 @@ describe('resolveCongregation', () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue({
       ...baseCongregation,
       emailFromAddress: 'contact@test.org',
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.emailFrom).toBe('Congrégation Test <contact@test.org>')
   })
 
   it('construit le baseUrl à partir du slug quand baseUrl est null', async () => {
-    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
 
     const result = await resolveCongregation(1)
     expect(result.baseUrl).toBe('https://test.unitae.app')
@@ -99,7 +99,7 @@ describe('resolveCongregation', () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue({
       ...baseCongregation,
       baseUrl: 'https://custom.example.com',
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.baseUrl).toBe('https://custom.example.com')
@@ -114,7 +114,7 @@ describe('resolveCongregation', () => {
       maxUsers: 10,
       maxStorageBytes: 1000000n,
       maxBoardDocuments: 25,
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.plan).toBe('pro')
@@ -131,7 +131,7 @@ describe('resolveCongregation', () => {
       ...baseCongregation,
       suspendedAt: suspendedDate,
       suspendedReason: 'Impayé',
-    })
+    } as never)
 
     const result = await resolveCongregation(1)
     expect(result.suspendedAt).toBe(suspendedDate)
@@ -141,7 +141,7 @@ describe('resolveCongregation', () => {
 
 describe('getCongregationFromContext', () => {
   it('retourne null quand le contexte n\'est pas défini', () => {
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
 
     expect(getCongregationFromContext()).toBeNull()
   })
@@ -151,7 +151,7 @@ describe('getCongregationFromContext', () => {
     vi.mocked(congregationContext.getStore).mockReturnValue({
       congregationId: 1,
       congregation: fakeCongregation,
-    })
+    } as never)
 
     expect(getCongregationFromContext()).toBe(fakeCongregation)
   })
@@ -167,7 +167,7 @@ describe('getCongregationFromContext', () => {
 
 describe('requireCongregation', () => {
   it('lance une erreur quand le contexte n\'est pas défini', () => {
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined)
+    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
 
     expect(() => requireCongregation()).toThrow('Congregation context is required but not set')
   })
@@ -177,7 +177,7 @@ describe('requireCongregation', () => {
     vi.mocked(congregationContext.getStore).mockReturnValue({
       congregationId: 1,
       congregation: fakeCongregation,
-    })
+    } as never)
 
     expect(requireCongregation()).toBe(fakeCongregation)
   })

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -67,3 +67,44 @@ export async function resolveCongregation(congregationId: number): Promise<Congr
 export function getPlatformName(): string {
   return DEFAULT_PLATFORM_NAME
 }
+
+const DEFAULT_CONGREGATION_NAME = 'Ma Congrégation'
+
+export async function getBrandingName(request?: Request): Promise<string> {
+  let congregation: { name: string; displayName: string | null } | null = null
+
+  if (process.env.MULTI_TENANT === 'true' && request) {
+    const hostname = new URL(request.url).hostname
+    const appBaseUrl = (process.env.APP_BASE_URL ?? 'unitae.app').replace('https://', '').replace('http://', '')
+    const slug = hostname.endsWith(appBaseUrl) ? hostname.replace(`.${appBaseUrl}`, '') : null
+
+    if (slug) {
+      congregation = await unscopedDb.congregation.findUnique({
+        where: { slug },
+        select: { name: true, displayName: true },
+      })
+    }
+    if (!congregation) {
+      congregation = await unscopedDb.congregation.findFirst({
+        where: { domain: hostname },
+        select: { name: true, displayName: true },
+      })
+    }
+  } else {
+    congregation = await unscopedDb.congregation.findFirst({
+      select: { name: true, displayName: true },
+    })
+  }
+
+  if (!congregation) return DEFAULT_PLATFORM_NAME
+
+  if (congregation.displayName && congregation.displayName !== DEFAULT_CONGREGATION_NAME) {
+    return congregation.displayName
+  }
+
+  if (congregation.name !== DEFAULT_CONGREGATION_NAME) {
+    return congregation.name
+  }
+
+  return DEFAULT_PLATFORM_NAME
+}

--- a/app/shared/libs/crypto.server.test.ts
+++ b/app/shared/libs/crypto.server.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { compare, hash } from './crypto.server'
+
+const HEX_PATTERN = /^[0-9a-f]+$/
+
+describe('hash', () => {
+  it('retourne un hash au format salt.key', async () => {
+    const result = await hash('motdepasse')
+    const parts = result.split('.')
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toMatch(HEX_PATTERN)
+    expect(parts[1]).toMatch(HEX_PATTERN)
+  })
+
+  it('produit des résultats différents pour le même mot de passe (sel aléatoire)', async () => {
+    const hash1 = await hash('motdepasse')
+    const hash2 = await hash('motdepasse')
+
+    expect(hash1).not.toBe(hash2)
+  })
+})
+
+describe('compare', () => {
+  it('retourne true pour le bon mot de passe', async () => {
+    const hashed = await hash('motdepasse')
+    const result = await compare('motdepasse', hashed)
+
+    expect(result).toBe(true)
+  })
+
+  it('retourne false pour un mauvais mot de passe', async () => {
+    const hashed = await hash('motdepasse')
+    const result = await compare('mauvais', hashed)
+
+    expect(result).toBe(false)
+  })
+
+  it('rejette un format de hash invalide (sans point)', async () => {
+    await expect(compare('motdepasse', 'formatsansseparateur')).rejects.toThrow('Invalid format')
+  })
+
+  it('rejette un hash vide', async () => {
+    await expect(compare('motdepasse', '')).rejects.toThrow('Invalid format')
+  })
+
+  it('fonctionne en aller-retour pour différents mots de passe', async () => {
+    const passwords = ['simple', 'Compl3x!@#', '日本語', '  espaces  ', 'a']
+
+    for (const password of passwords) {
+      const hashed = await hash(password)
+      const result = await compare(password, hashed)
+      expect(result).toBe(true)
+    }
+  })
+})

--- a/app/shared/libs/file-storage.server.test.ts
+++ b/app/shared/libs/file-storage.server.test.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Force local driver (no S3_ENDPOINT)
+delete process.env.S3_ENDPOINT
+
+let testDir: string
+
+beforeAll(async () => {
+  testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'unitae-storage-test-'))
+  process.env.LOCAL_STORAGE_PATH = testDir
+})
+
+afterAll(async () => {
+  await fs.rm(testDir, { recursive: true, force: true })
+  delete process.env.LOCAL_STORAGE_PATH
+})
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+async function getModule() {
+  return await import('./file-storage.server')
+}
+
+describe('local filesystem driver', () => {
+  describe('uploadFile + getFileBuffer (aller-retour)', () => {
+    it('écrit et relit un fichier correctement', async () => {
+      const { uploadFile, getFileBuffer } = await getModule()
+      const content = Buffer.from('Contenu du fichier PDF')
+
+      await uploadFile('1/board/test.pdf', content, 'application/pdf')
+      const result = await getFileBuffer('1/board/test.pdf')
+
+      expect(result).not.toBeNull()
+      expect(result?.toString()).toBe('Contenu du fichier PDF')
+    })
+
+    it('crée les répertoires intermédiaires automatiquement', async () => {
+      const { uploadFile } = await getModule()
+
+      await uploadFile('99/deep/nested/file.txt', Buffer.from('ok'), 'text/plain')
+
+      const filePath = path.join(testDir, '99/deep/nested/file.txt')
+      const stat = await fs.stat(filePath)
+      expect(stat.isFile()).toBe(true)
+    })
+  })
+
+  describe('getFile', () => {
+    it('retourne le body et le contentType', async () => {
+      const { uploadFile, getFile } = await getModule()
+      await uploadFile('1/board/stream.pdf', Buffer.from('stream-data'), 'application/pdf')
+
+      const result = await getFile('1/board/stream.pdf')
+
+      expect(result).not.toBeNull()
+      expect(result?.contentType).toBe('application/pdf')
+    })
+
+    it('retourne null pour un fichier inexistant', async () => {
+      const { getFile } = await getModule()
+
+      const result = await getFile('inexistant/fichier.pdf')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getFileBuffer', () => {
+    it('retourne null pour un fichier inexistant', async () => {
+      const { getFileBuffer } = await getModule()
+
+      const result = await getFileBuffer('inexistant/fichier.pdf')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('deleteFileFromStorage', () => {
+    it('supprime un fichier existant', async () => {
+      const { uploadFile, deleteFileFromStorage, getFileBuffer } = await getModule()
+      await uploadFile('1/board/to-delete.pdf', Buffer.from('à supprimer'), 'application/pdf')
+
+      await deleteFileFromStorage('1/board/to-delete.pdf')
+
+      const result = await getFileBuffer('1/board/to-delete.pdf')
+      expect(result).toBeNull()
+    })
+
+    it('ne lance pas d\'erreur pour un fichier inexistant', async () => {
+      const { deleteFileFromStorage } = await getModule()
+
+      await expect(deleteFileFromStorage('inexistant/fichier.pdf')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('buildStorageKey', () => {
+    it('construit la clé au format congregationId/feature/filename', async () => {
+      const { buildStorageKey } = await getModule()
+
+      expect(buildStorageKey(5, 'board', 'abc.pdf')).toBe('5/board/abc.pdf')
+    })
+  })
+})

--- a/app/shared/libs/file-storage.server.ts
+++ b/app/shared/libs/file-storage.server.ts
@@ -1,94 +1,161 @@
-// biome-ignore-all lint/style/useNamingConvention: AWS SDK uses PascalCase properties
-import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { Readable } from 'node:stream'
 import logger from './logger.server'
 
-const s3 = new S3Client({
-  endpoint: process.env.S3_ENDPOINT,
-  region: process.env.S3_REGION ?? 'auto',
-  credentials:
-    process.env.S3_ACCESS_KEY && process.env.S3_SECRET_KEY
-      ? {
-          accessKeyId: process.env.S3_ACCESS_KEY,
-          secretAccessKey: process.env.S3_SECRET_KEY,
-        }
-      : undefined,
-  forcePathStyle: true,
-})
+const useS3 = Boolean(process.env.S3_ENDPOINT)
+const LOCAL_STORAGE_ROOT = path.resolve(process.env.LOCAL_STORAGE_PATH ?? 'content/uploads')
+
+// --- S3 driver (lazy-loaded to avoid import errors when not used) ---
+
+async function getS3Client() {
+  const { S3Client } = await import('@aws-sdk/client-s3')
+  return new S3Client({
+    endpoint: process.env.S3_ENDPOINT,
+    region: process.env.S3_REGION ?? 'auto',
+    credentials:
+      process.env.S3_ACCESS_KEY && process.env.S3_SECRET_KEY
+        ? {
+            accessKeyId: process.env.S3_ACCESS_KEY,
+            secretAccessKey: process.env.S3_SECRET_KEY,
+          }
+        : undefined,
+    forcePathStyle: true,
+  })
+}
 
 const BUCKET = process.env.S3_BUCKET ?? 'unitae'
 
-export async function uploadFile(
-  key: string,
-  body: ArrayBuffer | Buffer | Uint8Array,
-  contentType: string,
-): Promise<void> {
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: BUCKET,
-      Key: key,
-      Body: body instanceof ArrayBuffer ? new Uint8Array(body) : body,
-      ContentType: contentType,
-    }),
-  )
+async function s3Upload(key: string, body: ArrayBuffer | Buffer | Uint8Array, contentType: string): Promise<void> {
+  const { PutObjectCommand } = await import('@aws-sdk/client-s3')
+  const s3 = await getS3Client()
+  // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+  await s3.send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: body instanceof ArrayBuffer ? new Uint8Array(body) : body, ContentType: contentType }))
 }
 
-export async function getFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null> {
+async function s3GetFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null> {
+  const { GetObjectCommand } = await import('@aws-sdk/client-s3')
+  const s3 = await getS3Client()
   try {
-    const response = await s3.send(
-      new GetObjectCommand({
-        Bucket: BUCKET,
-        Key: key,
-      }),
-    )
-
+    // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+    const response = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }))
     if (!response.Body) return null
-
     return {
       body: response.Body.transformToWebStream(),
       contentType: response.ContentType ?? 'application/octet-stream',
     }
   } catch (error: unknown) {
     const code = (error as { name?: string })?.name
-    if (code === 'NoSuchKey' || code === 'NotFound') {
-      return null
-    }
+    if (code === 'NoSuchKey' || code === 'NotFound') return null
     throw error
   }
 }
 
-export async function getFileBuffer(key: string): Promise<Buffer | null> {
+async function s3GetFileBuffer(key: string): Promise<Buffer | null> {
+  const { GetObjectCommand } = await import('@aws-sdk/client-s3')
+  const s3 = await getS3Client()
   try {
-    const response = await s3.send(
-      new GetObjectCommand({
-        Bucket: BUCKET,
-        Key: key,
-      }),
-    )
-
+    // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+    const response = await s3.send(new GetObjectCommand({ Bucket: BUCKET, Key: key }))
     if (!response.Body) return null
-
     const bytes = await response.Body.transformToByteArray()
     return Buffer.from(bytes)
   } catch (error: unknown) {
     const code = (error as { name?: string })?.name
-    if (code === 'NoSuchKey' || code === 'NotFound') {
-      return null
-    }
+    if (code === 'NoSuchKey' || code === 'NotFound') return null
     throw error
   }
 }
 
-export async function deleteFileFromStorage(key: string): Promise<void> {
+async function s3Delete(key: string): Promise<void> {
+  const { DeleteObjectCommand } = await import('@aws-sdk/client-s3')
+  const s3 = await getS3Client()
   try {
-    await s3.send(
-      new DeleteObjectCommand({
-        Bucket: BUCKET,
-        Key: key,
-      }),
-    )
+    // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+    await s3.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: key }))
   } catch (error) {
     logger.error(`Failed to delete file from S3: ${key}`, { error })
   }
+}
+
+// --- Local filesystem driver ---
+
+function localPath(key: string): string {
+  return path.join(LOCAL_STORAGE_ROOT, key)
+}
+
+function metaPath(key: string): string {
+  return `${localPath(key)}.meta`
+}
+
+async function localUpload(key: string, body: ArrayBuffer | Buffer | Uint8Array, contentType: string): Promise<void> {
+  const filePath = localPath(key)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const buffer = body instanceof ArrayBuffer ? Buffer.from(body) : Buffer.from(body)
+  await fs.writeFile(filePath, buffer)
+  await fs.writeFile(metaPath(key), contentType, 'utf-8')
+}
+
+async function localGetFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null> {
+  const filePath = localPath(key)
+  try {
+    await fs.access(filePath)
+  } catch {
+    return null
+  }
+
+  let contentType = 'application/octet-stream'
+  try {
+    contentType = await fs.readFile(metaPath(key), 'utf-8')
+  } catch {
+    // Pas de fichier .meta, on utilise le type par défaut
+  }
+
+  const nodeStream = Readable.toWeb(Readable.from(await fs.readFile(filePath))) as ReadableStream
+  return { body: nodeStream, contentType }
+}
+
+async function localGetFileBuffer(key: string): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(localPath(key))
+  } catch {
+    return null
+  }
+}
+
+async function localDelete(key: string): Promise<void> {
+  try {
+    await fs.unlink(localPath(key))
+  } catch (error) {
+    logger.error(`Failed to delete local file: ${key}`, { error })
+  }
+  try {
+    await fs.unlink(metaPath(key))
+  } catch {
+    // Le fichier .meta peut ne pas exister
+  }
+}
+
+// --- Public API (delegates to active driver) ---
+
+export function uploadFile(
+  key: string,
+  body: ArrayBuffer | Buffer | Uint8Array,
+  contentType: string,
+): Promise<void> {
+  return useS3 ? s3Upload(key, body, contentType) : localUpload(key, body, contentType)
+}
+
+export function getFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null> {
+  return useS3 ? s3GetFile(key) : localGetFile(key)
+}
+
+export function getFileBuffer(key: string): Promise<Buffer | null> {
+  return useS3 ? s3GetFileBuffer(key) : localGetFileBuffer(key)
+}
+
+export function deleteFileFromStorage(key: string): Promise<void> {
+  return useS3 ? s3Delete(key) : localDelete(key)
 }
 
 export function buildStorageKey(congregationId: number, feature: string, filename: string): string {

--- a/app/shared/libs/host-settings.server.test.ts
+++ b/app/shared/libs/host-settings.server.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('getHostSettings', () => {
+  const originalEnv = process.env.HOST_SETTINGS
+
+  beforeEach(() => {
+    // Chaque test a besoin d'un module frais pour réinitialiser le cache
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.HOST_SETTINGS = originalEnv
+    } else {
+      delete process.env.HOST_SETTINGS
+    }
+  })
+
+  it('retourne un objet vide quand HOST_SETTINGS n\'est pas défini', async () => {
+    delete process.env.HOST_SETTINGS
+    const { getHostSettings } = await import('./host-settings.server')
+
+    expect(getHostSettings()).toEqual({})
+  })
+
+  it('parse le JSON de HOST_SETTINGS', async () => {
+    process.env.HOST_SETTINGS = JSON.stringify({
+      billing: { portalUrl: 'https://billing.example.com', upgradeUrl: 'https://upgrade.example.com' },
+      support: { url: 'https://support.example.com' },
+    })
+    const { getHostSettings } = await import('./host-settings.server')
+
+    const result = getHostSettings()
+    expect(result.billing?.portalUrl).toBe('https://billing.example.com')
+    expect(result.support?.url).toBe('https://support.example.com')
+  })
+
+  it('retourne un objet vide pour du JSON invalide', async () => {
+    process.env.HOST_SETTINGS = 'not-valid-json'
+    const { getHostSettings } = await import('./host-settings.server')
+
+    expect(getHostSettings()).toEqual({})
+  })
+
+  it('met en cache le résultat entre les appels', async () => {
+    process.env.HOST_SETTINGS = JSON.stringify({ branding: { platformName: 'TestApp' } })
+    const { getHostSettings } = await import('./host-settings.server')
+
+    const first = getHostSettings()
+    // Même si on change l'env, le cache retourne le même résultat
+    process.env.HOST_SETTINGS = JSON.stringify({ branding: { platformName: 'Changed' } })
+    const second = getHostSettings()
+
+    expect(first).toBe(second) // même référence (cache)
+    expect(first.branding?.platformName).toBe('TestApp')
+  })
+})

--- a/app/shared/libs/limits.server.test.ts
+++ b/app/shared/libs/limits.server.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LimitError, LimitService } from './limits.server'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    user: { count: vi.fn() },
+    territory: { count: vi.fn() },
+    boardDocument: { count: vi.fn() },
+  },
+}))
+
+function makeLimits(overrides: Partial<ConstructorParameters<typeof LimitService>[0]> = {}) {
+  return {
+    maxPublishers: null,
+    maxTerritories: null,
+    maxUsers: null,
+    maxStorageBytes: null,
+    maxBoardDocuments: null,
+    ...overrides,
+  }
+}
+
+describe('LimitService', () => {
+  describe('isLimited', () => {
+    it('retourne false quand la limite est null (illimité)', () => {
+      const service = new LimitService(makeLimits({ maxPublishers: null }))
+      expect(service.isLimited('publishers')).toBe(false)
+    })
+
+    it('retourne true quand la limite est définie', () => {
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      expect(service.isLimited('publishers')).toBe(true)
+    })
+
+    it('retourne true même quand la limite est 0', () => {
+      const service = new LimitService(makeLimits({ maxTerritories: 0 }))
+      expect(service.isLimited('territories')).toBe(true)
+    })
+
+    it('vérifie chaque type de limite indépendamment', () => {
+      const service = new LimitService(makeLimits({ maxPublishers: 10, maxTerritories: null }))
+      expect(service.isLimited('publishers')).toBe(true)
+      expect(service.isLimited('territories')).toBe(false)
+    })
+  })
+
+  describe('isStorageLimited', () => {
+    it('retourne false quand maxStorageBytes est null', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: null }))
+      expect(service.isStorageLimited()).toBe(false)
+    })
+
+    it('retourne true quand maxStorageBytes est défini', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      expect(service.isStorageLimited()).toBe(true)
+    })
+  })
+
+  describe('checkStorageLimit', () => {
+    it('retourne false quand le stockage n\'est pas limité', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: null }))
+      expect(service.checkStorageLimit(500n, 100n)).toBe(false)
+    })
+
+    it('retourne false quand le total est sous la limite', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      expect(service.checkStorageLimit(500n, 100n)).toBe(false)
+    })
+
+    it('retourne false quand le total est exactement à la limite', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      expect(service.checkStorageLimit(500n, 500n)).toBe(false)
+    })
+
+    it('retourne true quand le total dépasse la limite', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      expect(service.checkStorageLimit(500n, 501n)).toBe(true)
+    })
+  })
+
+  describe('errorIfStorageOverLimit', () => {
+    it('ne lance pas d\'erreur quand sous la limite', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      expect(() => service.errorIfStorageOverLimit(100n, 100n)).not.toThrow()
+    })
+
+    it('lance LimitError quand la limite est dépassée', () => {
+      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      try {
+        service.errorIfStorageOverLimit(900n, 200n)
+        expect.unreachable('devrait lancer une erreur')
+      } catch (error) {
+        expect(error).toBeInstanceOf(LimitError)
+        expect((error as LimitError).limitName).toBe('storage')
+      }
+    })
+  })
+
+  describe('checkWouldGoOverLimit', () => {
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
+
+    it('retourne false quand la ressource n\'est pas limitée', async () => {
+      const service = new LimitService(makeLimits({ maxPublishers: null }))
+      const result = await service.checkWouldGoOverLimit('publishers')
+      expect(result).toBe(false)
+    })
+
+    it('retourne false quand le count est sous la limite', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.user.count).mockResolvedValue(5)
+
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const result = await service.checkWouldGoOverLimit('publishers')
+      expect(result).toBe(false)
+    })
+
+    it('retourne true quand le count atteint la limite', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.user.count).mockResolvedValue(10)
+
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const result = await service.checkWouldGoOverLimit('publishers')
+      expect(result).toBe(true)
+    })
+
+    it('retourne true quand le count dépasse la limite', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.user.count).mockResolvedValue(15)
+
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const result = await service.checkWouldGoOverLimit('publishers')
+      expect(result).toBe(true)
+    })
+
+    it('vérifie les territoires via db.territory.count', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.territory.count).mockResolvedValue(3)
+
+      const service = new LimitService(makeLimits({ maxTerritories: 5 }))
+      const result = await service.checkWouldGoOverLimit('territories')
+      expect(result).toBe(false)
+    })
+
+    it('vérifie les documents via db.boardDocument.count', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.boardDocument.count).mockResolvedValue(20)
+
+      const service = new LimitService(makeLimits({ maxBoardDocuments: 20 }))
+      const result = await service.checkWouldGoOverLimit('boardDocuments')
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('errorIfWouldGoOverLimit', () => {
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
+
+    it('ne lance pas d\'erreur quand sous la limite', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.user.count).mockResolvedValue(5)
+
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      await expect(service.errorIfWouldGoOverLimit('publishers')).resolves.toBeUndefined()
+    })
+
+    it('lance LimitError quand la limite est atteinte', async () => {
+      const { db } = await import('~/shared/libs/db.server')
+      vi.mocked(db.user.count).mockResolvedValue(10)
+
+      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      try {
+        await service.errorIfWouldGoOverLimit('publishers')
+        expect.unreachable('devrait lancer une erreur')
+      } catch (error) {
+        expect(error).toBeInstanceOf(LimitError)
+        expect((error as LimitError).limitName).toBe('publishers')
+      }
+    })
+  })
+})
+
+describe('LimitError', () => {
+  it('est une instance de Error', () => {
+    const error = new LimitError('publishers')
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('a la propriété limitName correcte', () => {
+    const error = new LimitError('storage')
+    expect(error.limitName).toBe('storage')
+  })
+
+  it('a un message contenant le nom de la limite', () => {
+    const error = new LimitError('publishers')
+    expect(error.message).toContain('publishers')
+  })
+})

--- a/app/shared/libs/pagination.server.test.ts
+++ b/app/shared/libs/pagination.server.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { paginationFromUrl } from './pagination.server'
+
+describe('paginationFromUrl', () => {
+  it('retourne les valeurs par défaut sans paramètres', () => {
+    const url = new URL('http://localhost/')
+    const result = paginationFromUrl(url, 100)
+
+    expect(result.page).toBe(1)
+    expect(result.size).toBe(25)
+    expect(result.offset).toBe(0)
+    expect(result.total).toBe(100)
+    expect(result.pages).toBe(4)
+    expect(result.previous).toBeNull()
+    expect(result.next).toBe(2)
+  })
+
+  it('utilise les paramètres page et pageSize de l\'URL', () => {
+    const url = new URL('http://localhost/?page=3&pageSize=10')
+    const result = paginationFromUrl(url, 50)
+
+    expect(result.page).toBe(3)
+    expect(result.size).toBe(10)
+    expect(result.offset).toBe(20)
+    expect(result.total).toBe(50)
+    expect(result.pages).toBe(5)
+  })
+
+  it('retourne previous null sur la première page', () => {
+    const url = new URL('http://localhost/?page=1')
+    const result = paginationFromUrl(url, 50)
+
+    expect(result.previous).toBeNull()
+  })
+
+  it('retourne previous quand page > 1', () => {
+    const url = new URL('http://localhost/?page=3')
+    const result = paginationFromUrl(url, 100)
+
+    expect(result.previous).toBe(2)
+  })
+
+  it('retourne next null sur la dernière page', () => {
+    const url = new URL('http://localhost/?page=4&pageSize=25')
+    const result = paginationFromUrl(url, 100)
+
+    expect(result.next).toBeNull()
+  })
+
+  it('retourne next quand il y a des pages suivantes', () => {
+    const url = new URL('http://localhost/?page=1&pageSize=25')
+    const result = paginationFromUrl(url, 100)
+
+    expect(result.next).toBe(2)
+  })
+
+  it('gère count=0 correctement', () => {
+    const url = new URL('http://localhost/')
+    const result = paginationFromUrl(url, 0)
+
+    expect(result.total).toBe(0)
+    expect(result.pages).toBe(0)
+    expect(result.previous).toBeNull()
+    expect(result.next).toBeNull()
+  })
+
+  it('gère la division exacte des pages', () => {
+    const url = new URL('http://localhost/?pageSize=10')
+    const result = paginationFromUrl(url, 30)
+
+    expect(result.pages).toBe(3)
+  })
+
+  it('arrondit au supérieur pour les pages partielles', () => {
+    const url = new URL('http://localhost/?pageSize=10')
+    const result = paginationFromUrl(url, 31)
+
+    expect(result.pages).toBe(4)
+  })
+
+  it('calcule l\'offset correctement', () => {
+    const url = new URL('http://localhost/?page=5&pageSize=20')
+    const result = paginationFromUrl(url, 200)
+
+    expect(result.offset).toBe(80)
+  })
+})

--- a/app/shared/libs/params.server.test.ts
+++ b/app/shared/libs/params.server.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { requireParamId } from './params.server'
+
+describe('requireParamId', () => {
+  it('retourne le nombre pour un string numérique valide', () => {
+    expect(requireParamId('42')).toBe(42)
+  })
+
+  it('retourne 0 pour "0"', () => {
+    expect(requireParamId('0')).toBe(0)
+  })
+
+  it('lance une redirection pour undefined', () => {
+    try {
+      requireParamId(undefined)
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/')
+    }
+  })
+
+  it('lance une redirection pour un string non-numérique', () => {
+    try {
+      requireParamId('abc')
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/')
+    }
+  })
+
+  it('utilise le redirectTo personnalisé', () => {
+    try {
+      requireParamId('abc', '/territoires')
+      expect.unreachable('devrait lancer une redirection')
+    } catch (thrown) {
+      const response = thrown as Response
+      expect(response.status).toBe(302)
+      expect(response.headers.get('Location')).toBe('/territoires')
+    }
+  })
+
+  it('gère les nombres négatifs', () => {
+    expect(requireParamId('-1')).toBe(-1)
+  })
+
+  it('gère les nombres décimaux (Number les accepte)', () => {
+    expect(requireParamId('3.14')).toBe(3.14)
+  })
+})

--- a/app/shared/libs/point-in-polygon.server.test.ts
+++ b/app/shared/libs/point-in-polygon.server.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { pointInPolygon } from './point-in-polygon.server'
+
+describe('pointInPolygon', () => {
+  const square: [number, number][] = [
+    [0, 0],
+    [0, 10],
+    [10, 10],
+    [10, 0],
+  ]
+
+  it('retourne true pour un point à l\'intérieur d\'un carré', () => {
+    expect(pointInPolygon([5, 5], square)).toBe(true)
+  })
+
+  it('retourne false pour un point à l\'extérieur d\'un carré', () => {
+    expect(pointInPolygon([15, 5], square)).toBe(false)
+  })
+
+  it('retourne false pour un point complètement éloigné', () => {
+    expect(pointInPolygon([100, 100], square)).toBe(false)
+  })
+
+  it('fonctionne avec un triangle', () => {
+    const triangle: [number, number][] = [
+      [0, 0],
+      [5, 10],
+      [10, 0],
+    ]
+
+    expect(pointInPolygon([5, 5], triangle)).toBe(true)
+    expect(pointInPolygon([1, 9], triangle)).toBe(false)
+  })
+
+  it('fonctionne avec un polygone concave (forme en L)', () => {
+    const lShape: [number, number][] = [
+      [0, 0],
+      [0, 10],
+      [5, 10],
+      [5, 5],
+      [10, 5],
+      [10, 0],
+    ]
+
+    // Point dans la partie inférieure du L
+    expect(pointInPolygon([7, 2], lShape)).toBe(true)
+    // Point dans la partie supérieure du L
+    expect(pointInPolygon([2, 7], lShape)).toBe(true)
+    // Point dans le creux du L (extérieur)
+    expect(pointInPolygon([7, 7], lShape)).toBe(false)
+  })
+
+  it('retourne false pour un polygone vide', () => {
+    expect(pointInPolygon([5, 5], [])).toBe(false)
+  })
+
+  it('retourne false pour un point avec coordonnées négatives hors polygone', () => {
+    expect(pointInPolygon([-5, -5], square)).toBe(false)
+  })
+})

--- a/docs/architecture-schema.md
+++ b/docs/architecture-schema.md
@@ -17,10 +17,10 @@
                     │             │              │
          ┌─────────┴─────────────┴──────────────┘
          │
-    ┌────▼────┐    ┌───────┐    ┌──────────┐    ┌─────┐
-    │PostgreSQL│    │ Redis │    │  Worker   │    │ S3  │
-    │  (PVC)  │    │ (PVC) │    │ (BullMQ) │    │     │
-    └─────────┘    └───────┘    └──────────┘    └─────┘
+    ┌────▼────┐    ┌───────┐    ┌──────────┐    ┌──────────────┐
+    │PostgreSQL│    │ Redis │    │  Worker   │    │ File Storage │
+    │  (PVC)  │    │ (PVC) │    │ (BullMQ) │    │ (S3 or local)│
+    └─────────┘    └───────┘    └──────────┘    └──────────────┘
 ```
 
 ## Multi-Tenancy Model
@@ -52,11 +52,13 @@
 ## Request Flow
 
 1. **Traefik** routes incoming requests to web pods
-2. **React Router** matches route, runs loader
+2. **React Router** matches route, runs loader/action
 3. **`verifySession()`** authenticates user, resolves congregation, sets `AsyncLocalStorage` context
 4. **Prisma extension** auto-injects `congregationId` into all scoped queries
 5. **Service layer** (`features/*/server/`) handles business logic
 6. **Route component** renders with loader data
+
+> **Important**: Route actions must call `verifySession(request)` and use the returned `congregation` object directly (e.g., `congregation.id`) instead of reading from `congregationContext.getStore()`. The Prisma 7 pg adapter breaks AsyncLocalStorage propagation across async boundaries — context set by `enterWith()` can be lost after awaited Prisma queries.
 
 ## Authentication & Role Flow
 
@@ -87,15 +89,28 @@ Registration → /register (open, no auth)
 - **Scoped models** (12): User, Territory, Building, BuildingEntrance, Attribution, PublisherGroup, PublisherActivity, BoardSection, BoardDocument, Event, EventKind, Setting
 - **Global models**: UserRole, Congregation, CongregationUserRole, PasswordResetToken
 
+> **Important**: Never use `congregationId: 0 as number` as a placeholder. Always pass the real `congregation.id` from `verifySession()`. The `0` placeholder relied on the Prisma extension to replace it at runtime, but context loss causes FK violations.
+
 ## File Storage
 
+Two storage drivers, selected automatically based on `S3_ENDPOINT`:
+
+| Condition | Driver | Storage location |
+|-----------|--------|------------------|
+| `S3_ENDPOINT` is set | S3 | S3-compatible bucket |
+| `S3_ENDPOINT` is absent | Local filesystem | `content/uploads/` (configurable via `LOCAL_STORAGE_PATH`) |
+
+Key structure (same for both drivers):
+
 ```
-S3 Bucket: unitae/
+{root}/
 ├── {congregationId}/
 │   └── board/
 │       ├── {uuid}.pdf
-│       └── {uuid}.pdf
+│       └── {uuid}.pdf.meta    ← content-type sidecar (local driver only)
 ```
+
+Self-hosted users need no S3 setup — document uploads work out of the box with local storage.
 
 ## Background Job Flow
 
@@ -103,11 +118,27 @@ S3 Bucket: unitae/
 User triggers sync → syncQueue.add({ userEmail, userName, congregationId })
                    → Redis queue
 
-Worker picks up job → congregationContext.enterWith({ congregationId })
-                   → importOpenData() (scoped queries via extension)
+Worker picks up job → resolveCongregation(congregationId)
+                   → congregationContext.enterWith({ congregationId, congregation })
+                   → importOpenData(congregationId, progressCallback)
                    → sendMailAfterDataSync(email, name, congregation)
                    → job complete
 ```
+
+## Testing
+
+Unit tests use **Vitest** with co-located test files (`*.server.test.ts` next to source):
+
+```bash
+pnpm test:unit              # Run tests once
+pnpm test:unit:watch        # Watch mode
+pnpm test:unit:coverage     # With coverage report
+```
+
+Testing conventions:
+- **Black-box testing**: assert on return values and thrown errors, not on mock call counts
+- **Mocking**: `vi.mock()` for `db.server`, `redis.server`, `crypto.server`
+- **Sentinel pattern**: for negative tests expecting `undefined`, use a sentinel initial value to prove the code path ran
 
 ## Security
 
@@ -116,4 +147,4 @@ Worker picks up job → congregationContext.enterWith({ congregationId })
 - **Roles**: Congregation-scoped via CongregationUserRole — admin in A ≠ admin in B
 - **Platform admin**: Separate `platformAdmin` boolean on User
 - **K8s**: PSS restricted, seccomp, NetworkPolicies, non-root pods
-- **Files**: S3 with congregation-scoped keys, UUID validation
+- **Files**: Congregation-scoped storage keys, UUID filenames

--- a/docs/background-processing-architecture.md
+++ b/docs/background-processing-architecture.md
@@ -69,11 +69,13 @@ export async function handleSyncWork(job: Job<SyncJobData>) {
   const congregation = await resolveCongregation(congregationId)
   congregationContext.enterWith({ congregationId, congregation })
 
-  // All db.* queries are now scoped to this congregation
-  await importOpenData(...)
+  // Pass congregationId explicitly to avoid AsyncLocalStorage context loss
+  await importOpenData(congregationId, progressCallback)
   await sendMailAfterDataSync(email, name, congregation)
 }
 ```
+
+> **Note**: Service functions that create records should accept `congregationId` as an explicit parameter rather than relying on AsyncLocalStorage context, which can be lost across async boundaries with the Prisma 7 pg adapter.
 
 ## Development
 
@@ -101,6 +103,7 @@ pnpm start:dev
 1. **Queue**: `app/features/{feature}/server/{name}-queue.server.ts`
 2. **Handler**: `app/features/{feature}/server/handle-{name}-work.server.ts`
    - Set `congregationContext.enterWith()` from job data
+   - Pass `congregationId` explicitly to service functions that create records
 3. **Worker**: `workers/{name}-worker.server.ts`
    - Include HTTP health server
    - Handle SIGTERM gracefully

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         "start:emails": "email dev",
         "start:worker": "pnpm tsx ./workers/sync-worker.server.ts",
         "test:lint": "biome lint",
-        "test:typecheck": "react-router typegen && tsc"
+        "test:typecheck": "react-router typegen && tsc",
+        "test:unit": "vitest run",
+        "test:unit:watch": "vitest",
+        "test:unit:coverage": "vitest run --coverage"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
@@ -55,13 +58,15 @@
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@vitest/coverage-v8": "^4.1.3",
         "prisma": "^7.6.0",
         "react-email": "5.2.10",
         "shadcn": "^4.2.0",
         "tailwindcss": "^4.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2",
-        "vite": "^8.0.3"
+        "vite": "^8.0.3",
+        "vitest": "^4.1.3"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.3
+        version: 4.1.3(vitest@4.1.3)
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
@@ -141,6 +144,9 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0)
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@types/node@24.1.0)(@vitest/coverage-v8@4.1.3)(msw@2.13.1(@types/node@24.1.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0))
 
 packages:
 
@@ -381,6 +387,10 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -396,6 +406,11 @@ packages:
 
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -448,6 +463,14 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.10':
     resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
@@ -2375,6 +2398,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -2489,6 +2515,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
@@ -2518,6 +2547,9 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2559,6 +2591,44 @@ packages:
     peerDependencies:
       react: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
       react-dom: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
+
+  '@vitest/coverage-v8@4.1.3':
+    resolution: {integrity: sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==}
+    peerDependencies:
+      '@vitest/browser': 4.1.3
+      vitest: 4.1.3
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
+
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
+
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
   abs-svg-path@0.1.1:
     resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
@@ -2635,9 +2705,16 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2804,6 +2881,10 @@ packages:
 
   caniuse-lite@1.0.30001786:
     resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chainsaw@0.1.0:
     resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
@@ -3304,6 +3385,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3327,6 +3411,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -3366,6 +3453,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -3599,6 +3690,10 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3619,6 +3714,9 @@ packages:
 
   hsl-to-rgb-for-reals@1.1.1:
     resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -3802,6 +3900,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
@@ -3815,6 +3925,9 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4035,6 +4148,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -4273,6 +4393,9 @@ packages:
   object-treeify@1.1.33:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -4877,6 +5000,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4935,6 +5061,9 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -4951,6 +5080,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -5013,6 +5145,10 @@ packages:
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   svg-arc-to-cubic-bezier@3.2.0:
     resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
 
@@ -5049,8 +5185,15 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -5059,6 +5202,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
@@ -5348,6 +5495,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -5363,6 +5551,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   winston-transport@4.9.0:
@@ -6024,6 +6217,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.28.2':
@@ -6038,6 +6233,10 @@ snapshots:
   '@babel/parser@7.28.0':
     dependencies:
       '@babel/types': 7.28.2
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.0)':
     dependencies:
@@ -6115,6 +6314,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.10':
     optionalDependencies:
@@ -8157,6 +8363,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.21':
@@ -8250,6 +8458,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 24.1.0
@@ -8277,6 +8490,8 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -8317,6 +8532,62 @@ snapshots:
       fast-deep-equal: 3.1.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@vitest/coverage-v8@4.1.3(vitest@4.1.3)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.3
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.3(@types/node@24.1.0)(@vitest/coverage-v8@4.1.3)(msw@2.13.1(@types/node@24.1.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0))
+
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.3(msw@2.13.1(@types/node@24.1.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.1(@types/node@24.1.0)(typescript@6.0.2)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0)
+
+  '@vitest/pretty-format@4.1.3':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.3': {}
+
+  '@vitest/utils@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   abs-svg-path@0.1.1: {}
 
@@ -8405,9 +8676,17 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async@3.2.6: {}
 
@@ -8613,6 +8892,8 @@ snapshots:
   caniuse-lite@1.0.30001731: {}
 
   caniuse-lite@1.0.30001786: {}
+
+  chai@6.2.2: {}
 
   chainsaw@0.1.0:
     dependencies:
@@ -9031,6 +9312,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9071,6 +9354,10 @@ snapshots:
   escape-html@1.0.3: {}
 
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -9127,6 +9414,8 @@ snapshots:
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
@@ -9433,6 +9722,8 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -9448,6 +9739,8 @@ snapshots:
       hsl-to-rgb-for-reals: 1.1.1
 
   hsl-to-rgb-for-reals@1.1.1: {}
+
+  html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
     dependencies:
@@ -9604,6 +9897,19 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jay-peg@1.1.1:
     dependencies:
       restructure: 3.0.2
@@ -9613,6 +9919,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -9789,6 +10097,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -10016,6 +10334,8 @@ snapshots:
   object-inspect@1.13.4: {}
 
   object-treeify@1.1.33: {}
+
+  obug@2.1.1: {}
 
   ohash@2.0.11: {}
 
@@ -10795,6 +11115,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -10865,6 +11187,8 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   standardwebhooks@1.0.0:
@@ -10877,6 +11201,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.0.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -10935,6 +11261,10 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svg-arc-to-cubic-bezier@3.2.0: {}
 
   svix@1.88.0:
@@ -10972,7 +11302,11 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.14:
     dependencies:
@@ -10983,6 +11317,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.28: {}
 
@@ -11234,6 +11570,34 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vitest@4.1.3(@types/node@24.1.0)(@vitest/coverage-v8@4.1.3)(msw@2.13.1(@types/node@24.1.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(msw@2.13.1(@types/node@24.1.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.1.0)(esbuild@0.25.8)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.1.0
+      '@vitest/coverage-v8': 4.1.3(vitest@4.1.3)
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
 
   when-exit@2.1.5: {}
@@ -11245,6 +11609,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   winston-transport@4.9.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': resolve(import.meta.dirname, './app'),
+      emails: resolve(import.meta.dirname, './emails'),
+    },
+  },
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['app/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['app/**/*.server.ts'],
+      exclude: ['app/database/**', 'app/**/routes/**'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- **Unit test suite**: Added Vitest with 244 tests across 46 files (~56% coverage), integrated into CI workflow
- **AsyncLocalStorage fix**: Route actions now call `verifySession()` and use the returned `congregation` object directly instead of relying on `congregationContext.getStore()` which breaks with Prisma 7 pg adapter
- **congregationId placeholder removal**: Replaced all `congregationId: 0 as number` placeholders with explicit `congregation.id` to prevent FK violations
- **Local file storage**: Added filesystem driver as alternative to S3 — auto-selected when `S3_ENDPOINT` is absent, files stored in `content/uploads/`
- **Bug fixes**: Document highlight toggle, missing await on createDayOff, prospection validity with unconfigured setting, territory polygon default, territory coverage date filtering
- **Features**: Optional deputy for publisher groups (schema migration), congregation display name editing, dynamic branding on auth pages
- **UI**: Replaced "congrégation" with "assemblée locale" in all user-facing text, added stat tooltips on territory stats page
- **Docs**: Updated README, CONTRIBUTING, architecture docs, and background processing docs
- **CI**: Run CI only on pull requests

## Test plan

- [x] Run `pnpm test:unit` — 244 tests pass
- [x] Run `pnpm test:lint` — no errors
- [x] Test user edit at `/settings/users/:id/edit` — saves correctly, redirects to user list
- [x] Test board section creation at `/board/sections/new` — no FK error
- [x] Test document highlight/unhighlight toggle
- [x] Test publisher group creation without deputy
- [x] Test days off creation — appears immediately in list
- [x] Test territory stats page — tooltips visible, coverage percentages correct
- [x] Test document upload without S3 configured — uses local storage
- [x] Test congregation display name change in `/settings/congregation`
- [x] Test login page shows congregation name in single-tenant mode