### PR TITLE
fix: correct bugs in export services (Excel, PDF, S-13)

### DIFF
--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
@@ -1,0 +1,112 @@
+import excelJs from 'exceljs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PublisherType } from '~/shared/types/publisher-type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    publisherActivity: { findMany: vi.fn() },
+  },
+}))
+
+const { generatePublishersYearlyActivityXlsx } = await import('./generate-publishers-yearly-activity-xlsx.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.publisherActivity.findMany).mockResolvedValue([] as never)
+})
+
+function makeActivity(
+  type: PublisherType,
+  { hours = 0, studies = 0, isPublisher = true, notes = '' } = {},
+) {
+  return {
+    type,
+    hours,
+    studies,
+    isPublisher,
+    notes,
+    publisher: {
+      id: 1,
+      firstname: 'Jean',
+      lastname: 'Dupont',
+      publisherGroup: { id: 1, name: 'Groupe A' },
+    },
+  }
+}
+
+async function readWorkbook(buffer: excelJs.Buffer) {
+  const workbook = new excelJs.Workbook()
+  await workbook.xlsx.load(buffer)
+  return workbook
+}
+
+describe('generatePublishersYearlyActivityXlsx', () => {
+  it('génère 12 feuilles pour une année théocratique', async () => {
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+
+    expect(workbook.worksheets).toHaveLength(12)
+  })
+
+  it('affiche "A préché" pour un proclamateur normal', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+      makeActivity(PublisherType.Normal, { isPublisher: true, hours: 0, studies: 1 }),
+    ] as never)
+
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+    const firstSheet = workbook.worksheets[0]
+    const dataRow = firstSheet.getRow(2)
+
+    expect(dataRow.getCell(3).value).toBe('A préché')
+  })
+
+  it('affiche les heures pour un pionnier permanent', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+      makeActivity(PublisherType.PionnierPermanant, { hours: 50 }),
+    ] as never)
+
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+    const dataRow = workbook.worksheets[0].getRow(2)
+
+    expect(dataRow.getCell(3).value).toBe('50')
+  })
+
+  it('affiche les heures pour un pionnier auxiliaire', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+      makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 }),
+    ] as never)
+
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+    const dataRow = workbook.worksheets[0].getRow(2)
+
+    expect(dataRow.getCell(3).value).toBe('30')
+  })
+
+  it('affiche les heures pour un pionnier spécial', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+      makeActivity(PublisherType.PionnierSpecial, { hours: 130 }),
+    ] as never)
+
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+    const dataRow = workbook.worksheets[0].getRow(2)
+
+    expect(dataRow.getCell(3).value).toBe('130')
+  })
+
+  it('affiche les heures pour un missionnaire', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+      makeActivity(PublisherType.Missionnaire, { hours: 120 }),
+    ] as never)
+
+    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const workbook = await readWorkbook(buffer)
+    const dataRow = workbook.worksheets[0].getRow(2)
+
+    expect(dataRow.getCell(3).value).toBe('120')
+  })
+})

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
@@ -1,7 +1,7 @@
 import excelJs from 'exceljs'
 
 import { db } from '~/shared/libs/db.server'
-import { PublisherType } from '~/shared/types/publisher-type'
+import { PublisherType, publisherTypeReportsHours } from '~/shared/types/publisher-type'
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
 export async function generatePublishersYearlyActivityXlsx(year: number) {
@@ -76,7 +76,7 @@ export async function generatePublishersYearlyActivityXlsx(year: number) {
 
       let hours = ''
       if (activity.isPublisher) hours = 'A préché'
-      if (activity.type === PublisherType.PionnierPermanant) hours = String(activity.hours)
+      if (publisherTypeReportsHours(activity.type)) hours = String(activity.hours)
 
       worksheet.addRow([
         `${activity.publisher.firstname} ${activity.publisher.lastname}`,

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    user: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('@react-pdf/renderer', () => ({
+  pdf: vi.fn(() => ({ toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-pdf')) })),
+  // biome-ignore lint/style/useNamingConvention: React component
+  Document: vi.fn(({ children }: { children: unknown }) => children),
+  // biome-ignore lint/style/useNamingConvention: React component
+  Page: vi.fn(({ children }: { children: unknown }) => children),
+  // biome-ignore lint/style/useNamingConvention: React component
+  View: vi.fn(({ children }: { children: unknown }) => children),
+  // biome-ignore lint/style/useNamingConvention: React component
+  Text: vi.fn(({ children }: { children: unknown }) => children),
+  // biome-ignore lint/style/useNamingConvention: React component
+  StyleSheet: { create: vi.fn((s: unknown) => s) },
+  // biome-ignore lint/style/useNamingConvention: React component
+  Font: { register: vi.fn() },
+}))
+
+vi.mock('~/features/authentication/server/sanitize-user.server', () => ({
+  sanitizeUser: vi.fn((u: unknown) => u),
+}))
+
+vi.mock('~/features/publishers/ui/PublisherActivityDocument', () => ({
+  // biome-ignore lint/style/useNamingConvention: React component
+  PublisherActivityDocument: vi.fn(() => null),
+}))
+
+const { renderActivityPdfZip } = await import('./render-activity-pdf-zip.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(db.user.findMany).mockResolvedValue([] as never)
+})
+
+describe('renderActivityPdfZip', () => {
+  it('filtre les activités de septembre à août (mois 8-11 puis 0-7)', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
+
+    await renderActivityPdfZip(2025)
+
+    const call = vi.mocked(db.user.findMany).mock.calls[0][0] as {
+      where: { activities: { some: { OR: Array<{ year: number; month: { gte?: number; lte?: number } }> } } }
+      include: { activities: { where: { OR: Array<{ year: number; month: { gte?: number; lte?: number } }> } } }
+    }
+
+    // Vérifier le filtre WHERE (sélection des users)
+    const whereOr = call.where.activities.some.OR
+    expect(whereOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
+    expect(whereOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
+
+    // Vérifier le filtre INCLUDE (sélection des activités)
+    const includeOr = call.include.activities.where.OR
+    expect(includeOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
+    expect(includeOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
+  })
+})

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -45,18 +45,17 @@ describe('renderActivityPdfZip', () => {
 
     await renderActivityPdfZip(2025)
 
-    const call = vi.mocked(db.user.findMany).mock.calls[0][0] as {
-      where: { activities: { some: { OR: Array<{ year: number; month: { gte?: number; lte?: number } }> } } }
-      include: { activities: { where: { OR: Array<{ year: number; month: { gte?: number; lte?: number } }> } } }
-    }
+    const call = vi.mocked(db.user.findMany).mock.calls[0][0] as Record<string, unknown>
+    const where = (call.where as { activities: { some: Record<string, unknown> } }).activities.some
+    const include = (call.include as { activities: { where: Record<string, unknown> } }).activities.where
 
     // Vérifier le filtre WHERE (sélection des users)
-    const whereOr = call.where.activities.some.OR
+    const whereOr = where.OR as { year: number; month: { gte?: number; lte?: number } }[]
     expect(whereOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
     expect(whereOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
 
     // Vérifier le filtre INCLUDE (sélection des activités)
-    const includeOr = call.include.activities.where.OR
+    const includeOr = include.OR as { year: number; month: { gte?: number; lte?: number } }[]
     expect(includeOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
     expect(includeOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
   })

--- a/app/features/publishers/server/render-activity-pdf-zip.server.tsx
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.tsx
@@ -21,7 +21,7 @@ export async function renderActivityPdfZip(year: number) {
             {
               year: yearBegining.getFullYear() + 1,
               month: {
-                lte: 11,
+                lte: 7,
               },
             },
           ],
@@ -48,7 +48,7 @@ export async function renderActivityPdfZip(year: number) {
             {
               year: yearBegining.getFullYear() + 1,
               month: {
-                lte: 11,
+                lte: 7,
               },
             },
           ],

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -43,4 +43,20 @@ describe('getTerritoriesExportData', () => {
     expect(vi.mocked(getBeginingDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
     expect(vi.mocked(getEndDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
   })
+
+  it('inclut les attributions anciennes encore actives (sans date de fin)', async () => {
+    await getTerritoriesExportData(2025)
+
+    const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as {
+      include: { attributions: { where: { OR: Array<Record<string, unknown>> } } }
+    }
+    const orConditions = call.include.attributions.where.OR
+
+    // La 4e condition attrape les attributions démarrées avant l'année précédente et toujours ouvertes
+    expect(orConditions).toHaveLength(4)
+    expect(orConditions[3]).toEqual({
+      startDate: { lt: new Date(2024, 8, 1) },
+      endDate: null,
+    })
+  })
 })

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -31,12 +31,12 @@ describe('getTerritoriesExportData', () => {
     expect(result).toEqual(fakeTerritories)
   })
 
-  it('retourne un tableau vide quand il n\'y a pas de territoires', async () => {
+  it("retourne un tableau vide quand il n'y a pas de territoires", async () => {
     const result = await getTerritoriesExportData(2025)
     expect(result).toEqual([])
   })
 
-  it('passe l\'année théocratique aux fonctions de date', async () => {
+  it("passe l'année théocratique aux fonctions de date", async () => {
     await getTerritoriesExportData(2024)
 
     // Vérifier que les fonctions de date ont été utilisées (via le résultat)
@@ -47,10 +47,9 @@ describe('getTerritoriesExportData', () => {
   it('inclut les attributions anciennes encore actives (sans date de fin)', async () => {
     await getTerritoriesExportData(2025)
 
-    const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as {
-      include: { attributions: { where: { OR: Array<Record<string, unknown>> } } }
-    }
-    const orConditions = call.include.attributions.where.OR
+    const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as Record<string, unknown>
+    const attrWhere = (call.include as { attributions: { where: Record<string, unknown> } }).attributions.where
+    const orConditions = attrWhere.OR as Record<string, unknown>[]
 
     // La 4e condition attrape les attributions démarrées avant l'année précédente et toujours ouvertes
     expect(orConditions).toHaveLength(4)

--- a/app/features/territories/server/territories-export-data.server.ts
+++ b/app/features/territories/server/territories-export-data.server.ts
@@ -41,6 +41,12 @@ export async function getTerritoriesExportData(theocraticYear?: number) {
               },
               endDate: null,
             },
+            {
+              startDate: {
+                lt: startDatePreviousYear,
+              },
+              endDate: null,
+            },
           ],
         },
         include: {

--- a/app/shared/libs/file-storage.server.ts
+++ b/app/shared/libs/file-storage.server.ts
@@ -29,8 +29,18 @@ const BUCKET = process.env.S3_BUCKET ?? 'unitae'
 async function s3Upload(key: string, body: ArrayBuffer | Buffer | Uint8Array, contentType: string): Promise<void> {
   const { PutObjectCommand } = await import('@aws-sdk/client-s3')
   const s3 = await getS3Client()
-  // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
-  await s3.send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: body instanceof ArrayBuffer ? new Uint8Array(body) : body, ContentType: contentType }))
+  await s3.send(
+    new PutObjectCommand({
+      // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+      Bucket: BUCKET,
+      // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+      Key: key,
+      // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+      Body: body instanceof ArrayBuffer ? new Uint8Array(body) : body,
+      // biome-ignore lint/style/useNamingConvention: AWS SDK uses PascalCase properties
+      ContentType: contentType,
+    }),
+  )
 }
 
 async function s3GetFile(key: string): Promise<{ body: ReadableStream; contentType: string } | null> {
@@ -138,11 +148,7 @@ async function localDelete(key: string): Promise<void> {
 
 // --- Public API (delegates to active driver) ---
 
-export function uploadFile(
-  key: string,
-  body: ArrayBuffer | Buffer | Uint8Array,
-  contentType: string,
-): Promise<void> {
+export function uploadFile(key: string, body: ArrayBuffer | Buffer | Uint8Array, contentType: string): Promise<void> {
   return useS3 ? s3Upload(key, body, contentType) : localUpload(key, body, contentType)
 }
 

--- a/app/shared/types/publisher-type.test.ts
+++ b/app/shared/types/publisher-type.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { PublisherType, publisherTypeReportsHours } from './publisher-type'
+
+describe('publisherTypeReportsHours', () => {
+  it('retourne false pour un proclamateur normal', () => {
+    expect(publisherTypeReportsHours(PublisherType.Normal)).toBe(false)
+  })
+
+  it('retourne true pour un pionnier auxiliaire', () => {
+    expect(publisherTypeReportsHours(PublisherType.PionnierAuxiliaires)).toBe(true)
+  })
+
+  it('retourne true pour un pionnier permanent', () => {
+    expect(publisherTypeReportsHours(PublisherType.PionnierPermanant)).toBe(true)
+  })
+
+  it('retourne true pour un pionnier spécial', () => {
+    expect(publisherTypeReportsHours(PublisherType.PionnierSpecial)).toBe(true)
+  })
+
+  it('retourne true pour un missionnaire', () => {
+    expect(publisherTypeReportsHours(PublisherType.Missionnaire)).toBe(true)
+  })
+})

--- a/app/shared/types/publisher-type.ts
+++ b/app/shared/types/publisher-type.ts
@@ -5,3 +5,7 @@ export enum PublisherType {
   PionnierSpecial = 'pionnier-special',
   Missionnaire = 'missionnaire',
 }
+
+export function publisherTypeReportsHours(type: string): boolean {
+  return type !== PublisherType.Normal
+}

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'prisma/config'
 
 export default defineConfig({
   datasource: {
+    // biome-ignore lint/style/noNonNullAssertion: required by Prisma config, validated at app startup
     url: process.env.DATABASE_URL!,
   },
   migrations: {


### PR DESCRIPTION
## Summary

- **Activity Excel export**: Show actual hours for all pioneer types (auxiliary, special, missionaries), not just permanent pioneers. Extracted logic into a reusable `publisherTypeReportsHours()` helper.
- **Activity PDF ZIP export**: Fixed month range filter (`lte: 11` → `lte: 7`) that was pulling in activities from the next theocratic year (Sep–Dec of year+1).
- **S-13 territory export**: Added a query condition to include attributions started more than one theocratic year ago that are still open (no end date).

## Test plan

- [x] Unit tests added for `publisherTypeReportsHours()` helper
- [x] Unit tests added for Excel export (verifies hours column per publisher type)
- [x] Unit tests added for PDF ZIP export (verifies correct month range in query)
- [x] Unit test added for S-13 export (verifies 4th OR condition for old attributions)
- [x] All 257 tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes