### PR TITLE
refactor: move Google Maps config from DB settings to env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ RESEND_API_KEY="re_123"
 SESSION_SECRET="your-secret-key"
 REDIS_HOST="localhost"
 REDIS_PORT="6379"
+GOOGLE_MAPS_API_KEY=""              # Optional — enables maps on territory pages and PDF exports
+GOOGLE_MAPS_MAP_ID=""               # Optional — enables custom styled maps
 ```
 
 ## Architecture Overview

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -38,8 +38,6 @@ export async function loader({ request }: Route.LoaderArgs) {
   const zips = await getAllowedZips()
   const banoUrl = await getSetting(TerritorySettingKey.BanoUrl)
   const prospectionValidity = await getSetting(TerritorySettingKey.ProspectionValidity)
-  const mapId = await getSetting(TerritorySettingKey.GoogleMapsMapId)
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
   const phoneTypeActivated = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   return {
@@ -47,14 +45,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     zips: serializeZips(zips),
     banoUrl: banoUrl ?? '',
     prospectionValidity: Number(prospectionValidity ?? '24'),
-    apiKey: apiKey ?? '',
-    mapId: mapId ?? '',
     phoneTypeActivated: phoneTypeActivated ?? false,
   }
 }
 
 export default function BuildingSettingsPage({ loaderData }: Route.ComponentProps) {
-  const { territory, zips, banoUrl, prospectionValidity, mapId, apiKey, phoneTypeActivated } = loaderData
+  const { territory, zips, banoUrl, prospectionValidity, phoneTypeActivated } = loaderData
 
   return (
     <div className="flex flex-col gap-6">
@@ -132,36 +128,6 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>APIs externes</CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
-            <div className="flex gap-4 max-sm:flex-col">
-              <div className="flex-1 space-y-2">
-                <Label htmlFor="api-google-map">Clé d'API Google Map</Label>
-                <Input
-                  id="api-google-map"
-                  name="api-google-map"
-                  type="text"
-                  placeholder="Entrez la clé d'API du compte Google Maps de l'assemblée"
-                  defaultValue={apiKey}
-                />
-              </div>
-              <div className="flex-1 space-y-2">
-                <Label htmlFor="mapid-google-map">Identifiant de carte Google Map</Label>
-                <Input
-                  id="mapid-google-map"
-                  name="mapid-google-map"
-                  type="text"
-                  placeholder="Entrez un identifiant de carte"
-                  defaultValue={mapId}
-                />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         <Button type="submit">Enregistrer</Button>
       </Form>
     </div>
@@ -181,16 +147,12 @@ export async function action({ request }: Route.ActionArgs) {
   const territory = parseTerritoryPolygon(String(form.get('territory')))
   const banoUrl = String(form.get('bano-url'))
   const prospectionValidity = String(form.get('prospection-validity'))
-  const mapId = String(form.get('mapid-google-map'))
-  const apiKey = String(form.get('api-google-map'))
   const phoneTypeActivated = String(Boolean(form.get('phone-territory-active')))
 
   await setSetting(TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregation.id)
   await setSetting(TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregation.id)
   await setSetting(TerritorySettingKey.BanoUrl, banoUrl, congregation.id)
   await setSetting(TerritorySettingKey.ProspectionValidity, prospectionValidity, congregation.id)
-  await setSetting(TerritorySettingKey.GoogleMapsApiKey, apiKey, congregation.id)
-  await setSetting(TerritorySettingKey.GoogleMapsMapId, mapId, congregation.id)
   await setSetting(TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregation.id)
 
   return redirect('/settings')

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -4,13 +4,12 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
-import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -28,7 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)
   const selectors: Prisma.BuildingWhereInput = {

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -4,13 +4,12 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
-import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -28,7 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)
   const selectors: Prisma.BuildingWhereInput = {

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -4,7 +4,8 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getBoolSetting, getSetting } from '~/features/settings/server/settings'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
@@ -28,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -4,7 +4,8 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getBoolSetting, getSetting } from '~/features/settings/server/settings'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
@@ -28,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   if (!phoneTypeActive) {
     throw redirect('/territories/buildings/split-territories')

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -4,13 +4,12 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
-import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -28,7 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)
   const selectors: Prisma.BuildingWhereInput = {

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -4,7 +4,8 @@ import { Form, Link, redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getBoolSetting, getSetting } from '~/features/settings/server/settings'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import {
@@ -53,8 +54,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       status: 404,
     })
   }
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
-  const mapId = await getSetting(TerritorySettingKey.GoogleMapsMapId)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
+  const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const zips = await getAvailableZips(territory.type as TerritoryKind)

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -3,7 +3,8 @@ import { data, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getBoolSetting, getSetting } from '~/features/settings/server/settings'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
@@ -37,8 +38,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
-  const mapId = await getSetting(TerritorySettingKey.GoogleMapsMapId)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
+  const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
 
   const url = new URL(request.url)
   const selectors = await computeFilters(url.searchParams)

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -4,7 +4,8 @@ import { Form, Link, redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { getBoolSetting, getSetting } from '~/features/settings/server/settings'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
@@ -32,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const apiKey = await getSetting(TerritorySettingKey.GoogleMapsApiKey)
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const url = new URL(request.url)
   const zips = await db.building.groupBy({

--- a/app/shared/libs/env.server.ts
+++ b/app/shared/libs/env.server.ts
@@ -6,6 +6,10 @@ function requireEnv(name: string): string {
   return value
 }
 
+export function getOptionalEnv(name: string): string | undefined {
+  return process.env[name] || undefined
+}
+
 export function validateEnv() {
   requireEnv('DATABASE_URL')
   requireEnv('SESSION_SECRET')

--- a/app/shared/types/territory-setting-key.ts
+++ b/app/shared/types/territory-setting-key.ts
@@ -1,6 +1,4 @@
 export enum TerritorySettingKey {
-  GoogleMapsApiKey = 'google-map-api-key',
-  GoogleMapsMapId = 'google-map-mapid',
   TerritoryPolygone = 'territory',
   TerritoryZipCodes = 'zips',
   BanoUrl = 'bano-url',

--- a/docs/architecture-schema.md
+++ b/docs/architecture-schema.md
@@ -112,6 +112,21 @@ Key structure (same for both drivers):
 
 Self-hosted users need no S3 setup — document uploads work out of the box with local storage.
 
+## Google Maps Integration
+
+Territory features use Google Maps for interactive maps (building entrance locations) and static map images in territory PDF cards.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_MAPS_API_KEY` | No | Google Maps API key — enables map rendering on territory pages and static maps in PDF exports |
+| `GOOGLE_MAPS_MAP_ID` | No | Google Maps Map ID — enables custom styled maps (requires `GOOGLE_MAPS_API_KEY`) |
+
+When `GOOGLE_MAPS_API_KEY` is not set, map features are silently disabled: interactive maps are hidden and PDF territory cards skip the map page. Self-hosted users who don't need maps can leave these unset.
+
+The API key must have the following Google APIs enabled:
+- **Maps JavaScript API** — for interactive maps on territory and split-tool pages
+- **Maps Static API** — for map images in territory PDF cards
+
 ## Background Job Flow
 
 ```


### PR DESCRIPTION
## Summary

- Replaced per-congregation database settings (`google-map-api-key`, `google-map-mapid`) with environment variables (`GOOGLE_MAPS_API_KEY`, `GOOGLE_MAPS_MAP_ID`)
- Removed the "APIs externes" card from the territory settings page
- Added `getOptionalEnv()` helper to `env.server.ts` for reading optional env vars
- Documented the new env vars in `docs/architecture-schema.md` and `CLAUDE.md`

## Test plan

- [x] Set `GOOGLE_MAPS_API_KEY` in `.env`, verify interactive maps render on territory and split-tool pages
- [x] Verify territory PDF exports include the static map page when the env var is set
- [x] Verify maps are gracefully hidden when env vars are unset
- [x] Verify the territory settings page no longer shows the "APIs externes" card
- [x] `pnpm test:typecheck` passes
- [x] `pnpm test:lint` passes
- [x] `pnpm test:unit` passes (309 tests)