### PR TITLE
feat: block access on expired trials and improve suspension page

### DIFF
--- a/app/features/authentication/server/session.server.ts
+++ b/app/features/authentication/server/session.server.ts
@@ -66,7 +66,16 @@ export async function verifySession(request: Request) {
   const congregation = await resolveCongregation(user.congregationId)
 
   if (congregation.suspendedAt) {
-    throw redirect('/suspended')
+    const params = new URLSearchParams()
+    if (congregation.suspendedReason) {
+      params.set('reason', congregation.suspendedReason)
+    }
+    const query = params.toString()
+    throw redirect(`/suspended${query ? `?${query}` : ''}`)
+  }
+
+  if (congregation.trialEndsAt && congregation.trialEndsAt < new Date()) {
+    throw redirect('/trial-expired')
   }
 
   congregationContext.enterWith({ congregationId: user.congregationId, congregation })

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   index('routes/_index.tsx'),
   route('health', 'routes/health.tsx'),
   route('suspended', 'routes/suspended.tsx'),
+  route('trial-expired', 'routes/trial-expired.tsx'),
   ...authenticationRoutes,
   route('', 'routes/_authenticated-layout.tsx', [
     route('me', 'features/authentication/routes/user/_layout.tsx', [

--- a/app/routes/suspended.tsx
+++ b/app/routes/suspended.tsx
@@ -8,29 +8,33 @@ export const meta: Route.MetaFunction = () => {
   return [{ title: 'Compte suspendu - Unitae' }]
 }
 
-export function loader() {
+export function loader({ request }: Route.LoaderArgs) {
   const hostSettings = getHostSettings()
+  const url = new URL(request.url)
+  const isMultiTenant = process.env.MULTI_TENANT === 'true'
 
   return {
-    billingUrl: hostSettings.billing?.portalUrl ?? null,
+    reason: url.searchParams.get('reason'),
+    supportUrl: isMultiTenant ? (hostSettings.support?.url ?? null) : null,
   }
 }
 
 export default function SuspendedPage({ loaderData }: Route.ComponentProps) {
-  const { billingUrl } = loaderData
+  const { reason, supportUrl } = loaderData
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="mx-auto max-w-md text-center">
         <h1 className="mb-4 font-bold text-2xl text-gray-900">Compte suspendu</h1>
         <p className="mb-6 text-gray-600">
-          L'accès à votre assemblée locale a été temporairement suspendu. Si vous pensez qu'il s'agit d'une erreur,
-          veuillez contacter l'administrateur.
+          {reason
+            ? reason
+            : "L'accès à votre assemblée locale a été temporairement suspendu. Si vous pensez qu'il s'agit d'une erreur, veuillez contacter l'administrateur."}
         </p>
         <div className="flex flex-col gap-3">
-          {billingUrl && (
-            <a href={billingUrl} className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
-              Gérer mon abonnement
+          {supportUrl && (
+            <a href={supportUrl} className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+              Contacter le support
             </a>
           )}
           <Link to="/logout" className="text-gray-500 text-sm hover:text-gray-700">

--- a/app/routes/trial-expired.tsx
+++ b/app/routes/trial-expired.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router'
+
+import { getHostSettings } from '~/shared/libs/host-settings.server'
+
+import type { Route } from './+types/trial-expired'
+
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "Période d'essai terminée - Unitae" }]
+}
+
+export function loader() {
+  const hostSettings = getHostSettings()
+  const isMultiTenant = process.env.MULTI_TENANT === 'true'
+
+  return {
+    upgradeUrl: isMultiTenant ? (hostSettings.billing?.upgradeUrl ?? null) : null,
+  }
+}
+
+export default function TrialExpiredPage({ loaderData }: Route.ComponentProps) {
+  const { upgradeUrl } = loaderData
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="mx-auto max-w-md text-center">
+        <h1 className="mb-4 font-bold text-2xl text-gray-900">Période d'essai terminée</h1>
+        <p className="mb-6 text-gray-600">
+          Votre période d'essai est arrivée à son terme. Pour continuer à utiliser Unitae, veuillez mettre à niveau
+          votre abonnement.
+        </p>
+        <div className="flex flex-col gap-3">
+          {upgradeUrl && (
+            <a href={upgradeUrl} className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+              Mettre à niveau mon abonnement
+            </a>
+          )}
+          <Link to="/logout" className="text-gray-500 text-sm hover:text-gray-700">
+            Se déconnecter
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -18,6 +18,7 @@ export type CongregationInfo = {
   maxBoardDocuments: number | null
   suspendedAt: Date | null
   suspendedReason: string | null
+  trialEndsAt: Date | null
 }
 
 export function getCongregationFromContext(): CongregationInfo | null {
@@ -61,6 +62,7 @@ export async function resolveCongregation(congregationId: number): Promise<Congr
     maxBoardDocuments: congregation.maxBoardDocuments,
     suspendedAt: congregation.suspendedAt,
     suspendedReason: congregation.suspendedReason,
+    trialEndsAt: congregation.trialEndsAt,
   }
 }
 


### PR DESCRIPTION
## Summary

- Add trial expiration check in `verifySession()` middleware — redirects to `/trial-expired` when `trialEndsAt` is in the past
- Create dedicated `/trial-expired` page with upgrade CTA (shown only in MULTI_TENANT mode via `HOST_SETTINGS`)
- Update `/suspended` page to show `suspendedReason` and link to support instead of billing portal
- Add `trialEndsAt` to `CongregationInfo` type and resolver

## Test plan

- [x] Set `trialEndsAt` to a past date → verify redirect to `/trial-expired`
- [x] Set `trialEndsAt` to a future date → verify normal access
- [x] Set `trialEndsAt` to null → verify normal access (no trial)
- [x] Set `suspendedAt` + expired `trialEndsAt` → verify `/suspended` takes priority
- [x] Set `suspendedReason` on a suspended congregation → verify reason is displayed
- [x] Verify upgrade link appears only when `MULTI_TENANT=true` and `HOST_SETTINGS` has `billing.upgradeUrl`
- [x] Verify support link appears only when `MULTI_TENANT=true` and `HOST_SETTINGS` has `support.url`
- [x] `pnpm test:typecheck` passes
- [x] `pnpm test:lint` passes
- [x] `pnpm test:unit` passes (244 tests)