### PR TITLE
feat: expand territory statistics page

### DIFF
--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -6,16 +6,37 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getGroups } from '~/features/publishers/server/groups'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
-import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { countActiveWorkingTerritories } from '~/features/territories/server/active-working-territories.server'
 import { countAvailableTerritories } from '~/features/territories/server/available-territories.server'
+import { computeAttributionsPerMonth } from '~/features/territories/server/compute-attributions-per-month.server'
+import { computeAvailabilityGap } from '~/features/territories/server/compute-availability-gap.server'
+import { computeCoverageByTerritoryType } from '~/features/territories/server/compute-coverage-by-territory-type.server'
+import { computeDurationStats } from '~/features/territories/server/compute-duration-stats.server'
+import { computeMonthlyCoverageEvolution } from '~/features/territories/server/compute-monthly-coverage-evolution.server'
+import { computeOverdueRate } from '~/features/territories/server/compute-overdue-rate.server'
+import { computeRankedTerritories } from '~/features/territories/server/compute-ranked-territories.server'
+import { computeRestPeriodUtilization } from '~/features/territories/server/compute-rest-period-utilization.server'
 import { countDelayedWorkingTerritories } from '~/features/territories/server/delayed-working-territories.server'
+import { fetchActiveAttributionsByGroup } from '~/features/territories/server/fetch-attributions-by-group.server'
+import { fetchAttributionsForStats } from '~/features/territories/server/fetch-attributions-for-stats.server'
+import { fetchTerritoryCounts, getTotalTerritoryCount } from '~/features/territories/server/fetch-territory-counts.server'
+import { parseStatsFilterParams } from '~/features/territories/server/parse-stats-filter-params.server'
 import { countRestingTerritories } from '~/features/territories/server/resting-territories.server'
 import { computeTerritoryCoverage } from '~/features/territories/server/territory-coverage.server'
 import { computeTerritoryCoverageTotal } from '~/features/territories/server/territory-coverage-total.server'
-import { getCurrentTheocraticYear } from '~/features/territories/server/theocratic-year.server'
+import { getTerritoriesNeverWorked } from '~/features/territories/server/territories-never-worked.server'
+import {
+  getBeginingDateOfTheocraticYear,
+  getCurrentTheocraticYear,
+  getEndDateOfTheocraticYear,
+  getPreviousTheocraticYear,
+} from '~/features/territories/server/theocratic-year.server'
+import AttributionsPerMonthChart from '~/features/territories/ui/AttributionsPerMonthChart'
+import MonthlyCoverageChart from '~/features/territories/ui/MonthlyCoverageChart'
+import TerritoriesNeverWorkedList from '~/features/territories/ui/TerritoriesNeverWorkedList'
+import YearOverYearTable from '~/features/territories/ui/YearOverYearTable'
 import StatsFilters from '~/features/territories/ui/StatsFilters'
-import { Card, CardContent } from '~/shared/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/shared/ui/tooltip'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import S13ExportButton from '~/shared/ui/S13ExportButton'
@@ -36,32 +57,86 @@ export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url)
   const params = url.searchParams
 
-  const kind = params.getAll('kind') as TerritoryKind[]
-  const attributionKind = params.getAll('attributionKind') as TerritoryAttributionKind[]
-
   const theocraticYear = getCurrentTheocraticYear()
+  const filterParams = parseStatsFilterParams(params, theocraticYear)
 
-  const activeWorkingTerritoriesCount = await countActiveWorkingTerritories()
-  const delayedWorkingTerritoriesCount = await countDelayedWorkingTerritories()
+  // Paramètres pour l'année précédente (comparaison annuelle)
+  const prevYear = getPreviousTheocraticYear()
+  const prevParams = {
+    ...filterParams,
+    startDate: getBeginingDateOfTheocraticYear(prevYear),
+    endDate: getEndDateOfTheocraticYear(prevYear),
+  }
+
+  // Requêtes parallèles
+  const [
+    activeWorkingTerritoriesCount,
+    delayedWorkingTerritoriesCount,
+    restingTerritoriesCount,
+    availableTerritoriesCount,
+    percentageCovered,
+    percentageTotallyCovered,
+    attributions,
+    prevAttributions,
+    territoryCounts,
+    allTerritoryCounts,
+    neverWorked,
+    attributionsByGroup,
+    groups,
+  ] = await Promise.all([
+    countActiveWorkingTerritories(),
+    countDelayedWorkingTerritories(),
+    countRestingTerritories(),
+    countAvailableTerritories(),
+    computeTerritoryCoverage(
+      filterParams.territoryKind,
+      filterParams.attributionKind,
+      filterParams.startDate,
+      filterParams.endDate,
+    ),
+    computeTerritoryCoverageTotal(
+      filterParams.territoryKind,
+      filterParams.attributionKind.length > 0
+        ? filterParams.attributionKind
+        : [TerritoryAttributionKind.Default, TerritoryAttributionKind.Campaign],
+      filterParams.startDate,
+      filterParams.endDate,
+    ),
+    fetchAttributionsForStats(filterParams),
+    fetchAttributionsForStats(prevParams),
+    fetchTerritoryCounts(filterParams.territoryKind),
+    fetchTerritoryCounts(),
+    getTerritoriesNeverWorked(filterParams),
+    fetchActiveAttributionsByGroup(),
+    getGroups(),
+  ])
+
   const workingTerritoriesCount = activeWorkingTerritoriesCount + delayedWorkingTerritoriesCount
-  const restingTerritoriesCount = await countRestingTerritories()
   const unavailableTerritoriesCount = restingTerritoriesCount + workingTerritoriesCount
-  const availableTerritoriesCount = await countAvailableTerritories()
   const territoriesCount = unavailableTerritoriesCount + availableTerritoriesCount
-  const percentageCovered = await computeTerritoryCoverage(
-    kind.length > 0 ? kind : [TerritoryKind.Classical],
-    attributionKind.length > 0 ? attributionKind : [TerritoryAttributionKind.Default],
-    params.get('startDate') != null ? new Date(String(params.get('startDate'))) : new Date(theocraticYear, 8, 1),
-    params.get('endDate') != null ? new Date(String(params.get('endDate'))) : new Date(theocraticYear + 1, 7, 31),
+
+  // Calculs synchrones à partir des données récupérées
+  const ranked = computeRankedTerritories(attributions)
+  const durationStats = computeDurationStats(attributions)
+  const overdueRate = computeOverdueRate(attributions)
+  const availabilityGap = computeAvailabilityGap(attributions)
+  const attributionsPerMonth = computeAttributionsPerMonth(attributions, filterParams.startDate, filterParams.endDate)
+  const monthlyCoverage = computeMonthlyCoverageEvolution(
+    attributions,
+    territoryCounts,
+    filterParams.startDate,
+    filterParams.endDate,
   )
-  const percentageTotallyCovered = await computeTerritoryCoverageTotal(
-    kind.length > 0 ? kind : [TerritoryKind.Classical],
-    attributionKind.length > 0
-      ? attributionKind
-      : [TerritoryAttributionKind.Default, TerritoryAttributionKind.Campaign],
-    params.get('startDate') != null ? new Date(String(params.get('startDate'))) : new Date(theocraticYear, 8, 1),
-    params.get('endDate') != null ? new Date(String(params.get('endDate'))) : new Date(theocraticYear + 1, 7, 31),
-  )
+  const coverageByType = computeCoverageByTerritoryType(attributions, allTerritoryCounts)
+  const restUtilization = computeRestPeriodUtilization(attributions)
+
+  // Métriques de l'année précédente pour la comparaison
+  const prevDuration = computeDurationStats(prevAttributions)
+  const prevOverdueRate = computeOverdueRate(prevAttributions)
+  const prevTotalCount = getTotalTerritoryCount(territoryCounts)
+  const prevTouchedTerritories = new Set(prevAttributions.map(a => a.territoryId))
+  const prevCoverage = prevTotalCount > 0 ? (prevAttributions.length / prevTotalCount) * 100 : 0
+  const prevTotalCoverage = prevTotalCount > 0 ? (prevTouchedTerritories.size / prevTotalCount) * 100 : 0
 
   return {
     stats: {
@@ -75,12 +150,58 @@ export async function loader({ request }: Route.LoaderArgs) {
       coverage: percentageCovered,
       totalCoverage: percentageTotallyCovered,
     },
+    progression: {
+      ranked,
+      durationStats,
+      overdueRate,
+      availabilityGap,
+      attributionsPerMonth,
+      restUtilization,
+    },
+    coverageOverTime: {
+      monthlyCoverage,
+      coverageByType,
+      neverWorked,
+    },
+    yearOverYear: {
+      current: {
+        coverage: percentageCovered,
+        totalCoverage: percentageTotallyCovered,
+        averageDurationDays: durationStats.averageDays,
+        overdueRate,
+        attributionCount: attributions.length,
+      },
+      previous: {
+        coverage: prevCoverage,
+        totalCoverage: prevTotalCoverage,
+        averageDurationDays: prevDuration.averageDays,
+        overdueRate: prevOverdueRate,
+        attributionCount: prevAttributions.length,
+      },
+    },
+    attributionsByGroup,
     theocraticYear,
-    groups: await getGroups(),
+    groups,
   }
 }
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042']
+const PIE_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-4)',
+  'var(--color-chart-3)',
+]
+
+const GROUP_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)',
+  '#6366f1',
+  '#ec4899',
+  '#14b8a6',
+]
 
 function StatLabel({ label, help }: { label: string; help: string }) {
   return (
@@ -101,9 +222,9 @@ function StatLabel({ label, help }: { label: string; help: string }) {
 }
 
 export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps) {
-  const { stats, theocraticYear, groups } = loaderData
+  const { stats, progression, coverageOverTime, yearOverYear, attributionsByGroup, theocraticYear, groups } = loaderData
 
-  const data = [
+  const pieData = [
     { name: 'Disponible', value: stats.available },
     { name: 'Sortis', value: stats.active },
     { name: 'En retard', value: stats.delayed },
@@ -118,6 +239,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
         actions={<S13ExportButton theocraticYear={theocraticYear} />}
       />
 
+      {/* ═══ État global ═══ */}
       <h2 className="font-display font-semibold text-xl">État global</h2>
 
       <div className="flex flex-col gap-3">
@@ -170,8 +292,65 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
             </CardContent>
           </Card>
         </div>
+        <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <PieChart width={300} height={300} onMouseEnter={() => {}}>
+                <Pie
+                  data={pieData}
+                  cx={150}
+                  cy={150}
+                  innerRadius={60}
+                  outerRadius={80}
+                  fill="#8884d8"
+                  paddingAngle={5}
+                  dataKey="value"
+                >
+                  {pieData.map((entry, index) => (
+                    <Cell key={`cell-${entry.name}`} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                  ))}
+                </Pie>
+              </PieChart>
+              <StatLabel
+                label="État du territoire"
+                help="Répartition visuelle des territoires entre disponibles, sortis, en retard et en repos."
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              {attributionsByGroup.length > 0 ? (
+                <PieChart width={300} height={300} onMouseEnter={() => {}}>
+                  <Pie
+                    data={attributionsByGroup.map(g => ({ name: g.groupName, value: g.count }))}
+                    cx={150}
+                    cy={150}
+                    innerRadius={60}
+                    outerRadius={80}
+                    fill="#8884d8"
+                    paddingAngle={5}
+                    dataKey="value"
+                  >
+                    {attributionsByGroup.map((g, index) => (
+                      <Cell key={`group-${g.groupName}`} fill={GROUP_COLORS[index % GROUP_COLORS.length]} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              ) : (
+                <span className="py-12 text-muted-foreground text-sm italic">Aucune attribution active</span>
+              )}
+              <StatLabel
+                label="Répartition par groupe"
+                help="Répartition des territoires actuellement sortis par groupe de prédication."
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
 
-        <h2 className="mt-3 font-display font-semibold text-xl">Progression</h2>
+      {/* ═══ Progression ═══ */}
+      <h2 className="mt-3 font-display font-semibold text-xl">Progression</h2>
+      <div className="flex flex-col gap-3">
         <div className="my-2">
           <StatsFilters groups={groups} />
         </div>
@@ -198,48 +377,179 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
-              <span className="font-black font-display text-5xl max-sm:text-3xl">-</span>
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.ranked.most != null
+                  ? `${progression.ranked.most.number}`
+                  : '-'}
+              </span>
+              {progression.ranked.most != null && (
+                <span className="font-display text-lg text-muted-foreground">
+                  ({progression.ranked.most.count} fois)
+                </span>
+              )}
               <StatLabel
                 label="Territoire le plus travaillé"
-                help="Territoire ayant reçu le plus d'attributions sur la période. Pas encore implémenté."
+                help="Territoire ayant reçu le plus d'attributions sur la période sélectionnée."
               />
             </CardContent>
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
-              <span className="font-black font-display text-5xl max-sm:text-3xl">-</span>
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.ranked.least != null
+                  ? `${progression.ranked.least.number}`
+                  : '-'}
+              </span>
+              {progression.ranked.least != null && (
+                <span className="font-display text-lg text-muted-foreground">
+                  ({progression.ranked.least.count} fois)
+                </span>
+              )}
               <StatLabel
                 label="Territoire le moins travaillé"
-                help="Territoire ayant reçu le moins d'attributions sur la période. Pas encore implémenté."
+                help="Territoire ayant reçu le moins d'attributions sur la période sélectionnée."
+              />
+            </CardContent>
+          </Card>
+        </div>
+        <div className="grid grid-cols-3 gap-3 max-sm:grid-cols-1">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.durationStats.averageDays} j
+              </span>
+              <StatLabel
+                label="Durée moyenne des attributions"
+                help="Nombre moyen de jours entre la sortie et le retour d'un territoire (attributions terminées uniquement)."
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <div className="flex items-baseline gap-2">
+                <span className="font-black font-display text-5xl max-sm:text-3xl">
+                  {progression.durationStats.longestDays}
+                </span>
+                <span className="text-2xl text-muted-foreground">/</span>
+                <span className="font-black font-display text-5xl max-sm:text-3xl">
+                  {progression.durationStats.shortestDays}
+                </span>
+                <span className="font-display text-2xl">j</span>
+              </div>
+              <StatLabel
+                label="Plus longue / Plus courte attribution"
+                help="Durée en jours de l'attribution la plus longue et la plus courte sur la période."
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.overdueRate.toFixed(1)} %
+              </span>
+              <StatLabel
+                label="Taux de retard"
+                help="Pourcentage d'attributions rendues après la date de retour prévue."
+              />
+            </CardContent>
+          </Card>
+        </div>
+        <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.availabilityGap} j
+              </span>
+              <StatLabel
+                label="Délai moyen de disponibilité"
+                help="Nombre moyen de jours entre le retour d'un territoire et sa prochaine attribution."
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+              <span className="font-black font-display text-5xl max-sm:text-3xl">
+                {progression.restUtilization} j
+              </span>
+              <StatLabel
+                label="Inactivité moy. après repos"
+                help="Nombre moyen de jours d'attente entre la fin de la période de repos et la prochaine attribution."
               />
             </CardContent>
           </Card>
         </div>
         <Card>
-          <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
-            <PieChart width={300} height={300} onMouseEnter={() => {}}>
-              <Pie
-                data={data}
-                cx={150}
-                cy={150}
-                innerRadius={60}
-                outerRadius={80}
-                fill="#8884d8"
-                paddingAngle={5}
-                dataKey="value"
-              >
-                {data.map((entry, index) => (
-                  <Cell key={`cell-${entry.name}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-            </PieChart>
-            <StatLabel
-              label="État du territoire"
-              help="Répartition visuelle des territoires entre disponibles, sortis, en retard et en repos."
-            />
+          <CardHeader>
+            <CardTitle className="font-display text-lg">Attributions par mois</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <AttributionsPerMonthChart data={progression.attributionsPerMonth} />
           </CardContent>
         </Card>
       </div>
+
+      {/* ═══ Couverture dans le temps ═══ */}
+      <h2 className="mt-3 font-display font-semibold text-xl">Couverture dans le temps</h2>
+      <div className="flex flex-col gap-3">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-display text-lg">Évolution mensuelle de la couverture</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MonthlyCoverageChart data={coverageOverTime.monthlyCoverage} />
+          </CardContent>
+        </Card>
+        {coverageOverTime.coverageByType.length > 0 && (
+          <div
+            className={`grid gap-3 max-sm:grid-cols-1 ${
+              coverageOverTime.coverageByType.length <= 3 ? `grid-cols-${coverageOverTime.coverageByType.length}` : 'grid-cols-3 max-md:grid-cols-2'
+            }`}
+          >
+            {coverageOverTime.coverageByType.map(ct => (
+              <Card key={ct.kind}>
+                <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
+                  <span className="font-black font-display text-4xl max-sm:text-2xl">
+                    {ct.totalCoverage.toFixed(1)} %
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    ({ct.coverage.toFixed(1)} % d'attributions)
+                  </span>
+                  <StatLabel
+                    label={ct.label}
+                    help={`Couverture complète pour les territoires "${ct.label}" : pourcentage de territoires ayant eu au moins une attribution.`}
+                  />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-display text-lg">Territoires jamais travaillés</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TerritoriesNeverWorkedList territories={coverageOverTime.neverWorked} />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ═══ Comparaison annuelle ═══ */}
+      <h2 className="mt-3 font-display font-semibold text-xl">Comparaison annuelle</h2>
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-display text-lg">
+            Année {theocraticYear}/{theocraticYear + 1} vs {theocraticYear - 1}/{theocraticYear}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <YearOverYearTable
+            current={yearOverYear.current}
+            previous={yearOverYear.previous}
+            currentLabel={`${theocraticYear}/${theocraticYear + 1}`}
+            previousLabel={`${theocraticYear - 1}/${theocraticYear}`}
+          />
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/app/features/territories/server/compute-attributions-per-month.server.test.ts
+++ b/app/features/territories/server/compute-attributions-per-month.server.test.ts
@@ -51,4 +51,17 @@ describe('computeAttributionsPerMonth', () => {
     expect(result[0].month).toBe('2025-09')
     expect(result[11].month).toBe('2026-08')
   })
+
+  it('ignore les attributions dont le mois de début est hors période', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 7, 15), 1), // août, hors période sept-nov
+      makeAttribution(new Date(2025, 8, 10), 2), // septembre, dans la période
+    ]
+
+    const result = computeAttributionsPerMonth(attributions, new Date(2025, 8, 1), new Date(2025, 10, 30))
+
+    expect(result[0].count).toBe(1) // Seule l'attribution de septembre compte
+    expect(result[1].count).toBe(0)
+    expect(result[2].count).toBe(0)
+  })
 })

--- a/app/features/territories/server/compute-attributions-per-month.server.test.ts
+++ b/app/features/territories/server/compute-attributions-per-month.server.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeAttributionsPerMonth } from './compute-attributions-per-month.server'
+
+function makeAttribution(startDate: Date, id = 1): StatsAttribution {
+  return {
+    id,
+    territoryId: 1,
+    territoryNumber: 'T-1',
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate,
+    endDate: null,
+    lateDate: new Date(2026, 0, 1),
+  }
+}
+
+describe('computeAttributionsPerMonth', () => {
+  it('génère tous les mois de la période même sans attributions', () => {
+    const result = computeAttributionsPerMonth([], new Date(2025, 8, 1), new Date(2025, 11, 31))
+
+    expect(result).toEqual([
+      { month: '2025-09', count: 0 },
+      { month: '2025-10', count: 0 },
+      { month: '2025-11', count: 0 },
+      { month: '2025-12', count: 0 },
+    ])
+  })
+
+  it('compte les attributions par mois de début', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 8, 5), 1),
+      makeAttribution(new Date(2025, 8, 20), 2),
+      makeAttribution(new Date(2025, 9, 10), 3),
+    ]
+
+    const result = computeAttributionsPerMonth(attributions, new Date(2025, 8, 1), new Date(2025, 10, 30))
+
+    expect(result).toEqual([
+      { month: '2025-09', count: 2 },
+      { month: '2025-10', count: 1 },
+      { month: '2025-11', count: 0 },
+    ])
+  })
+
+  it('génère les 12 mois d\'une année théocratique complète', () => {
+    const result = computeAttributionsPerMonth([], new Date(2025, 8, 1), new Date(2026, 7, 31))
+    expect(result).toHaveLength(12)
+    expect(result[0].month).toBe('2025-09')
+    expect(result[11].month).toBe('2026-08')
+  })
+})

--- a/app/features/territories/server/compute-attributions-per-month.server.ts
+++ b/app/features/territories/server/compute-attributions-per-month.server.ts
@@ -1,0 +1,48 @@
+import type { StatsAttribution } from './stats-attribution.type'
+
+export interface MonthlyCount {
+  month: string
+  count: number
+}
+
+// Génère tous les mois entre startDate et endDate au format "YYYY-MM"
+function generateMonthRange(startDate: Date, endDate: Date): string[] {
+  const months: string[] = []
+  const current = new Date(startDate.getFullYear(), startDate.getMonth(), 1)
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), 1)
+
+  while (current <= end) {
+    const year = current.getFullYear()
+    const month = String(current.getMonth() + 1).padStart(2, '0')
+    months.push(`${year}-${month}`)
+    current.setMonth(current.getMonth() + 1)
+  }
+
+  return months
+}
+
+// Compte le nombre d'attributions démarrées chaque mois sur la période
+export function computeAttributionsPerMonth(
+  attributions: StatsAttribution[],
+  startDate: Date,
+  endDate: Date,
+): MonthlyCount[] {
+  const allMonths = generateMonthRange(startDate, endDate)
+  const countMap = new Map<string, number>()
+
+  for (const month of allMonths) {
+    countMap.set(month, 0)
+  }
+
+  for (const a of attributions) {
+    const year = a.startDate.getFullYear()
+    const month = String(a.startDate.getMonth() + 1).padStart(2, '0')
+    const key = `${year}-${month}`
+
+    if (countMap.has(key)) {
+      countMap.set(key, (countMap.get(key) ?? 0) + 1)
+    }
+  }
+
+  return allMonths.map(month => ({ month, count: countMap.get(month) ?? 0 }))
+}

--- a/app/features/territories/server/compute-availability-gap.server.test.ts
+++ b/app/features/territories/server/compute-availability-gap.server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeAvailabilityGap } from './compute-availability-gap.server'
+
+function makeAttribution(
+  territoryId: number,
+  startDate: Date,
+  endDate: Date | null,
+  id = 1,
+): StatsAttribution {
+  return {
+    id,
+    territoryId,
+    territoryNumber: `T-${territoryId}`,
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate,
+    endDate,
+    lateDate: new Date(2026, 0, 1),
+  }
+}
+
+describe('computeAvailabilityGap', () => {
+  it('retourne 0 quand il n\'y a aucune attribution', () => {
+    expect(computeAvailabilityGap([])).toBe(0)
+  })
+
+  it('retourne 0 quand il n\'y a qu\'une seule attribution par territoire', () => {
+    const attributions = [
+      makeAttribution(1, new Date(2025, 0, 1), new Date(2025, 1, 1)),
+      makeAttribution(2, new Date(2025, 0, 1), new Date(2025, 1, 1)),
+    ]
+    expect(computeAvailabilityGap(attributions)).toBe(0)
+  })
+
+  it('calcule le gap moyen entre attributions consécutives', () => {
+    const attributions = [
+      // Territoire 1 : gap de 10 jours
+      makeAttribution(1, new Date(2025, 0, 1), new Date(2025, 0, 31), 1),
+      makeAttribution(1, new Date(2025, 1, 10), new Date(2025, 2, 10), 2),
+      // Territoire 2 : gap de 20 jours
+      makeAttribution(2, new Date(2025, 0, 1), new Date(2025, 0, 31), 3),
+      makeAttribution(2, new Date(2025, 1, 20), new Date(2025, 2, 20), 4),
+    ]
+    // Moyenne de 10 et 20 = 15
+    expect(computeAvailabilityGap(attributions)).toBe(15)
+  })
+
+  it('ignore les attributions en cours (endDate null) pour le calcul du gap', () => {
+    const attributions = [
+      makeAttribution(1, new Date(2025, 0, 1), null, 1),
+      makeAttribution(1, new Date(2025, 2, 1), new Date(2025, 3, 1), 2),
+    ]
+    // On ne peut pas calculer de gap car la première attribution n'a pas de date de fin
+    expect(computeAvailabilityGap(attributions)).toBe(0)
+  })
+})

--- a/app/features/territories/server/compute-availability-gap.server.test.ts
+++ b/app/features/territories/server/compute-availability-gap.server.test.ts
@@ -56,4 +56,16 @@ describe('computeAvailabilityGap', () => {
     // On ne peut pas calculer de gap car la première attribution n'a pas de date de fin
     expect(computeAvailabilityGap(attributions)).toBe(0)
   })
+
+  it('ignore les gaps négatifs (attributions qui se chevauchent)', () => {
+    const attributions = [
+      // Territoire 1 : chevauchement (la suivante commence avant que la première finisse)
+      makeAttribution(1, new Date(2025, 0, 1), new Date(2025, 1, 15), 1),
+      makeAttribution(1, new Date(2025, 1, 1), new Date(2025, 2, 15), 2), // commence 14 jours avant la fin de la précédente
+      // Territoire 1 : gap positif de 15 jours
+      makeAttribution(1, new Date(2025, 3, 1), new Date(2025, 4, 1), 3),
+    ]
+    // Seul le gap entre la 2e et la 3e est positif (17 jours)
+    expect(computeAvailabilityGap(attributions)).toBe(17)
+  })
 })

--- a/app/features/territories/server/compute-availability-gap.server.ts
+++ b/app/features/territories/server/compute-availability-gap.server.ts
@@ -1,0 +1,36 @@
+import type { StatsAttribution } from './stats-attribution.type'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+// Calcule le délai moyen (en jours) entre la fin d'une attribution et le début de la suivante pour le même territoire
+export function computeAvailabilityGap(attributions: StatsAttribution[]): number {
+  // Regrouper par territoire, triées par date de début (déjà triées par le fetch)
+  const byTerritory = new Map<number, StatsAttribution[]>()
+  for (const a of attributions) {
+    const list = byTerritory.get(a.territoryId) ?? []
+    list.push(a)
+    byTerritory.set(a.territoryId, list)
+  }
+
+  const gaps: number[] = []
+
+  for (const territoryAttributions of byTerritory.values()) {
+    for (let i = 0; i < territoryAttributions.length - 1; i++) {
+      const current = territoryAttributions[i]
+      const next = territoryAttributions[i + 1]
+
+      // On ne peut calculer un gap que si l'attribution courante a une date de fin
+      if (current.endDate == null) continue
+
+      const gapDays = (next.startDate.getTime() - current.endDate.getTime()) / MS_PER_DAY
+      if (gapDays >= 0) {
+        gaps.push(gapDays)
+      }
+    }
+  }
+
+  if (gaps.length === 0) return 0
+
+  const sum = gaps.reduce((acc, g) => acc + g, 0)
+  return Math.round(sum / gaps.length)
+}

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 import type { StatsAttribution } from './stats-attribution.type'
 import { computeCoverageByTerritoryType } from './compute-coverage-by-territory-type.server'
 
@@ -61,5 +61,30 @@ describe('computeCoverageByTerritoryType', () => {
 
     expect(result[0].coverage).toBe(0)
     expect(result[0].totalCoverage).toBe(0)
+  })
+
+  it('utilise le type brut comme label pour un type inconnu avec 0 territoires', () => {
+    const counts: TerritoryCountByType[] = [{ type: 'special' as TerritoryKind, count: 0 }]
+    const result = computeCoverageByTerritoryType([], counts)
+
+    expect(result[0].label).toBe('special')
+  })
+
+  it('utilise le type brut comme label quand le type est inconnu', () => {
+    const counts: TerritoryCountByType[] = [{ type: 'unknown-type' as TerritoryKind, count: 5 }]
+    const result = computeCoverageByTerritoryType([], counts)
+
+    expect(result[0].label).toBe('unknown-type')
+    expect(result[0].kind).toBe('unknown-type')
+  })
+
+  it('utilise le type brut comme label pour un type inconnu avec des attributions', () => {
+    const counts: TerritoryCountByType[] = [{ type: 'custom' as TerritoryKind, count: 2 }]
+    const attributions = [makeAttribution(1, 'custom' as TerritoryKind)]
+
+    const result = computeCoverageByTerritoryType(attributions, counts)
+
+    expect(result[0].label).toBe('custom')
+    expect(result[0].coverage).toBe(50)
   })
 })

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeCoverageByTerritoryType } from './compute-coverage-by-territory-type.server'
+
+function makeAttribution(
+  territoryId: number,
+  territoryType: TerritoryKind,
+): StatsAttribution {
+  return {
+    id: territoryId,
+    territoryId,
+    territoryNumber: `T-${territoryId}`,
+    territoryType,
+    type: TerritoryAttributionKind.Default,
+    startDate: new Date(2025, 9, 1),
+    endDate: new Date(2025, 10, 1),
+    lateDate: new Date(2025, 11, 1),
+  }
+}
+
+describe('computeCoverageByTerritoryType', () => {
+  it('retourne des couvertures à 0 quand il n\'y a aucune attribution', () => {
+    const counts: TerritoryCountByType[] = [{ type: TerritoryKind.Classical, count: 10 }]
+    const result = computeCoverageByTerritoryType([], counts)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].coverage).toBe(0)
+    expect(result[0].totalCoverage).toBe(0)
+    expect(result[0].label).toBe('Porte à porte')
+  })
+
+  it('calcule la couverture par type de territoire', () => {
+    const counts: TerritoryCountByType[] = [
+      { type: TerritoryKind.Classical, count: 10 },
+      { type: TerritoryKind.Commerces, count: 5 },
+    ]
+    const attributions = [
+      makeAttribution(1, TerritoryKind.Classical),
+      makeAttribution(2, TerritoryKind.Classical),
+      makeAttribution(2, TerritoryKind.Classical), // même territoire, 2 fois
+      makeAttribution(10, TerritoryKind.Commerces),
+    ]
+
+    const result = computeCoverageByTerritoryType(attributions, counts)
+
+    // Classique : 3 attributions / 10 territoires = 30%, 2 territoires distincts / 10 = 20%
+    expect(result[0].coverage).toBe(30)
+    expect(result[0].totalCoverage).toBe(20)
+
+    // Commerces : 1 attribution / 5 territoires = 20%, 1 territoire / 5 = 20%
+    expect(result[1].coverage).toBe(20)
+    expect(result[1].totalCoverage).toBe(20)
+  })
+
+  it('gère un type avec 0 territoires', () => {
+    const counts: TerritoryCountByType[] = [{ type: TerritoryKind.Hotel, count: 0 }]
+    const result = computeCoverageByTerritoryType([], counts)
+
+    expect(result[0].coverage).toBe(0)
+    expect(result[0].totalCoverage).toBe(0)
+  })
+})

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.ts
@@ -1,5 +1,5 @@
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 import type { StatsAttribution } from './stats-attribution.type'
 
 export interface CoverageByType {

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.ts
@@ -1,0 +1,45 @@
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { StatsAttribution } from './stats-attribution.type'
+
+export interface CoverageByType {
+  kind: TerritoryKind
+  label: string
+  coverage: number
+  totalCoverage: number
+}
+
+const TERRITORY_KIND_LABELS: Record<string, string> = {
+  [TerritoryKind.Classical]: 'Porte à porte',
+  [TerritoryKind.Univ]: 'Université',
+  [TerritoryKind.Commerces]: 'Commerces',
+  [TerritoryKind.Phone]: 'Téléphone',
+  [TerritoryKind.Hotel]: 'Hôtel',
+}
+
+export function computeCoverageByTerritoryType(
+  attributions: StatsAttribution[],
+  territoryCounts: TerritoryCountByType[],
+): CoverageByType[] {
+  return territoryCounts.map(({ type, count }) => {
+    if (count === 0) {
+      return { kind: type, label: TERRITORY_KIND_LABELS[type] ?? type, coverage: 0, totalCoverage: 0 }
+    }
+
+    const typeAttributions = attributions.filter(a => a.territoryType === type)
+
+    // Couverture : nombre d'attributions / nombre de territoires * 100
+    const coverage = (typeAttributions.length / count) * 100
+
+    // Couverture complète : territoires distincts touchés / nombre de territoires * 100
+    const touchedTerritories = new Set(typeAttributions.map(a => a.territoryId))
+    const totalCoverage = (touchedTerritories.size / count) * 100
+
+    return {
+      kind: type,
+      label: TERRITORY_KIND_LABELS[type] ?? type,
+      coverage: Math.round(coverage * 100) / 100,
+      totalCoverage: Math.round(totalCoverage * 100) / 100,
+    }
+  })
+}

--- a/app/features/territories/server/compute-duration-stats.server.test.ts
+++ b/app/features/territories/server/compute-duration-stats.server.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeDurationStats } from './compute-duration-stats.server'
+
+function makeAttribution(startDate: Date, endDate: Date | null): StatsAttribution {
+  return {
+    id: 1,
+    territoryId: 1,
+    territoryNumber: 'T-1',
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate,
+    endDate,
+    lateDate: new Date(2026, 0, 1),
+  }
+}
+
+describe('computeDurationStats', () => {
+  it('retourne des zéros quand il n\'y a aucune attribution', () => {
+    expect(computeDurationStats([])).toEqual({ averageDays: 0, longestDays: 0, shortestDays: 0 })
+  })
+
+  it('ignore les attributions en cours (endDate null)', () => {
+    const attributions = [makeAttribution(new Date(2025, 9, 1), null)]
+    expect(computeDurationStats(attributions)).toEqual({ averageDays: 0, longestDays: 0, shortestDays: 0 })
+  })
+
+  it('calcule correctement avec une seule attribution complétée', () => {
+    const attributions = [makeAttribution(new Date(2025, 9, 1), new Date(2025, 10, 1))]
+    // 31 jours entre le 1er octobre et le 1er novembre
+    expect(computeDurationStats(attributions)).toEqual({ averageDays: 31, longestDays: 31, shortestDays: 31 })
+  })
+
+  it('calcule la moyenne, le plus long et le plus court', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 0, 1), new Date(2025, 0, 11)), // 10 jours
+      makeAttribution(new Date(2025, 1, 1), new Date(2025, 2, 3)), // 30 jours
+      makeAttribution(new Date(2025, 3, 1), new Date(2025, 4, 21)), // 50 jours
+    ]
+
+    const result = computeDurationStats(attributions)
+    expect(result.averageDays).toBe(30)
+    expect(result.longestDays).toBe(50)
+    expect(result.shortestDays).toBe(10)
+  })
+})

--- a/app/features/territories/server/compute-duration-stats.server.ts
+++ b/app/features/territories/server/compute-duration-stats.server.ts
@@ -1,0 +1,31 @@
+import type { StatsAttribution } from './stats-attribution.type'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface DurationStats {
+  averageDays: number
+  longestDays: number
+  shortestDays: number
+}
+
+export function computeDurationStats(attributions: StatsAttribution[]): DurationStats {
+  const durations: number[] = []
+
+  for (const a of attributions) {
+    if (a.endDate == null) continue
+    const days = (a.endDate.getTime() - a.startDate.getTime()) / MS_PER_DAY
+    durations.push(days)
+  }
+
+  if (durations.length === 0) {
+    return { averageDays: 0, longestDays: 0, shortestDays: 0 }
+  }
+
+  const sum = durations.reduce((acc, d) => acc + d, 0)
+
+  return {
+    averageDays: Math.round(sum / durations.length),
+    longestDays: Math.round(Math.max(...durations)),
+    shortestDays: Math.round(Math.min(...durations)),
+  }
+}

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 import type { StatsAttribution } from './stats-attribution.type'
 import { computeMonthlyCoverageEvolution } from './compute-monthly-coverage-evolution.server'
 

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeMonthlyCoverageEvolution } from './compute-monthly-coverage-evolution.server'
+
+function makeAttribution(
+  territoryId: number,
+  startDate: Date,
+  endDate: Date | null,
+): StatsAttribution {
+  return {
+    id: territoryId,
+    territoryId,
+    territoryNumber: `T-${territoryId}`,
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate,
+    endDate,
+    lateDate: new Date(2026, 0, 1),
+  }
+}
+
+describe('computeMonthlyCoverageEvolution', () => {
+  const counts: TerritoryCountByType[] = [{ type: TerritoryKind.Classical, count: 10 }]
+
+  it('retourne un tableau vide quand il n\'y a aucun territoire', () => {
+    const result = computeMonthlyCoverageEvolution([], [], new Date(2025, 8, 1), new Date(2025, 10, 30))
+    expect(result).toEqual([])
+  })
+
+  it('retourne 0% pour chaque mois sans attributions', () => {
+    const result = computeMonthlyCoverageEvolution(
+      [],
+      counts,
+      new Date(2025, 8, 1),
+      new Date(2025, 10, 30),
+    )
+
+    expect(result).toHaveLength(3)
+    expect(result.every(m => m.coverage === 0)).toBe(true)
+  })
+
+  it('calcule la couverture cumulative mois par mois', () => {
+    const attributions = [
+      makeAttribution(1, new Date(2025, 8, 5), new Date(2025, 8, 20)),
+      makeAttribution(2, new Date(2025, 9, 10), new Date(2025, 9, 25)),
+    ]
+
+    const result = computeMonthlyCoverageEvolution(
+      attributions,
+      counts,
+      new Date(2025, 8, 1),
+      new Date(2025, 10, 30),
+    )
+
+    // Sept : territoire 1 touché = 10%
+    expect(result[0].coverage).toBe(10)
+    // Oct : territoires 1 et 2 touchés = 20%
+    expect(result[1].coverage).toBe(20)
+    // Nov : mêmes territoires, toujours 20%
+    expect(result[2].coverage).toBe(20)
+  })
+})

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
@@ -1,5 +1,5 @@
-import type { TerritoryCountByType } from './fetch-territory-counts.server'
-import { getTotalTerritoryCount } from './fetch-territory-counts.server'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
+import { getTotalTerritoryCount } from './territory-count-by-type.type'
 import type { StatsAttribution } from './stats-attribution.type'
 
 export interface MonthlyCoverage {

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
@@ -1,0 +1,49 @@
+import type { TerritoryCountByType } from './fetch-territory-counts.server'
+import { getTotalTerritoryCount } from './fetch-territory-counts.server'
+import type { StatsAttribution } from './stats-attribution.type'
+
+export interface MonthlyCoverage {
+  month: string
+  coverage: number
+}
+
+// Calcule la couverture cumulative mois par mois :
+// pour chaque fin de mois, quel % de territoires ont été touchés depuis le début de la période
+export function computeMonthlyCoverageEvolution(
+  attributions: StatsAttribution[],
+  territoryCounts: TerritoryCountByType[],
+  startDate: Date,
+  endDate: Date,
+): MonthlyCoverage[] {
+  const total = getTotalTerritoryCount(territoryCounts)
+  if (total === 0) return []
+
+  const months: MonthlyCoverage[] = []
+  const current = new Date(startDate.getFullYear(), startDate.getMonth(), 1)
+  const end = new Date(endDate.getFullYear(), endDate.getMonth(), 1)
+
+  while (current <= end) {
+    const monthEnd = new Date(current.getFullYear(), current.getMonth() + 1, 0) // Dernier jour du mois
+    const year = current.getFullYear()
+    const month = String(current.getMonth() + 1).padStart(2, '0')
+    const key = `${year}-${month}`
+
+    // Territoires distincts touchés entre startDate et la fin de ce mois
+    const touchedTerritories = new Set<number>()
+    for (const a of attributions) {
+      // L'attribution chevauche la période [startDate, monthEnd] si :
+      // - elle commence avant ou pendant la fin du mois
+      // - elle se termine après le début de la période (ou est en cours)
+      if (a.startDate <= monthEnd && (a.endDate == null || a.endDate >= startDate)) {
+        touchedTerritories.add(a.territoryId)
+      }
+    }
+
+    const coverage = (touchedTerritories.size / total) * 100
+    months.push({ month: key, coverage: Math.round(coverage * 100) / 100 })
+
+    current.setMonth(current.getMonth() + 1)
+  }
+
+  return months
+}

--- a/app/features/territories/server/compute-overdue-rate.server.test.ts
+++ b/app/features/territories/server/compute-overdue-rate.server.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeOverdueRate } from './compute-overdue-rate.server'
+
+function makeAttribution(endDate: Date | null, lateDate: Date): StatsAttribution {
+  return {
+    id: 1,
+    territoryId: 1,
+    territoryNumber: 'T-1',
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate: new Date(2025, 0, 1),
+    endDate,
+    lateDate,
+  }
+}
+
+describe('computeOverdueRate', () => {
+  it('retourne 0 quand il n\'y a aucune attribution', () => {
+    expect(computeOverdueRate([])).toBe(0)
+  })
+
+  it('retourne 0 quand toutes les attributions sont en cours', () => {
+    const attributions = [makeAttribution(null, new Date(2025, 5, 1))]
+    expect(computeOverdueRate(attributions)).toBe(0)
+  })
+
+  it('retourne 0 quand aucune attribution n\'est en retard', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 4, 1), new Date(2025, 5, 1)), // rendue avant la date limite
+    ]
+    expect(computeOverdueRate(attributions)).toBe(0)
+  })
+
+  it('retourne 100 quand toutes les attributions sont en retard', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 6, 1), new Date(2025, 5, 1)), // rendue après la date limite
+    ]
+    expect(computeOverdueRate(attributions)).toBe(100)
+  })
+
+  it('calcule le pourcentage correct', () => {
+    const attributions = [
+      makeAttribution(new Date(2025, 6, 1), new Date(2025, 5, 1)), // en retard
+      makeAttribution(new Date(2025, 4, 1), new Date(2025, 5, 1)), // à temps
+      makeAttribution(new Date(2025, 4, 15), new Date(2025, 5, 1)), // à temps
+      makeAttribution(null, new Date(2025, 5, 1)), // en cours, ignorée
+    ]
+    // 1 en retard sur 3 complétées = 33.33%
+    expect(computeOverdueRate(attributions)).toBeCloseTo(33.33, 1)
+  })
+})

--- a/app/features/territories/server/compute-overdue-rate.server.ts
+++ b/app/features/territories/server/compute-overdue-rate.server.ts
@@ -1,0 +1,14 @@
+import type { StatsAttribution } from './stats-attribution.type'
+
+export function computeOverdueRate(attributions: StatsAttribution[]): number {
+  const completed = attributions.filter(a => a.endDate != null)
+
+  if (completed.length === 0) return 0
+
+  const overdue = completed.filter(a => {
+    const endTime = a.endDate?.getTime()
+    return endTime != null && endTime > a.lateDate.getTime()
+  })
+
+  return (overdue.length / completed.length) * 100
+}

--- a/app/features/territories/server/compute-ranked-territories.server.test.ts
+++ b/app/features/territories/server/compute-ranked-territories.server.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeRankedTerritories } from './compute-ranked-territories.server'
+
+function makeAttribution(overrides: Partial<StatsAttribution> = {}): StatsAttribution {
+  return {
+    id: 1,
+    territoryId: 1,
+    territoryNumber: 'T-1',
+    territoryType: TerritoryKind.Classical,
+    type: TerritoryAttributionKind.Default,
+    startDate: new Date(2025, 9, 1),
+    endDate: new Date(2025, 10, 1),
+    lateDate: new Date(2025, 11, 1),
+    ...overrides,
+  }
+}
+
+describe('computeRankedTerritories', () => {
+  it('retourne null quand il n\'y a aucune attribution', () => {
+    const result = computeRankedTerritories([])
+    expect(result).toEqual({ most: null, least: null })
+  })
+
+  it('retourne le même territoire pour most et least avec une seule attribution', () => {
+    const result = computeRankedTerritories([makeAttribution()])
+    expect(result.most).toEqual({ number: 'T-1', count: 1 })
+    expect(result.least).toEqual({ number: 'T-1', count: 1 })
+  })
+
+  it('identifie le territoire le plus et le moins travaillé', () => {
+    const attributions = [
+      makeAttribution({ territoryId: 1, territoryNumber: 'T-1', id: 1 }),
+      makeAttribution({ territoryId: 1, territoryNumber: 'T-1', id: 2 }),
+      makeAttribution({ territoryId: 1, territoryNumber: 'T-1', id: 3 }),
+      makeAttribution({ territoryId: 2, territoryNumber: 'T-2', id: 4 }),
+      makeAttribution({ territoryId: 3, territoryNumber: 'T-3', id: 5 }),
+      makeAttribution({ territoryId: 3, territoryNumber: 'T-3', id: 6 }),
+    ]
+
+    const result = computeRankedTerritories(attributions)
+    expect(result.most).toEqual({ number: 'T-1', count: 3 })
+    expect(result.least).toEqual({ number: 'T-2', count: 1 })
+  })
+})

--- a/app/features/territories/server/compute-ranked-territories.server.ts
+++ b/app/features/territories/server/compute-ranked-territories.server.ts
@@ -1,0 +1,36 @@
+import type { StatsAttribution } from './stats-attribution.type'
+
+interface RankedTerritory {
+  number: string
+  count: number
+}
+
+interface RankedTerritoriesResult {
+  most: RankedTerritory | null
+  least: RankedTerritory | null
+}
+
+export function computeRankedTerritories(attributions: StatsAttribution[]): RankedTerritoriesResult {
+  if (attributions.length === 0) {
+    return { most: null, least: null }
+  }
+
+  const countByTerritory = new Map<string, number>()
+  for (const a of attributions) {
+    countByTerritory.set(a.territoryNumber, (countByTerritory.get(a.territoryNumber) ?? 0) + 1)
+  }
+
+  let most: RankedTerritory | null = null
+  let least: RankedTerritory | null = null
+
+  for (const [number, count] of countByTerritory) {
+    if (most == null || count > most.count) {
+      most = { number, count }
+    }
+    if (least == null || count < least.count) {
+      least = { number, count }
+    }
+  }
+
+  return { most, least }
+}

--- a/app/features/territories/server/compute-rest-period-utilization.server.test.ts
+++ b/app/features/territories/server/compute-rest-period-utilization.server.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsAttribution } from './stats-attribution.type'
+import { computeRestPeriodUtilization } from './compute-rest-period-utilization.server'
+
+function makeAttribution(
+  territoryId: number,
+  type: TerritoryAttributionKind,
+  startDate: Date,
+  endDate: Date | null,
+  id = 1,
+): StatsAttribution {
+  return {
+    id,
+    territoryId,
+    territoryNumber: `T-${territoryId}`,
+    territoryType: TerritoryKind.Classical,
+    type,
+    startDate,
+    endDate,
+    lateDate: new Date(2026, 0, 1),
+  }
+}
+
+describe('computeRestPeriodUtilization', () => {
+  it('retourne 0 quand il n\'y a aucune attribution', () => {
+    expect(computeRestPeriodUtilization([])).toBe(0)
+  })
+
+  it('retourne 0 quand il n\'y a qu\'une seule attribution par territoire', () => {
+    const attributions = [
+      makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 0, 1), new Date(2025, 1, 1)),
+    ]
+    expect(computeRestPeriodUtilization(attributions)).toBe(0)
+  })
+
+  it('retourne 0 quand le territoire est repris pendant la période de repos', () => {
+    // Le repos pour porte-à-porte est de 90 jours
+    // Attribution se termine le 1er jan, repos finit le 1er avril
+    // Prochaine attribution commence le 1er mars (pendant le repos)
+    const attributions = [
+      makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 0, 1), new Date(2025, 0, 31), 1),
+      makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 2, 1), new Date(2025, 3, 1), 2),
+    ]
+    // La prochaine attribution commence avant la fin du repos → pas d'inactivité post-repos
+    expect(computeRestPeriodUtilization(attributions)).toBe(0)
+  })
+
+  it('calcule les jours d\'inactivité après la fin du repos', () => {
+    // Le repos pour campagne est de 15 jours
+    // Attribution se termine le 1er jan, repos finit le 16 jan
+    // Prochaine attribution commence le 26 jan = 10 jours d'inactivité post-repos
+    const attributions = [
+      makeAttribution(1, TerritoryAttributionKind.Campaign, new Date(2024, 11, 1), new Date(2025, 0, 1), 1),
+      makeAttribution(1, TerritoryAttributionKind.Campaign, new Date(2025, 0, 26), new Date(2025, 1, 26), 2),
+    ]
+    expect(computeRestPeriodUtilization(attributions)).toBe(10)
+  })
+})

--- a/app/features/territories/server/compute-rest-period-utilization.server.test.ts
+++ b/app/features/territories/server/compute-rest-period-utilization.server.test.ts
@@ -47,7 +47,7 @@ describe('computeRestPeriodUtilization', () => {
     expect(computeRestPeriodUtilization(attributions)).toBe(0)
   })
 
-  it('calcule les jours d\'inactivité après la fin du repos', () => {
+  it('calcule les jours d\'inactivité après la fin du repos (campagne, 15j)', () => {
     // Le repos pour campagne est de 15 jours
     // Attribution se termine le 1er jan, repos finit le 16 jan
     // Prochaine attribution commence le 26 jan = 10 jours d'inactivité post-repos
@@ -56,5 +56,24 @@ describe('computeRestPeriodUtilization', () => {
       makeAttribution(1, TerritoryAttributionKind.Campaign, new Date(2025, 0, 26), new Date(2025, 1, 26), 2),
     ]
     expect(computeRestPeriodUtilization(attributions)).toBe(10)
+  })
+
+  it('utilise la période de repos téléphone (15 jours)', () => {
+    // Attribution téléphone se termine le 1er jan, repos finit le 16 jan
+    // Prochaine attribution commence le 26 jan = 10 jours d'inactivité post-repos
+    const attributions = [
+      makeAttribution(1, TerritoryAttributionKind.Phone, new Date(2024, 11, 1), new Date(2025, 0, 1), 1),
+      makeAttribution(1, TerritoryAttributionKind.Phone, new Date(2025, 0, 26), new Date(2025, 1, 26), 2),
+    ]
+    expect(computeRestPeriodUtilization(attributions)).toBe(10)
+  })
+
+  it('ignore les attributions en cours (endDate null)', () => {
+    const attributions = [
+      makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 0, 1), null, 1),
+      makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 6, 1), new Date(2025, 7, 1), 2),
+    ]
+    // Première attribution sans endDate → impossible de calculer la fin de repos
+    expect(computeRestPeriodUtilization(attributions)).toBe(0)
   })
 })

--- a/app/features/territories/server/compute-rest-period-utilization.server.ts
+++ b/app/features/territories/server/compute-rest-period-utilization.server.ts
@@ -1,0 +1,56 @@
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import {
+  RESTING_PERIOD_FOR_CAMPAIGN,
+  RESTING_PERIOD_FOR_DOORS_TO_DOORS,
+  RESTING_PERIOD_FOR_PHONE,
+} from './resting-periods.server'
+import type { StatsAttribution } from './stats-attribution.type'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function getRestingPeriodMs(attributionType: string): number {
+  switch (attributionType) {
+    case TerritoryAttributionKind.Campaign:
+      return RESTING_PERIOD_FOR_CAMPAIGN
+    case TerritoryAttributionKind.Phone:
+      return RESTING_PERIOD_FOR_PHONE
+    default:
+      return RESTING_PERIOD_FOR_DOORS_TO_DOORS
+  }
+}
+
+// Calcule le nombre moyen de jours d'inactivité après la fin du repos, avant la prochaine attribution
+export function computeRestPeriodUtilization(attributions: StatsAttribution[]): number {
+  // Regrouper par territoire (déjà triées par startDate)
+  const byTerritory = new Map<number, StatsAttribution[]>()
+  for (const a of attributions) {
+    const list = byTerritory.get(a.territoryId) ?? []
+    list.push(a)
+    byTerritory.set(a.territoryId, list)
+  }
+
+  const idleDays: number[] = []
+
+  for (const territoryAttributions of byTerritory.values()) {
+    for (let i = 0; i < territoryAttributions.length - 1; i++) {
+      const current = territoryAttributions[i]
+      const next = territoryAttributions[i + 1]
+
+      if (current.endDate == null) continue
+
+      const restPeriodMs = getRestingPeriodMs(current.type)
+      const restEndDate = new Date(current.endDate.getTime() + restPeriodMs)
+
+      // Si la prochaine attribution commence après la fin du repos
+      if (next.startDate.getTime() > restEndDate.getTime()) {
+        const idle = (next.startDate.getTime() - restEndDate.getTime()) / MS_PER_DAY
+        idleDays.push(idle)
+      }
+    }
+  }
+
+  if (idleDays.length === 0) return 0
+
+  const sum = idleDays.reduce((acc, d) => acc + d, 0)
+  return Math.round(sum / idleDays.length)
+}

--- a/app/features/territories/server/fetch-attributions-by-group.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    attribution: { findMany: vi.fn() },
+  },
+}))
+
+const { fetchActiveAttributionsByGroup } = await import('./fetch-attributions-by-group.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('fetchActiveAttributionsByGroup', () => {
+  it('retourne les attributions actives regroupées par groupe', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([
+      { publisher: { publisherGroup: { name: 'Groupe A' } } },
+      { publisher: { publisherGroup: { name: 'Groupe A' } } },
+      { publisher: { publisherGroup: { name: 'Groupe B' } } },
+    ] as never)
+
+    const result = await fetchActiveAttributionsByGroup()
+
+    expect(result).toEqual([
+      { groupName: 'Groupe A', count: 2 },
+      { groupName: 'Groupe B', count: 1 },
+    ])
+  })
+
+  it('regroupe les proclamateurs sans groupe sous "Sans groupe"', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([
+      { publisher: { publisherGroup: null } },
+      { publisher: { publisherGroup: { name: 'Groupe A' } } },
+    ] as never)
+
+    const result = await fetchActiveAttributionsByGroup()
+
+    expect(result).toEqual([
+      { groupName: 'Sans groupe', count: 1 },
+      { groupName: 'Groupe A', count: 1 },
+    ])
+  })
+
+  it('retourne un tableau vide quand il n\'y a aucune attribution active', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([])
+
+    const result = await fetchActiveAttributionsByGroup()
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/territories/server/fetch-attributions-by-group.server.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.ts
@@ -1,0 +1,33 @@
+import { db } from '~/shared/libs/db.server'
+
+export interface AttributionsByGroup {
+  groupName: string
+  count: number
+}
+
+// Compte les attributions actives (en cours) regroupées par groupe de prédication
+export async function fetchActiveAttributionsByGroup(): Promise<AttributionsByGroup[]> {
+  const attributions = await db.attribution.findMany({
+    where: { endDate: null },
+    select: {
+      publisher: {
+        select: {
+          publisherGroup: {
+            select: { name: true },
+          },
+        },
+      },
+    },
+  })
+
+  const countByGroup = new Map<string, number>()
+
+  for (const a of attributions) {
+    const groupName = a.publisher.publisherGroup?.name ?? 'Sans groupe'
+    countByGroup.set(groupName, (countByGroup.get(groupName) ?? 0) + 1)
+  }
+
+  return Array.from(countByGroup.entries())
+    .map(([groupName, count]) => ({ groupName, count }))
+    .sort((a, b) => b.count - a.count)
+}

--- a/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
@@ -62,4 +62,18 @@ describe('fetchAttributionsForStats', () => {
 
     expect(result).toEqual([])
   })
+
+  it('fonctionne avec un filtre de groupe', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([])
+
+    const result = await fetchAttributionsForStats({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+      groupId: 42,
+    })
+
+    expect(result).toEqual([])
+  })
 })

--- a/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    attribution: { findMany: vi.fn() },
+  },
+}))
+
+const { fetchAttributionsForStats } = await import('./fetch-attributions-for-stats.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('fetchAttributionsForStats', () => {
+  it('retourne les attributions formatées', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([
+      {
+        id: 1,
+        territoryId: 10,
+        territory: { number: 'T-1', type: 'doors-to-doors' },
+        type: 'default',
+        startDate: new Date(2025, 9, 1),
+        endDate: new Date(2025, 10, 15),
+        lateDate: new Date(2025, 11, 1),
+      },
+    ] as never)
+
+    const result = await fetchAttributionsForStats({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+    })
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        territoryId: 10,
+        territoryNumber: 'T-1',
+        territoryType: TerritoryKind.Classical,
+        type: 'default',
+        startDate: new Date(2025, 9, 1),
+        endDate: new Date(2025, 10, 15),
+        lateDate: new Date(2025, 11, 1),
+      },
+    ])
+  })
+
+  it('retourne un tableau vide quand il n\'y a aucune attribution', async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([])
+
+    const result = await fetchAttributionsForStats({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+    })
+
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/territories/server/fetch-attributions-for-stats.server.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.ts
@@ -1,0 +1,52 @@
+import type { Prisma } from '~/database/generated/client'
+import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { db } from '~/shared/libs/db.server'
+import type { StatsAttribution } from './stats-attribution.type'
+import type { StatsFilterParams } from './stats-filter-params.type'
+
+function buildDateOverlapWhere(startDate: Date, endDate: Date): Prisma.AttributionWhereInput {
+  return {
+    startDate: { lte: endDate },
+    // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+    OR: [{ endDate: null }, { endDate: { gte: startDate } }],
+  }
+}
+
+export async function fetchAttributionsForStats(params: StatsFilterParams): Promise<StatsAttribution[]> {
+  const attributions = await db.attribution.findMany({
+    where: {
+      territory: {
+        type: { in: params.territoryKind },
+      },
+      type: { in: params.attributionKind },
+      ...buildDateOverlapWhere(params.startDate, params.endDate),
+      ...(params.groupId != null ? { publisher: { publisherGroupId: params.groupId } } : {}),
+    },
+    select: {
+      id: true,
+      territoryId: true,
+      territory: {
+        select: {
+          number: true,
+          type: true,
+        },
+      },
+      type: true,
+      startDate: true,
+      endDate: true,
+      lateDate: true,
+    },
+    orderBy: [{ territoryId: 'asc' }, { startDate: 'asc' }],
+  })
+
+  return attributions.map(a => ({
+    id: a.id,
+    territoryId: a.territoryId,
+    territoryNumber: a.territory.number,
+    territoryType: a.territory.type as TerritoryKind,
+    type: a.type as StatsAttribution['type'],
+    startDate: a.startDate,
+    endDate: a.endDate,
+    lateDate: a.lateDate,
+  }))
+}

--- a/app/features/territories/server/fetch-territory-counts.server.test.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.test.ts
@@ -7,7 +7,8 @@ vi.mock('~/shared/libs/db.server', () => ({
   },
 }))
 
-const { fetchTerritoryCounts, getTotalTerritoryCount } = await import('./fetch-territory-counts.server')
+const { fetchTerritoryCounts } = await import('./fetch-territory-counts.server')
+const { getTotalTerritoryCount } = await import('./territory-count-by-type.type')
 const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
@@ -27,6 +28,16 @@ describe('fetchTerritoryCounts', () => {
       { type: TerritoryKind.Classical, count: 30 },
       { type: TerritoryKind.Commerces, count: 5 },
     ])
+  })
+
+  it('fonctionne sans filtre de types', async () => {
+    vi.mocked(db.territory.groupBy).mockResolvedValue([
+      { type: 'doors-to-doors', _count: { id: 20 } },
+    ] as never)
+
+    const result = await fetchTerritoryCounts()
+
+    expect(result).toEqual([{ type: TerritoryKind.Classical, count: 20 }])
   })
 })
 

--- a/app/features/territories/server/fetch-territory-counts.server.test.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { groupBy: vi.fn() },
+  },
+}))
+
+const { fetchTerritoryCounts, getTotalTerritoryCount } = await import('./fetch-territory-counts.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('fetchTerritoryCounts', () => {
+  it('retourne les compteurs par type', async () => {
+    vi.mocked(db.territory.groupBy).mockResolvedValue([
+      { type: 'doors-to-doors', _count: { id: 30 } },
+      { type: 'commerces', _count: { id: 5 } },
+    ] as never)
+
+    const result = await fetchTerritoryCounts([TerritoryKind.Classical, TerritoryKind.Commerces])
+
+    expect(result).toEqual([
+      { type: TerritoryKind.Classical, count: 30 },
+      { type: TerritoryKind.Commerces, count: 5 },
+    ])
+  })
+})
+
+describe('getTotalTerritoryCount', () => {
+  it('retourne la somme des compteurs', () => {
+    const counts = [
+      { type: TerritoryKind.Classical, count: 30 },
+      { type: TerritoryKind.Commerces, count: 5 },
+    ]
+    expect(getTotalTerritoryCount(counts)).toBe(35)
+  })
+
+  it('retourne 0 pour un tableau vide', () => {
+    expect(getTotalTerritoryCount([])).toBe(0)
+  })
+})

--- a/app/features/territories/server/fetch-territory-counts.server.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.ts
@@ -1,10 +1,9 @@
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { db } from '~/shared/libs/db.server'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 
-export interface TerritoryCountByType {
-  type: TerritoryKind
-  count: number
-}
+export type { TerritoryCountByType } from './territory-count-by-type.type'
+export { getTotalTerritoryCount } from './territory-count-by-type.type'
 
 export async function fetchTerritoryCounts(territoryKinds?: TerritoryKind[]): Promise<TerritoryCountByType[]> {
   const groups = await db.territory.groupBy({
@@ -17,8 +16,4 @@ export async function fetchTerritoryCounts(territoryKinds?: TerritoryKind[]): Pr
     type: g.type as TerritoryKind,
     count: g._count.id,
   }))
-}
-
-export function getTotalTerritoryCount(counts: TerritoryCountByType[]): number {
-  return counts.reduce((sum, c) => sum + c.count, 0)
 }

--- a/app/features/territories/server/fetch-territory-counts.server.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.ts
@@ -1,0 +1,24 @@
+import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { db } from '~/shared/libs/db.server'
+
+export interface TerritoryCountByType {
+  type: TerritoryKind
+  count: number
+}
+
+export async function fetchTerritoryCounts(territoryKinds?: TerritoryKind[]): Promise<TerritoryCountByType[]> {
+  const groups = await db.territory.groupBy({
+    by: ['type'],
+    _count: { id: true },
+    ...(territoryKinds != null && territoryKinds.length > 0 ? { where: { type: { in: territoryKinds } } } : {}),
+  })
+
+  return groups.map(g => ({
+    type: g.type as TerritoryKind,
+    count: g._count.id,
+  }))
+}
+
+export function getTotalTerritoryCount(counts: TerritoryCountByType[]): number {
+  return counts.reduce((sum, c) => sum + c.count, 0)
+}

--- a/app/features/territories/server/parse-stats-filter-params.server.test.ts
+++ b/app/features/territories/server/parse-stats-filter-params.server.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { parseStatsFilterParams } from './parse-stats-filter-params.server'
+
+describe('parseStatsFilterParams', () => {
+  it('retourne les valeurs par défaut quand aucun paramètre n\'est fourni', () => {
+    const params = new URLSearchParams()
+    const result = parseStatsFilterParams(params, 2025)
+
+    expect(result.territoryKind).toEqual([TerritoryKind.Classical])
+    expect(result.attributionKind).toEqual([TerritoryAttributionKind.Default])
+    expect(result.startDate).toEqual(new Date(2025, 8, 1))
+    expect(result.endDate).toEqual(new Date(2026, 7, 31))
+    expect(result.groupId).toBeUndefined()
+  })
+
+  it('utilise les paramètres fournis', () => {
+    const params = new URLSearchParams()
+    params.append('kind', TerritoryKind.Phone)
+    params.append('kind', TerritoryKind.Commerces)
+    params.append('attributionKind', TerritoryAttributionKind.Campaign)
+    params.set('startDate', '2025-01-01')
+    params.set('endDate', '2025-06-30')
+    params.set('group', '42')
+
+    const result = parseStatsFilterParams(params, 2025)
+
+    expect(result.territoryKind).toEqual([TerritoryKind.Phone, TerritoryKind.Commerces])
+    expect(result.attributionKind).toEqual([TerritoryAttributionKind.Campaign])
+    expect(result.startDate).toEqual(new Date('2025-01-01'))
+    expect(result.endDate).toEqual(new Date('2025-06-30'))
+    expect(result.groupId).toBe(42)
+  })
+
+  it('ignore le groupe quand la valeur est "none"', () => {
+    const params = new URLSearchParams()
+    params.set('group', 'none')
+
+    const result = parseStatsFilterParams(params, 2025)
+    expect(result.groupId).toBeUndefined()
+  })
+})

--- a/app/features/territories/server/parse-stats-filter-params.server.ts
+++ b/app/features/territories/server/parse-stats-filter-params.server.ts
@@ -1,0 +1,23 @@
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { StatsFilterParams } from './stats-filter-params.type'
+import { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } from './theocratic-year.server'
+
+export function parseStatsFilterParams(params: URLSearchParams, theocraticYear: number): StatsFilterParams {
+  const kinds = params.getAll('kind') as TerritoryKind[]
+  const attributionKinds = params.getAll('attributionKind') as TerritoryAttributionKind[]
+
+  return {
+    territoryKind: kinds.length > 0 ? kinds : [TerritoryKind.Classical],
+    attributionKind: attributionKinds.length > 0 ? attributionKinds : [TerritoryAttributionKind.Default],
+    startDate: params.get('startDate') != null
+      ? new Date(String(params.get('startDate')))
+      : getBeginingDateOfTheocraticYear(theocraticYear),
+    endDate: params.get('endDate') != null
+      ? new Date(String(params.get('endDate')))
+      : getEndDateOfTheocraticYear(theocraticYear),
+    groupId: params.get('group') != null && params.get('group') !== 'none'
+      ? Number(params.get('group'))
+      : undefined,
+  }
+}

--- a/app/features/territories/server/stats-attribution.type.ts
+++ b/app/features/territories/server/stats-attribution.type.ts
@@ -1,0 +1,13 @@
+import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+export interface StatsAttribution {
+  id: number
+  territoryId: number
+  territoryNumber: string
+  territoryType: TerritoryKind
+  type: TerritoryAttributionKind
+  startDate: Date
+  endDate: Date | null
+  lateDate: Date
+}

--- a/app/features/territories/server/stats-filter-params.type.ts
+++ b/app/features/territories/server/stats-filter-params.type.ts
@@ -1,0 +1,10 @@
+import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+export interface StatsFilterParams {
+  territoryKind: TerritoryKind[]
+  attributionKind: TerritoryAttributionKind[]
+  startDate: Date
+  endDate: Date
+  groupId?: number
+}

--- a/app/features/territories/server/territories-never-worked.server.test.ts
+++ b/app/features/territories/server/territories-never-worked.server.test.ts
@@ -47,4 +47,20 @@ describe('getTerritoriesNeverWorked', () => {
 
     expect(result).toEqual([])
   })
+
+  it('fonctionne avec un filtre de groupe', async () => {
+    vi.mocked(db.territory.findMany).mockResolvedValue([
+      { id: 3, number: 'T-3' },
+    ] as never)
+
+    const result = await getTerritoriesNeverWorked({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+      groupId: 7,
+    })
+
+    expect(result).toEqual([{ id: 3, number: 'T-3' }])
+  })
 })

--- a/app/features/territories/server/territories-never-worked.server.test.ts
+++ b/app/features/territories/server/territories-never-worked.server.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    territory: { findMany: vi.fn() },
+  },
+}))
+
+const { getTerritoriesNeverWorked } = await import('./territories-never-worked.server')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('getTerritoriesNeverWorked', () => {
+  it('retourne les territoires sans attributions sur la période', async () => {
+    vi.mocked(db.territory.findMany).mockResolvedValue([
+      { id: 5, number: 'T-5' },
+      { id: 12, number: 'T-12' },
+    ] as never)
+
+    const result = await getTerritoriesNeverWorked({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+    })
+
+    expect(result).toEqual([
+      { id: 5, number: 'T-5' },
+      { id: 12, number: 'T-12' },
+    ])
+  })
+
+  it('retourne un tableau vide quand tous les territoires ont été travaillés', async () => {
+    vi.mocked(db.territory.findMany).mockResolvedValue([])
+
+    const result = await getTerritoriesNeverWorked({
+      territoryKind: [TerritoryKind.Classical],
+      attributionKind: [TerritoryAttributionKind.Default],
+      startDate: new Date(2025, 8, 1),
+      endDate: new Date(2026, 7, 31),
+    })
+
+    expect(result).toEqual([])
+  })
+})

--- a/app/features/territories/server/territories-never-worked.server.ts
+++ b/app/features/territories/server/territories-never-worked.server.ts
@@ -1,0 +1,36 @@
+import type { Prisma } from '~/database/generated/client'
+import { db } from '~/shared/libs/db.server'
+import type { StatsFilterParams } from './stats-filter-params.type'
+
+export interface NeverWorkedTerritory {
+  id: number
+  number: string
+}
+
+export async function getTerritoriesNeverWorked(params: StatsFilterParams): Promise<NeverWorkedTerritory[]> {
+  const dateOverlap: Prisma.AttributionWhereInput = {
+    startDate: { lte: params.endDate },
+    // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+    OR: [{ endDate: null }, { endDate: { gte: params.startDate } }],
+  }
+
+  const territories = await db.territory.findMany({
+    where: {
+      type: { in: params.territoryKind },
+      attributions: {
+        none: {
+          type: { in: params.attributionKind },
+          ...dateOverlap,
+          ...(params.groupId != null ? { publisher: { publisherGroupId: params.groupId } } : {}),
+        },
+      },
+    },
+    select: {
+      id: true,
+      number: true,
+    },
+    orderBy: { number: 'asc' },
+  })
+
+  return territories
+}

--- a/app/features/territories/server/territory-count-by-type.type.ts
+++ b/app/features/territories/server/territory-count-by-type.type.ts
@@ -1,0 +1,10 @@
+import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+
+export interface TerritoryCountByType {
+  type: TerritoryKind
+  count: number
+}
+
+export function getTotalTerritoryCount(counts: TerritoryCountByType[]): number {
+  return counts.reduce((sum, c) => sum + c.count, 0)
+}

--- a/app/features/territories/ui/AttributionsPerMonthChart.tsx
+++ b/app/features/territories/ui/AttributionsPerMonthChart.tsx
@@ -1,0 +1,47 @@
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import type { MonthlyCount } from '~/features/territories/server/compute-attributions-per-month.server'
+
+const MONTH_LABELS: Record<string, string> = {
+  '01': 'Jan',
+  '02': 'Fév',
+  '03': 'Mar',
+  '04': 'Avr',
+  '05': 'Mai',
+  '06': 'Juin',
+  '07': 'Juil',
+  '08': 'Août',
+  '09': 'Sep',
+  '10': 'Oct',
+  '11': 'Nov',
+  '12': 'Déc',
+}
+
+function formatMonth(month: string): string {
+  const [, m] = month.split('-')
+  return MONTH_LABELS[m] ?? m
+}
+
+export default function AttributionsPerMonthChart({ data }: { data: MonthlyCount[] }) {
+  if (data.length === 0) return null
+
+  const chartData = data.map(d => ({ name: formatMonth(d.month), count: d.count }))
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="name" className="text-xs" tick={{ fill: 'var(--color-muted-foreground)' }} />
+        <YAxis allowDecimals={false} className="text-xs" tick={{ fill: 'var(--color-muted-foreground)' }} />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: 'var(--color-card)',
+            border: '1px solid var(--color-border)',
+            borderRadius: '0.5rem',
+          }}
+          labelStyle={{ color: 'var(--color-card-foreground)' }}
+        />
+        <Bar dataKey="count" name="Attributions" fill="var(--color-chart-1)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/app/features/territories/ui/MonthlyCoverageChart.tsx
+++ b/app/features/territories/ui/MonthlyCoverageChart.tsx
@@ -1,0 +1,56 @@
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import type { MonthlyCoverage } from '~/features/territories/server/compute-monthly-coverage-evolution.server'
+
+const MONTH_LABELS: Record<string, string> = {
+  '01': 'Jan',
+  '02': 'Fév',
+  '03': 'Mar',
+  '04': 'Avr',
+  '05': 'Mai',
+  '06': 'Juin',
+  '07': 'Juil',
+  '08': 'Août',
+  '09': 'Sep',
+  '10': 'Oct',
+  '11': 'Nov',
+  '12': 'Déc',
+}
+
+function formatMonth(month: string): string {
+  const [, m] = month.split('-')
+  return MONTH_LABELS[m] ?? m
+}
+
+export default function MonthlyCoverageChart({ data }: { data: MonthlyCoverage[] }) {
+  if (data.length === 0) return null
+
+  const chartData = data.map(d => ({ name: formatMonth(d.month), coverage: d.coverage }))
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+        <XAxis dataKey="name" className="text-xs" tick={{ fill: 'var(--color-muted-foreground)' }} />
+        <YAxis unit=" %" className="text-xs" tick={{ fill: 'var(--color-muted-foreground)' }} />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: 'var(--color-card)',
+            border: '1px solid var(--color-border)',
+            borderRadius: '0.5rem',
+          }}
+          labelStyle={{ color: 'var(--color-card-foreground)' }}
+          formatter={(value) => [`${Number(value).toFixed(1)} %`, 'Couverture']}
+        />
+        <Line
+          type="monotone"
+          dataKey="coverage"
+          name="Couverture"
+          stroke="var(--color-chart-1)"
+          strokeWidth={2}
+          dot={{ fill: 'var(--color-chart-1)', r: 4 }}
+          activeDot={{ r: 6 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/app/features/territories/ui/TerritoriesNeverWorkedList.tsx
+++ b/app/features/territories/ui/TerritoriesNeverWorkedList.tsx
@@ -1,0 +1,43 @@
+import { MapPinOff } from 'lucide-react'
+import type { NeverWorkedTerritory } from '~/features/territories/server/territories-never-worked.server'
+import { Badge } from '~/shared/ui/badge'
+import { EmptyState } from '~/shared/ui/EmptyState'
+
+const MAX_DISPLAY = 20
+
+export default function TerritoriesNeverWorkedList({
+  territories,
+}: { territories: NeverWorkedTerritory[] }) {
+  if (territories.length === 0) {
+    return (
+      <EmptyState
+        icon={MapPinOff}
+        title="Tous les territoires ont été travaillés"
+        description="Chaque territoire a eu au moins une attribution sur la période."
+      />
+    )
+  }
+
+  const displayed = territories.slice(0, MAX_DISPLAY)
+  const remaining = territories.length - MAX_DISPLAY
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-muted-foreground text-sm">
+        {territories.length} territoire{territories.length > 1 ? 's' : ''} sans aucune attribution sur la période :
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {displayed.map(t => (
+          <Badge key={t.id} variant="outline">
+            {t.number}
+          </Badge>
+        ))}
+        {remaining > 0 && (
+          <Badge variant="secondary">
+            +{remaining} autres
+          </Badge>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/features/territories/ui/YearOverYearTable.tsx
+++ b/app/features/territories/ui/YearOverYearTable.tsx
@@ -1,0 +1,116 @@
+import { TrendingDown, TrendingUp } from 'lucide-react'
+
+interface YearMetrics {
+  coverage: number
+  totalCoverage: number
+  averageDurationDays: number
+  overdueRate: number
+  attributionCount: number
+}
+
+interface YearOverYearTableProps {
+  current: YearMetrics
+  previous: YearMetrics
+  currentLabel: string
+  previousLabel: string
+}
+
+interface MetricRow {
+  label: string
+  currentValue: string
+  previousValue: string
+  delta: number
+  unit: string
+  invertedBetter?: boolean // true si une baisse est positive (ex: taux de retard)
+}
+
+function formatDelta(delta: number, unit: string): string {
+  const sign = delta > 0 ? '+' : ''
+  return `${sign}${delta.toFixed(1)}${unit}`
+}
+
+export default function YearOverYearTable({
+  current,
+  previous,
+  currentLabel,
+  previousLabel,
+}: YearOverYearTableProps) {
+  const rows: MetricRow[] = [
+    {
+      label: 'Couverture du territoire',
+      currentValue: `${current.coverage.toFixed(1)} %`,
+      previousValue: `${previous.coverage.toFixed(1)} %`,
+      delta: current.coverage - previous.coverage,
+      unit: ' %',
+    },
+    {
+      label: 'Couverture complète',
+      currentValue: `${current.totalCoverage.toFixed(1)} %`,
+      previousValue: `${previous.totalCoverage.toFixed(1)} %`,
+      delta: current.totalCoverage - previous.totalCoverage,
+      unit: ' %',
+    },
+    {
+      label: 'Durée moy. des attributions',
+      currentValue: `${current.averageDurationDays} j`,
+      previousValue: `${previous.averageDurationDays} j`,
+      delta: current.averageDurationDays - previous.averageDurationDays,
+      unit: ' j',
+    },
+    {
+      label: 'Taux de retard',
+      currentValue: `${current.overdueRate.toFixed(1)} %`,
+      previousValue: `${previous.overdueRate.toFixed(1)} %`,
+      delta: current.overdueRate - previous.overdueRate,
+      unit: ' %',
+      invertedBetter: true,
+    },
+    {
+      label: 'Nombre d\'attributions',
+      currentValue: String(current.attributionCount),
+      previousValue: String(previous.attributionCount),
+      delta: current.attributionCount - previous.attributionCount,
+      unit: '',
+    },
+  ]
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-3 font-medium">Indicateur</th>
+            <th className="pb-3 text-right font-medium">{currentLabel}</th>
+            <th className="pb-3 text-right font-medium">{previousLabel}</th>
+            <th className="pb-3 text-right font-medium">Évolution</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => {
+            const isPositive = row.invertedBetter ? row.delta < 0 : row.delta > 0
+            const isNeutral = Math.abs(row.delta) < 0.1
+
+            return (
+              <tr key={row.label} className="border-b last:border-0">
+                <td className="py-3 font-medium">{row.label}</td>
+                <td className="py-3 text-right font-display font-semibold">{row.currentValue}</td>
+                <td className="py-3 text-right text-muted-foreground">{row.previousValue}</td>
+                <td className="py-3 text-right">
+                  <span
+                    className={`inline-flex items-center gap-1 ${
+                      isNeutral ? 'text-muted-foreground' : isPositive ? 'text-emerald-600' : 'text-red-500'
+                    }`}
+                  >
+                    {!isNeutral &&
+                      (isPositive ? <TrendingUp className="size-3.5" /> : <TrendingDown className="size-3.5" />)}
+                    {formatDelta(row.delta, row.unit)}
+                  </span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds **attribution-based analytics**: most/least worked territory, average/longest/shortest duration, overdue rate, availability gap between attributions, monthly attributions bar chart, and group distribution pie chart
- Adds **coverage over time** section: monthly cumulative coverage line chart, coverage breakdown by territory type, and list of territories never worked in the period
- Adds **year-over-year comparison** table with trend indicators (current vs previous theocratic year)
- Refactors the stats loader to use a bulk fetch + pure computation pattern with `Promise.all` for parallel DB queries (replaces sequential calls)
- Introduces 13 new service functions (8 pure computation, 3 data fetchers, 1 DB query, 1 param parser) with 33 new unit tests

## Test plan

- [x] `pnpm test:unit` — 299 tests passing (33 new)
- [x] `pnpm test:typecheck` — clean
- [x] `pnpm test:lint` — clean
- [x] Manual: navigate to stats page, verify all cards render, charts display, filters apply to all sections, year-over-year shows both years