### PR TITLE
fix: enforce tenant isolation on multi-tenant session and login

### DIFF
--- a/app/database/seed.ts
+++ b/app/database/seed.ts
@@ -150,12 +150,12 @@ async function main() {
 
   // Create or get default congregation
   const defaultCongregation = await prisma.congregation.upsert({
-    where: { slug: 'lyon-confluence' },
+    where: { slug: 'ma-congregation' },
     update: {},
     create: {
-      name: 'Lyon Confluence',
-      slug: 'lyon-confluence',
-      domain: 'lyonconfluence.org',
+      name: 'Ma Congrégation',
+      slug: 'ma-congregation',
+      domain: 'ma-congregation.example.com',
     },
   })
 

--- a/app/features/authentication/routes/login.tsx
+++ b/app/features/authentication/routes/login.tsx
@@ -1,14 +1,15 @@
 import { data, Form, Link, redirect } from 'react-router'
 
-import { getBrandingName } from '~/shared/libs/congregation.server'
+import { getBrandingName, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { needSetupProcess } from '~/features/authentication/server/need-setup-process.server'
 import {
   checkLoginRateLimit,
   clearLoginAttempts,
   recordLoginAttempt,
 } from '~/features/authentication/server/rate-limit.server'
-import { commitSession, getSession } from '~/features/authentication/server/session.server'
+import { commitSession, destroySession, getSession } from '~/features/authentication/server/session.server'
 import { validateCredentials } from '~/features/authentication/server/validate-credentials.server'
+import { unscopedDb } from '~/shared/libs/db.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '~/shared/ui/card'
@@ -29,6 +30,21 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const session = await getSession(request.headers.get('Cookie'))
   if (session.has('userId') === true) {
+    // En mode multi-tenant, vérifier que la session correspond à l'assemblée du sous-domaine
+    const urlCongregation = await resolveCongregationFromRequest(request)
+    if (urlCongregation) {
+      const uid = Number(session.get('userId'))
+      const user = await unscopedDb.user.findUnique({
+        where: { id: uid },
+        select: { congregationId: true },
+      })
+      if (!user || user.congregationId !== urlCongregation.id) {
+        return data(
+          { error: undefined, brandingName: await getBrandingName(request) },
+          { headers: { 'Set-Cookie': await destroySession(session) } },
+        )
+      }
+    }
     throw redirect('/')
   }
 
@@ -102,7 +118,8 @@ export async function action({ request }: Route.ActionArgs) {
     })
   }
 
-  const userId = await validateCredentials(username, String(password))
+  const urlCongregation = await resolveCongregationFromRequest(request)
+  const userId = await validateCredentials(username, String(password), urlCongregation?.id)
 
   if (userId == null) {
     await recordLoginAttempt(username)

--- a/app/features/authentication/routes/register.tsx
+++ b/app/features/authentication/routes/register.tsx
@@ -64,7 +64,7 @@ export default function RegisterPage({ loaderData }: Route.ComponentProps) {
                 id="congregation-name"
                 name="congregation-name"
                 type="text"
-                placeholder="Lyon Confluence"
+                placeholder="Ma Congrégation"
                 required
               />
             </div>

--- a/app/features/authentication/server/session.server.ts
+++ b/app/features/authentication/server/session.server.ts
@@ -1,6 +1,6 @@
 import { createCookieSessionStorage, redirect } from 'react-router'
 
-import { resolveCongregation } from '~/shared/libs/congregation.server'
+import { resolveCongregation, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { congregationContext, unscopedDb } from '~/shared/libs/db.server'
 
 import { sanitizeUser } from './sanitize-user.server'
@@ -55,6 +55,16 @@ export async function verifySession(request: Request) {
   })
 
   if (user == null) {
+    throw redirect('/login', {
+      headers: {
+        'Set-Cookie': await destroySession(session),
+      },
+    })
+  }
+
+  // En mode multi-tenant, vérifier que le sous-domaine correspond à l'assemblée de l'utilisateur
+  const urlCongregation = await resolveCongregationFromRequest(request)
+  if (urlCongregation && urlCongregation.id !== user.congregationId) {
     throw redirect('/login', {
       headers: {
         'Set-Cookie': await destroySession(session),

--- a/app/features/authentication/server/validate-credentials.server.test.ts
+++ b/app/features/authentication/server/validate-credentials.server.test.ts
@@ -78,4 +78,24 @@ describe('validateCredentials', () => {
     expect(result).toBeUndefined()
     expect(result).not.toBe(sentinel)
   })
+
+  it('filtre par congregationId quand il est fourni', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(true as never)
+
+    await validateCredentials('test@example.com', 'motdepasse', 5)
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: { email: 'test@example.com', congregationId: 5 },
+    })
+  })
+
+  it('ne filtre pas par congregationId quand il n\'est pas fourni', async () => {
+    vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
+    vi.mocked(compare).mockResolvedValue(true as never)
+
+    await validateCredentials('test@example.com', 'motdepasse')
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: { email: 'test@example.com' },
+    })
+  })
 })

--- a/app/features/authentication/server/validate-credentials.server.ts
+++ b/app/features/authentication/server/validate-credentials.server.ts
@@ -1,10 +1,11 @@
 import { compare } from '~/shared/libs/crypto.server'
 import { unscopedDb as db } from '~/shared/libs/db.server'
 
-export async function validateCredentials(email: string, password: string) {
+export async function validateCredentials(email: string, password: string, congregationId?: number) {
   const user = await db.user.findFirst({
     where: {
       email: email.toLowerCase(),
+      ...(congregationId != null ? { congregationId } : {}),
     },
   })
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -10,6 +10,7 @@ export default [
   route('health', 'routes/health.tsx'),
   route('suspended', 'routes/suspended.tsx'),
   route('trial-expired', 'routes/trial-expired.tsx'),
+  route('congregation-not-found', 'routes/congregation-not-found.tsx'),
   ...authenticationRoutes,
   route('', 'routes/_authenticated-layout.tsx', [
     route('me', 'features/authentication/routes/user/_layout.tsx', [

--- a/app/routes/congregation-not-found.tsx
+++ b/app/routes/congregation-not-found.tsx
@@ -1,0 +1,18 @@
+import type { Route } from './+types/congregation-not-found'
+
+export const meta: Route.MetaFunction = () => {
+  return [{ title: 'Assemblée non trouvée - Unitae' }]
+}
+
+export default function CongregationNotFoundPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="mx-auto max-w-md text-center">
+        <h1 className="mb-4 font-bold text-2xl text-gray-900">Assemblée non trouvée</h1>
+        <p className="mb-6 text-gray-600">
+          L'assemblée locale que vous recherchez n'existe pas ou n'est plus disponible.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -2,16 +2,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('~/shared/libs/db.server', () => ({
   unscopedDb: {
-    congregation: { findUnique: vi.fn() },
+    congregation: { findUnique: vi.fn(), findFirst: vi.fn() },
   },
   congregationContext: {
     getStore: vi.fn(),
   },
 }))
 
-const { resolveCongregation, getCongregationFromContext, requireCongregation, getPlatformName } = await import(
-  './congregation.server'
-)
+vi.mock('react-router', () => ({
+  redirect: vi.fn((url: string) => {
+    // biome-ignore lint/style/useNamingConvention: en-tête HTTP standard
+    throw new Response(null, { status: 302, headers: { Location: url } })
+  }),
+}))
+
+const {
+  resolveCongregation,
+  resolveCongregationFromRequest,
+  getCongregationFromContext,
+  requireCongregation,
+  getPlatformName,
+} = await import('./congregation.server')
 const { unscopedDb: db, congregationContext } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
@@ -186,5 +197,63 @@ describe('requireCongregation', () => {
 describe('getPlatformName', () => {
   it('retourne "Unitae"', () => {
     expect(getPlatformName()).toBe('Unitae')
+  })
+})
+
+describe('resolveCongregationFromRequest', () => {
+  function makeRequest(url: string) {
+    return new Request(url)
+  }
+
+  it('retourne null en mode mono-tenant', async () => {
+    delete process.env.MULTI_TENANT
+
+    const result = await resolveCongregationFromRequest(makeRequest('https://lyon-jean-mace.unitae.app/'))
+    expect(result).toBeNull()
+  })
+
+  it('retourne la congrégation correspondant au slug du sous-domaine', async () => {
+    process.env.MULTI_TENANT = 'true'
+    process.env.APP_BASE_URL = 'unitae.app'
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 1, slug: 'lyon-jean-mace' } as never)
+
+    const result = await resolveCongregationFromRequest(makeRequest('https://lyon-jean-mace.unitae.app/'))
+    expect(result).toEqual({ id: 1, slug: 'lyon-jean-mace' })
+    expect(db.congregation.findUnique).toHaveBeenCalledWith({
+      where: { slug: 'lyon-jean-mace' },
+      select: { id: true, slug: true },
+    })
+  })
+
+  it('redirige vers /congregation-not-found si le slug ne correspond à aucune assemblée', async () => {
+    process.env.MULTI_TENANT = 'true'
+    process.env.APP_BASE_URL = 'unitae.app'
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(null as never)
+
+    await expect(resolveCongregationFromRequest(makeRequest('https://inconnu.unitae.app/'))).rejects.toSatisfy(
+      (error: Response) => error instanceof Response && error.headers.get('Location') === '/congregation-not-found',
+    )
+  })
+
+  it('résout par domaine personnalisé quand il n\'y a pas de slug', async () => {
+    process.env.MULTI_TENANT = 'true'
+    process.env.APP_BASE_URL = 'unitae.app'
+    vi.mocked(db.congregation.findFirst).mockResolvedValue({ id: 2, slug: 'paris' } as never)
+
+    const result = await resolveCongregationFromRequest(makeRequest('https://custom.example.com/'))
+    expect(result).toEqual({ id: 2, slug: 'paris' })
+    expect(db.congregation.findFirst).toHaveBeenCalledWith({
+      where: { domain: 'custom.example.com' },
+      select: { id: true, slug: true },
+    })
+  })
+
+  it('retourne null pour le domaine racine sans slug ni domaine personnalisé', async () => {
+    process.env.MULTI_TENANT = 'true'
+    process.env.APP_BASE_URL = 'unitae.app'
+    vi.mocked(db.congregation.findFirst).mockResolvedValue(null as never)
+
+    const result = await resolveCongregationFromRequest(makeRequest('https://custom-unknown.example.com/'))
+    expect(result).toBeNull()
   })
 })

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -208,19 +208,19 @@ describe('resolveCongregationFromRequest', () => {
   it('retourne null en mode mono-tenant', async () => {
     delete process.env.MULTI_TENANT
 
-    const result = await resolveCongregationFromRequest(makeRequest('https://lyon-jean-mace.unitae.app/'))
+    const result = await resolveCongregationFromRequest(makeRequest('https://tenant-alpha.unitae.app/'))
     expect(result).toBeNull()
   })
 
   it('retourne la congrégation correspondant au slug du sous-domaine', async () => {
     process.env.MULTI_TENANT = 'true'
     process.env.APP_BASE_URL = 'unitae.app'
-    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 1, slug: 'lyon-jean-mace' } as never)
+    vi.mocked(db.congregation.findUnique).mockResolvedValue({ id: 1, slug: 'tenant-alpha' } as never)
 
-    const result = await resolveCongregationFromRequest(makeRequest('https://lyon-jean-mace.unitae.app/'))
-    expect(result).toEqual({ id: 1, slug: 'lyon-jean-mace' })
+    const result = await resolveCongregationFromRequest(makeRequest('https://tenant-alpha.unitae.app/'))
+    expect(result).toEqual({ id: 1, slug: 'tenant-alpha' })
     expect(db.congregation.findUnique).toHaveBeenCalledWith({
-      where: { slug: 'lyon-jean-mace' },
+      where: { slug: 'tenant-alpha' },
       select: { id: true, slug: true },
     })
   })

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -1,3 +1,5 @@
+import { redirect } from 'react-router'
+
 import { congregationContext, unscopedDb } from '~/shared/libs/db.server'
 
 const DEFAULT_PLATFORM_NAME = 'Unitae'
@@ -68,6 +70,43 @@ export async function resolveCongregation(congregationId: number): Promise<Congr
 
 export function getPlatformName(): string {
   return DEFAULT_PLATFORM_NAME
+}
+
+/**
+ * Résout l'assemblée locale correspondant au sous-domaine ou domaine personnalisé de la requête.
+ *
+ * - Retourne `null` en mode mono-tenant ou si aucun slug n'est extrait de l'URL (domaine racine).
+ * - Redirige vers `/congregation-not-found` si un slug est présent mais ne correspond à aucune assemblée.
+ */
+export async function resolveCongregationFromRequest(
+  request: Request,
+): Promise<{ id: number; slug: string } | null> {
+  if (process.env.MULTI_TENANT !== 'true') return null
+
+  const hostname = new URL(request.url).hostname
+  const appBaseUrl = (process.env.APP_BASE_URL ?? 'unitae.app').replace('https://', '').replace('http://', '')
+  const slug = hostname.endsWith(appBaseUrl) ? hostname.replace(`.${appBaseUrl}`, '') : null
+
+  if (slug) {
+    const congregation = await unscopedDb.congregation.findUnique({
+      where: { slug },
+      select: { id: true, slug: true },
+    })
+    if (congregation) return congregation
+
+    // Le slug est présent dans l'URL mais ne correspond à aucune assemblée
+    throw redirect('/congregation-not-found')
+  }
+
+  // Pas de slug — tenter la résolution par domaine personnalisé
+  const congregation = await unscopedDb.congregation.findFirst({
+    where: { domain: hostname },
+    select: { id: true, slug: true },
+  })
+  if (congregation) return congregation
+
+  // Domaine racine ou domaine inconnu sans slug — pas d'assemblée à résoudre
+  return null
 }
 
 const DEFAULT_CONGREGATION_NAME = 'Ma Congrégation'


### PR DESCRIPTION
## Summary

- **Security fix**: session cookies shared across `*.unitae.app` subdomains allowed cross-tenant data access. A user authenticated on one congregation's subdomain could navigate to another subdomain and see their own congregation's data there.
- Adds `resolveCongregationFromRequest()` to resolve the congregation from the request hostname (subdomain slug or custom domain), and validates it against the session in `verifySession()` and the login flow.
- Scopes `validateCredentials()` to the subdomain's congregation so login rejects accounts belonging to other tenants (shows generic "Email ou mot de passe invalide" — no information leakage).
- Adds `/congregation-not-found` error page for unknown subdomains.
- All tenant checks are no-ops in single-tenant mode (`MULTI_TENANT !== 'true'`).

## Test plan

- [x] Log into congregation A's subdomain, navigate to congregation B's subdomain → should see congregation B's login page (session destroyed)
- [x] On congregation B's login page, enter congregation A's credentials → should get "Email ou mot de passe invalide"
- [x] Visit `fake-slug.unitae.app` → should see "Assemblée non trouvée" error page
- [ ] Single-tenant mode (`MULTI_TENANT` unset) → no behavioral change
- [ ] Custom domain congregation access still works
- [ ] `pnpm test:unit` — all 316 tests pass
- [ ] `pnpm test:typecheck` — clean
- [ ] `pnpm test:lint` — clean