### PR TITLE
fix: enforce tenant data isolation and centralize auth

### DIFF
--- a/app/features/authentication/routes/login.tsx
+++ b/app/features/authentication/routes/login.tsx
@@ -23,7 +23,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  // Vérifier que le sous-domaine correspond à une assemblée existante
+  // Verify that the subdomain matches an existing congregation
   await resolveCongregationFromRequest(request)
 
   const shouldStartSetup = await needSetupProcess()
@@ -33,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const session = await getSession(request.headers.get('Cookie'))
   if (session.has('userId') === true) {
-    // En mode multi-tenant, vérifier que la session correspond à l'assemblée du sous-domaine
+    // In multi-tenant mode, verify the session matches the subdomain's congregation
     const urlCongregation = await resolveCongregationFromRequest(request)
     if (urlCongregation) {
       const uid = Number(session.get('userId'))

--- a/app/features/authentication/routes/password-invalidation.tsx
+++ b/app/features/authentication/routes/password-invalidation.tsx
@@ -2,9 +2,9 @@ import ResetPasswordRequired from 'emails/reset-password-required'
 import { redirect } from 'react-router'
 import { createPasswordResetToken } from '~/features/authentication/server/invalidate-user-password.server'
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { resolveCongregation } from '~/shared/libs/congregation.server'
 import { unscopedDb as db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
@@ -19,8 +19,8 @@ export function loader() {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
-  const canManageUser = await verifyRole(request, Role.SettingsUserManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) throw redirect('/')
 

--- a/app/features/authentication/routes/user/_layout.tsx
+++ b/app/features/authentication/routes/user/_layout.tsx
@@ -1,14 +1,14 @@
 import { Outlet } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 
 import type { Route } from './+types/_layout'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mon compte - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  await authenticateAndAuthorize(request)
   return {}
 }
 

--- a/app/features/authentication/routes/user/profile.tsx
+++ b/app/features/authentication/routes/user/profile.tsx
@@ -1,7 +1,6 @@
 import { Form, redirect } from 'react-router'
 import { changeUserPassword } from '~/features/authentication/server/change-user-password.server'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import logger from '~/shared/libs/logger.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -11,14 +10,14 @@ import { Label } from '~/shared/ui/label'
 import { PageHeader } from '~/shared/ui/PageHeader'
 
 import type { Route } from './+types/profile'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mon profil - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, congregation } = await verifySession(request)
-
+  const { currentUser, session, congregation } = await authenticateAndAuthorize(request)
   logger.info(`Loading profile data. User ID: ${currentUser.id}.`)
 
   return {
@@ -99,9 +98,7 @@ export default function ProfilePage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { session, currentUser } = await authenticateAndAuthorize(request)
   const formData = await request.formData()
   const password = formData.get('password')
   const newPassword = formData.get('new_password')

--- a/app/features/authentication/routes/user/profile.tsx
+++ b/app/features/authentication/routes/user/profile.tsx
@@ -1,6 +1,7 @@
 import { Form, redirect } from 'react-router'
 import { changeUserPassword } from '~/features/authentication/server/change-user-password.server'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -99,6 +100,8 @@ export default function ProfilePage({ loaderData }: Route.ComponentProps) {
 
 export async function action({ request }: Route.ActionArgs) {
   const { session, currentUser } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const formData = await request.formData()
   const password = formData.get('password')
   const newPassword = formData.get('new_password')

--- a/app/features/authentication/server/session.server.ts
+++ b/app/features/authentication/server/session.server.ts
@@ -62,7 +62,7 @@ export async function verifySession(request: Request) {
     })
   }
 
-  // En mode multi-tenant, vérifier que le sous-domaine correspond à l'assemblée de l'utilisateur
+  // In multi-tenant mode, verify that the subdomain matches the user's congregation
   const urlCongregation = await resolveCongregationFromRequest(request)
   if (urlCongregation && urlCongregation.id !== user.congregationId) {
     throw redirect('/login', {

--- a/app/features/authorization/server/verify-role.server.ts
+++ b/app/features/authorization/server/verify-role.server.ts
@@ -31,7 +31,7 @@ export async function verifyRole(request: Request, roleKey: Role) {
   })
 
   if (adminRole != null) {
-    // Restaurer le contexte ALS — les requêtes unscopedDb via l'adaptateur pg le cassent
+    // Restore ALS context — unscopedDb queries via the pg adapter break it
     congregationContext.enterWith({ congregationId })
     return true
   }

--- a/app/features/board/routes/_layout.tsx
+++ b/app/features/board/routes/_layout.tsx
@@ -1,7 +1,7 @@
 import { data, Outlet } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import type { Route } from './+types/_layout'
 
 export const meta: Route.MetaFunction = () => {
@@ -9,13 +9,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManageSettings = await verifyRole(request, Role.SettingsUserManager)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.TerritoriesViewer, Role.SettingsUserManager, Role.PublisherViewer, Role.BoardValidator, Role.ProspectionViewer])
+  const canUploadDocument = can(Role.BoardUploader)
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageSettings = can(Role.SettingsUserManager)
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManageBoard = can(Role.BoardValidator)
+  const canViewProspection = can(Role.ProspectionViewer)
 
   const messages = { success: session.get('success'), error: session.get('error') }
   return data(

--- a/app/features/board/routes/documents/delete.tsx
+++ b/app/features/board/routes/documents/delete.tsx
@@ -3,7 +3,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { deleteFile } from '~/features/board/server/document'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -12,13 +12,14 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canUploadDocument = await verifyRole(request, Role.BoardUploader)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.findUnique({ where: { id: requireParamId(params.documentId, '/board') } })
 
   if (document == null) {
@@ -55,6 +56,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.delete({ where: { id: requireParamId(params.documentId, '/board') } })
 
   try {

--- a/app/features/board/routes/documents/delete.tsx
+++ b/app/features/board/routes/documents/delete.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { deleteFile } from '~/features/board/server/document'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -12,14 +12,13 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
+  const { can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.findUnique({ where: { id: requireParamId(params.documentId, '/board') } })
 
   if (document == null) {
@@ -49,14 +48,13 @@ export default function DeleteDocumentPage({ loaderData }: Route.ComponentProps)
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
+  const { session, currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.delete({ where: { id: requireParamId(params.documentId, '/board') } })
 
   try {

--- a/app/features/board/routes/documents/edit.tsx
+++ b/app/features/board/routes/documents/edit.tsx
@@ -1,9 +1,9 @@
 import { Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,15 +18,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const canUploadDocument = can(Role.BoardUploader)
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.findUnique({
     where: {
       id: requireParamId(params.documentId, '/board'),
@@ -157,10 +156,9 @@ export default function EditDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const title = String(form.get('title'))
   const sectionId = Number(form.get('sectionId'))

--- a/app/features/board/routes/documents/edit.tsx
+++ b/app/features/board/routes/documents/edit.tsx
@@ -3,7 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canUploadDocument = await verifyRole(request, Role.BoardUploader)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
@@ -26,6 +26,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.findUnique({
     where: {
       id: requireParamId(params.documentId, '/board'),
@@ -156,9 +157,10 @@ export default function EditDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const title = String(form.get('title'))
   const sectionId = Number(form.get('sectionId'))

--- a/app/features/board/routes/documents/list.tsx
+++ b/app/features/board/routes/documents/list.tsx
@@ -4,7 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { DocumentVisibility } from '~/features/board/ui/DocumentVisibility'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -32,6 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board documents. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload document.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const documents = await db.boardDocument.findMany({
     include: {
       section: true,

--- a/app/features/board/routes/documents/list.tsx
+++ b/app/features/board/routes/documents/list.tsx
@@ -1,10 +1,9 @@
 import { ChevronDown, ChevronUp, Eye, FileText, Pencil, Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { DocumentVisibility } from '~/features/board/ui/DocumentVisibility'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -19,8 +18,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
     logger.warn(`Tried to load board documents. User ID: ${currentUser.id}. Does NOT have rights to upload document.`)
@@ -32,7 +31,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board documents. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload document.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const documents = await db.boardDocument.findMany({
     include: {
       section: true,

--- a/app/features/board/routes/documents/move-down.tsx
+++ b/app/features/board/routes/documents/move-down.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,13 +12,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const currentDocument = await db.boardDocument.findUnique({
     where: { id: requireParamId(params.documentId, '/board') },
   })

--- a/app/features/board/routes/documents/move-down.tsx
+++ b/app/features/board/routes/documents/move-down.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,14 +12,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const currentDocument = await db.boardDocument.findUnique({
     where: { id: requireParamId(params.documentId, '/board') },
   })

--- a/app/features/board/routes/documents/move-up.tsx
+++ b/app/features/board/routes/documents/move-up.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,13 +12,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const currentDocument = await db.boardDocument.findUnique({
     where: { id: requireParamId(params.documentId, '/board') },
   })

--- a/app/features/board/routes/documents/move-up.tsx
+++ b/app/features/board/routes/documents/move-up.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,14 +12,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const currentDocument = await db.boardDocument.findUnique({
     where: { id: requireParamId(params.documentId, '/board') },
   })

--- a/app/features/board/routes/documents/new.tsx
+++ b/app/features/board/routes/documents/new.tsx
@@ -1,11 +1,11 @@
 import { type FileUpload, parseFormData } from '@mjackson/form-data-parser'
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { saveFile } from '~/features/board/server/document'
 import { sendNewDocumentNotificationEmail } from '~/features/board/server/notifications'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
@@ -21,9 +21,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const canUploadDocument = can(Role.BoardUploader)
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canUploadDocument) {
     logger.warn(
@@ -36,7 +36,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading creation form for document. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload new document to the board.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany()
 
   return { sections, rights: { canUploadDocument, canManageBoard } }
@@ -133,10 +132,9 @@ export default function NewDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation } = await verifySession(request)
-
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { currentUser, session, congregation, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const canUploadDocument = can(Role.BoardUploader)
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canUploadDocument) {
     logger.warn(
@@ -145,7 +143,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   let uploadedFile: File | null = null
   const uploadHandler = async (fileUpload: FileUpload) => {
     if (fileUpload.fieldName === 'document') {

--- a/app/features/board/routes/documents/new.tsx
+++ b/app/features/board/routes/documents/new.tsx
@@ -5,7 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { saveFile } from '~/features/board/server/document'
 import { sendNewDocumentNotificationEmail } from '~/features/board/server/notifications'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
@@ -36,6 +36,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading creation form for document. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload new document to the board.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany()
 
   return { sections, rights: { canUploadDocument, canManageBoard } }
@@ -144,6 +145,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   let uploadedFile: File | null = null
   const uploadHandler = async (fileUpload: FileUpload) => {
     if (fileUpload.fieldName === 'document') {

--- a/app/features/board/routes/documents/pdf-loader.tsx
+++ b/app/features/board/routes/documents/pdf-loader.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { getFileStream } from '~/features/board/server/document'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
@@ -15,6 +15,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   const { currentUser } = await verifySession(request)
   logger.info(`Loading document ID: ${params.documentId}. User ID: ${currentUser.id}.`, { currentUser })
 
+  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.update({
     where: {
       id: requireParamId(params.documentId, '/board'),

--- a/app/features/board/routes/documents/pdf-loader.tsx
+++ b/app/features/board/routes/documents/pdf-loader.tsx
@@ -1,21 +1,20 @@
 import { redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { getFileStream } from '~/features/board/server/document'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/pdf-loader'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: `Tableau d'affichage - Unitae` }]
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
+  const { currentUser } = await authenticateAndAuthorize(request)
   logger.info(`Loading document ID: ${params.documentId}. User ID: ${currentUser.id}.`, { currentUser })
 
-  restoreCongregationContext(currentUser.congregationId)
   const document = await db.boardDocument.update({
     where: {
       id: requireParamId(params.documentId, '/board'),

--- a/app/features/board/routes/index.tsx
+++ b/app/features/board/routes/index.tsx
@@ -3,7 +3,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { DocumentCard } from '~/features/board/ui/DocumentCard'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { EmptyState } from '~/shared/ui/EmptyState'
 
@@ -18,6 +18,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const canUploadDocument = await verifyRole(request, Role.BoardUploader)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
+  restoreCongregationContext(currentUser.congregationId)
   const folders = await db.boardSection.findMany({
     where: {},
     include: {

--- a/app/features/board/routes/index.tsx
+++ b/app/features/board/routes/index.tsx
@@ -1,9 +1,8 @@
 import { FileText } from 'lucide-react'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { DocumentCard } from '~/features/board/ui/DocumentCard'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { EmptyState } from '~/shared/ui/EmptyState'
 
@@ -14,11 +13,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canUploadDocument = await verifyRole(request, Role.BoardUploader)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const canUploadDocument = can(Role.BoardUploader)
+  const canManageBoard = can(Role.BoardValidator)
 
-  restoreCongregationContext(currentUser.congregationId)
   const folders = await db.boardSection.findMany({
     where: {},
     include: {

--- a/app/features/board/routes/sections/delete.tsx
+++ b/app/features/board/routes/sections/delete.tsx
@@ -2,7 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -10,13 +10,14 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.findUnique({ where: { id: requireParamId(params.sectionId, '/board') } })
 
   if (section == null) {
@@ -46,13 +47,14 @@ export default function DeleteSectionPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.delete({ where: { id: requireParamId(params.sectionId, '/board') } })
 
   session.flash('success', `La section "${section.name}" a été correctement supprimée`)

--- a/app/features/board/routes/sections/delete.tsx
+++ b/app/features/board/routes/sections/delete.tsx
@@ -1,8 +1,8 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -10,14 +10,13 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.findUnique({ where: { id: requireParamId(params.sectionId, '/board') } })
 
   if (section == null) {
@@ -47,14 +46,13 @@ export default function DeleteSectionPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.delete({ where: { id: requireParamId(params.sectionId, '/board') } })
 
   session.flash('success', `La section "${section.name}" a été correctement supprimée`)

--- a/app/features/board/routes/sections/edit.tsx
+++ b/app/features/board/routes/sections/edit.tsx
@@ -3,7 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,13 +18,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.findUnique({
     where: {
       id: requireParamId(params.sectionId, '/board'),
@@ -77,7 +78,7 @@ export default function EditSectionPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -86,6 +87,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.update({
     where: {
       id: requireParamId(params.sectionId, '/board'),

--- a/app/features/board/routes/sections/edit.tsx
+++ b/app/features/board/routes/sections/edit.tsx
@@ -1,9 +1,9 @@
 import { Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,14 +18,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.findUnique({
     where: {
       id: requireParamId(params.sectionId, '/board'),
@@ -78,7 +77,7 @@ export default function EditSectionPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
+  const { session } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -87,7 +86,6 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.update({
     where: {
       id: requireParamId(params.sectionId, '/board'),

--- a/app/features/board/routes/sections/list.tsx
+++ b/app/features/board/routes/sections/list.tsx
@@ -3,7 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -31,6 +31,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board sections. User ID: ${currentUser.id}. ${canManageBoard ? 'Has' : 'Does NOT have'} rights to manage board sections.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({
     include: {
       documents: true,

--- a/app/features/board/routes/sections/list.tsx
+++ b/app/features/board/routes/sections/list.tsx
@@ -1,9 +1,8 @@
 import { ChevronDown, ChevronUp, FolderOpen, Pencil, Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -18,8 +17,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     logger.warn(`Tried to load board sections. User ID: ${currentUser.id}. Does NOT have rights to manage board.`)
@@ -31,7 +30,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board sections. User ID: ${currentUser.id}. ${canManageBoard ? 'Has' : 'Does NOT have'} rights to manage board sections.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({
     include: {
       documents: true,

--- a/app/features/board/routes/sections/move-down.tsx
+++ b/app/features/board/routes/sections/move-down.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,13 +12,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
   const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
   if (currentSection == null) {

--- a/app/features/board/routes/sections/move-down.tsx
+++ b/app/features/board/routes/sections/move-down.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,14 +12,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
   const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
   if (currentSection == null) {

--- a/app/features/board/routes/sections/move-up.tsx
+++ b/app/features/board/routes/sections/move-up.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,13 +12,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageBoard = await verifyRole(request, Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
   const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
   if (currentSection == null) {

--- a/app/features/board/routes/sections/move-up.tsx
+++ b/app/features/board/routes/sections/move-up.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,14 +12,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
   const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
   if (currentSection == null) {

--- a/app/features/board/routes/sections/new.tsx
+++ b/app/features/board/routes/sections/new.tsx
@@ -1,8 +1,8 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -16,8 +16,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
-  const canManageBoard = await verifyRole(request, Role.BoardValidator)
+  const { can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
@@ -49,7 +49,7 @@ export default function NewSectionPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, currentUser } = await verifySession(request)
+  const { session, congregation } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -58,7 +58,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.create({
     data: {
       name: String(name),

--- a/app/features/board/routes/sections/new.tsx
+++ b/app/features/board/routes/sections/new.tsx
@@ -2,7 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -49,7 +49,7 @@ export default function NewSectionPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation } = await verifySession(request)
+  const { session, congregation, currentUser } = await verifySession(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -58,6 +58,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const section = await db.boardSection.create({
     data: {
       name: String(name),

--- a/app/features/events/routes/days-off/delete.tsx
+++ b/app/features/events/routes/days-off/delete.tsx
@@ -1,21 +1,20 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
 
 import type { Route } from './+types/delete'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-
+  const { currentUser } = await authenticateAndAuthorize(request)
   logger.info(`Trying to remove days off. User ID: ${currentUser.id}. Event: ${params.eventId}`)
 
-  restoreCongregationContext(currentUser.congregationId)
   const event = await db.event.findUnique({
     where: { id: requireParamId(params.eventId, '/me/days-off'), kind: { key: EventKind.Off } },
     include: { createdBy: true },
@@ -56,9 +55,7 @@ export default function DeleteDayOff({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { session, currentUser } = await authenticateAndAuthorize(request)
   const event = await db.event.findUnique({
     where: { id: requireParamId(params.eventId, '/me/days-off') },
     include: { createdBy: true },

--- a/app/features/events/routes/days-off/delete.tsx
+++ b/app/features/events/routes/days-off/delete.tsx
@@ -2,7 +2,7 @@ import { Form, redirect } from 'react-router'
 
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -15,6 +15,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   logger.info(`Trying to remove days off. User ID: ${currentUser.id}. Event: ${params.eventId}`)
 
+  restoreCongregationContext(currentUser.congregationId)
   const event = await db.event.findUnique({
     where: { id: requireParamId(params.eventId, '/me/days-off'), kind: { key: EventKind.Off } },
     include: { createdBy: true },
@@ -57,6 +58,7 @@ export default function DeleteDayOff({ loaderData }: Route.ComponentProps) {
 export async function action({ request, params }: Route.ActionArgs) {
   const { session, currentUser } = await verifySession(request)
 
+  restoreCongregationContext(currentUser.congregationId)
   const event = await db.event.findUnique({
     where: { id: requireParamId(params.eventId, '/me/days-off') },
     include: { createdBy: true },

--- a/app/features/events/routes/days-off/list.tsx
+++ b/app/features/events/routes/days-off/list.tsx
@@ -1,8 +1,6 @@
 import { CalendarOff, X } from 'lucide-react'
 import { Link } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { getNextDaysOffs } from '~/features/events/server/days-off.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -10,15 +8,14 @@ import { EmptyState } from '~/shared/ui/EmptyState'
 import { PageHeader } from '~/shared/ui/PageHeader'
 
 import type { Route } from './+types/list'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mes absences - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { currentUser, session } = await authenticateAndAuthorize(request)
   const events = await getNextDaysOffs(currentUser.id)
 
   logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)

--- a/app/features/events/routes/days-off/list.tsx
+++ b/app/features/events/routes/days-off/list.tsx
@@ -2,6 +2,7 @@ import { CalendarOff, X } from 'lucide-react'
 import { Link } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { getNextDaysOffs } from '~/features/events/server/days-off.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -16,6 +17,8 @@ export const meta: Route.MetaFunction = () => {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { currentUser, session } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const events = await getNextDaysOffs(currentUser.id)
 
   logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { createDayOff } from '~/features/events/server/days-off.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -11,14 +10,14 @@ import { Label } from '~/shared/ui/label'
 import { PageHeader } from '~/shared/ui/PageHeader'
 
 import type { Route } from './+types/new'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Ajouter une absence - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-
+  const { currentUser, session } = await authenticateAndAuthorize(request)
   logger.info(`Loading personal Days Off form. User ID: ${currentUser.id}.`)
 
   return {
@@ -76,9 +75,7 @@ export default function DaysOffPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { currentUser, session, congregation } = await authenticateAndAuthorize(request)
   const formData = await request.formData()
   const startDate = new Date(String(formData.get('start_date')))
   const endDate = new Date(String(formData.get('end_date')))

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { createDayOff } from '~/features/events/server/days-off.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -76,6 +77,8 @@ export default function DaysOffPage() {
 
 export async function action({ request }: Route.ActionArgs) {
   const { currentUser, session, congregation } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const formData = await request.formData()
   const startDate = new Date(String(formData.get('start_date')))
   const endDate = new Date(String(formData.get('end_date')))

--- a/app/features/events/routes/programs/days-off.tsx
+++ b/app/features/events/routes/programs/days-off.tsx
@@ -1,12 +1,11 @@
 import { CalendarOff } from 'lucide-react'
 import { redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -21,9 +20,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewPrograms = await verifyRole(request, Role.ProgramViewer)
-  const canManagePrograms = await verifyRole(request, Role.ProgramManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const canViewPrograms = can(Role.ProgramViewer)
+  const canManagePrograms = can(Role.ProgramManager)
 
   if (!canViewPrograms) {
     logger.warn(`Try to load programs. User ID: ${currentUser.id}. Does NOT have rights to access programs.`)
@@ -35,7 +34,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading program list. User ID: ${currentUser.id}. ${canManagePrograms ? 'Has' : 'Does NOT have'} rights to manage programs.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   selectors.kind = { key: EventKind.Off } // Filter only for days off events

--- a/app/features/events/routes/programs/days-off.tsx
+++ b/app/features/events/routes/programs/days-off.tsx
@@ -6,7 +6,7 @@ import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -35,6 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading program list. User ID: ${currentUser.id}. ${canManagePrograms ? 'Has' : 'Does NOT have'} rights to manage programs.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   selectors.kind = { key: EventKind.Off } // Filter only for days off events

--- a/app/features/events/routes/programs/list.tsx
+++ b/app/features/events/routes/programs/list.tsx
@@ -1,11 +1,10 @@
 import { CalendarOff } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Button } from '~/shared/ui/button'
@@ -20,9 +19,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewPrograms = await verifyRole(request, Role.ProgramViewer)
-  const canManagePrograms = await verifyRole(request, Role.ProgramManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const canViewPrograms = can(Role.ProgramViewer)
+  const canManagePrograms = can(Role.ProgramManager)
 
   if (!canViewPrograms) {
     logger.warn(`Try to load programs. User ID: ${currentUser.id}. Does NOT have rights to access programs.`)
@@ -34,7 +33,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading program list. User ID: ${currentUser.id}. ${canManagePrograms ? 'Has' : 'Does NOT have'} rights to manage programs.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
 

--- a/app/features/events/routes/programs/list.tsx
+++ b/app/features/events/routes/programs/list.tsx
@@ -5,7 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Button } from '~/shared/ui/button'
@@ -34,6 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading program list. User ID: ${currentUser.id}. ${canManagePrograms ? 'Has' : 'Does NOT have'} rights to manage programs.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
 

--- a/app/features/publishers/routes/_layout.tsx
+++ b/app/features/publishers/routes/_layout.tsx
@@ -1,7 +1,7 @@
 import { data, Outlet, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 import type { Route } from './+types/_layout'
 
@@ -10,12 +10,12 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManageSettings = await verifyRole(request, Role.SettingsUserManager)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canViewPrograms = await verifyRole(request, Role.ProgramViewer)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.SettingsUserManager, Role.PublisherViewer, Role.ProgramViewer, Role.ProspectionViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageSettings = can(Role.SettingsUserManager)
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canViewPrograms = can(Role.ProgramViewer)
+  const canViewProspection = can(Role.ProspectionViewer)
 
   if (!canViewPublishers && !canViewPrograms) {
     throw redirect('/')

--- a/app/features/publishers/routes/activity/delete.tsx
+++ b/app/features/publishers/routes/activity/delete.tsx
@@ -3,7 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,13 +11,14 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageActivity = await verifyRole(request, Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.findUnique({
     where: {
       id: requireParamId(params.activityId, '/congregation/publishers/activity'),
@@ -64,13 +65,14 @@ export default function DeleteActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageActivity = await verifyRole(request, Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.delete({
     where: { id: requireParamId(params.activityId, '/congregation/publishers/activity') },
     include: { publisher: true },

--- a/app/features/publishers/routes/activity/delete.tsx
+++ b/app/features/publishers/routes/activity/delete.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,14 +11,13 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageActivity = await verifyRole(request, Role.ActivityManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.findUnique({
     where: {
       id: requireParamId(params.activityId, '/congregation/publishers/activity'),
@@ -65,14 +64,13 @@ export default function DeleteActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageActivity = await verifyRole(request, Role.ActivityManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.delete({
     where: { id: requireParamId(params.activityId, '/congregation/publishers/activity') },
     include: { publisher: true },

--- a/app/features/publishers/routes/activity/edit.tsx
+++ b/app/features/publishers/routes/activity/edit.tsx
@@ -4,7 +4,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -30,6 +30,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.findFirst({
     where: {
       id: requireParamId(params.activityId, '/congregation/publishers/activity'),
@@ -179,6 +180,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const activity = await db.publisherActivity.findUnique({
     where: {

--- a/app/features/publishers/routes/activity/edit.tsx
+++ b/app/features/publishers/routes/activity/edit.tsx
@@ -1,10 +1,10 @@
 import { Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -20,8 +20,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
+
   const canManageMyGroupActivity =
     currentUser.responsibleFor?.id === currentUser.publisherGroupId ||
     currentUser.deputyFor?.id === currentUser.publisherGroupId
@@ -30,7 +31,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const activity = await db.publisherActivity.findFirst({
     where: {
       id: requireParamId(params.activityId, '/congregation/publishers/activity'),
@@ -170,8 +170,9 @@ export default function EditActivity({ loaderData }: Route.ComponentProps) {
 
 export async function action({ request, params }: Route.ActionArgs) {
   const previousPage = request.headers.get('referer')
-  const { currentUser, session } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
+
   const canManageMyGroupActivity =
     currentUser.responsibleFor?.id === currentUser.publisherGroupId ||
     currentUser.deputyFor?.id === currentUser.publisherGroupId
@@ -180,7 +181,6 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const activity = await db.publisherActivity.findUnique({
     where: {

--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { generatePublishersYearlyActivityXlsx } from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -23,6 +24,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating publishers' activities XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -1,10 +1,8 @@
 import { redirect } from 'react-router'
 
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { generatePublishersYearlyActivityXlsx } from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -14,8 +12,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewActivities = await verifyRole(request, Role.ActivityViewer)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
     logger.warn(
@@ -24,7 +22,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating publishers' activities XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { Form, redirect, useSearchParams } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishers } from '~/features/publishers/server/publishers'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -19,8 +19,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
+
   const canManageMyGroupActivity =
     currentUser.responsibleFor?.id === currentUser.publisherGroupId ||
     currentUser.deputyFor?.id === currentUser.publisherGroupId
@@ -29,7 +30,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const groupFilter = canManageMyGroupActivity && !canManagePublisher ? currentUser.publisherGroupId : undefined
   const publishers = await getPublishers({ groupId: groupFilter })
 
@@ -274,8 +274,9 @@ export default function NewActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, session, congregation, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
+
   const canManageMyGroupActivity =
     currentUser.responsibleFor?.id === currentUser.publisherGroupId ||
     currentUser.deputyFor?.id === currentUser.publisherGroupId
@@ -284,7 +285,6 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const previousPage = String(form.get('previousPage'))
   const publisherId = Number(form.get('publisher'))

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -5,7 +5,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getPublishers } from '~/features/publishers/server/publishers'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -29,6 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const groupFilter = canManageMyGroupActivity && !canManagePublisher ? currentUser.publisherGroupId : undefined
   const publishers = await getPublishers({ groupId: groupFilter })
 
@@ -283,6 +284,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const previousPage = String(form.get('previousPage'))
   const publisherId = Number(form.get('publisher'))

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { renderActivityPdfZip } from '~/features/publishers/server/render-activity-pdf-zip.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -23,6 +24,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating publishers' activities PDF report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -1,10 +1,8 @@
 import { redirect } from 'react-router'
 
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { renderActivityPdfZip } from '~/features/publishers/server/render-activity-pdf-zip.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -14,8 +12,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewActivities = await verifyRole(request, Role.ActivityViewer)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
     logger.warn(
@@ -24,7 +22,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating publishers' activities PDF report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/publishers/routes/activity/publisher-list.tsx
+++ b/app/features/publishers/routes/activity/publisher-list.tsx
@@ -1,12 +1,10 @@
 import { ChevronLeft, ChevronRight, Download, Pencil, Plus, Users } from 'lucide-react'
 import { Link, redirect, useSearchParams } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublisherStats } from '~/features/publishers/server/get-publisher-stats.server'
 import { getPublisherWithActivities } from '~/features/publishers/server/get-publisher-with-activities.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import PublisherActivityStats from '~/features/publishers/ui/PublisherActivityStats'
 import logger from '~/shared/libs/logger.server'
 import { PublisherType } from '~/shared/types/publisher-type'
@@ -23,9 +21,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewActivities = await verifyRole(request, Role.ActivityViewer)
-  const canManageActivities = await verifyRole(request, Role.ActivityManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer, Role.ActivityManager])
+  const canViewActivities = can(Role.ActivityViewer)
+  const canManageActivities = can(Role.ActivityManager)
 
   if (!canViewActivities) {
     logger.warn(
@@ -34,7 +32,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Loading publishers' activities. User ID: ${currentUser.id}.`)
 
   const timeRange = new Date()

--- a/app/features/publishers/routes/activity/publisher-list.tsx
+++ b/app/features/publishers/routes/activity/publisher-list.tsx
@@ -6,6 +6,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getPublisherStats } from '~/features/publishers/server/get-publisher-stats.server'
 import { getPublisherWithActivities } from '~/features/publishers/server/get-publisher-with-activities.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import PublisherActivityStats from '~/features/publishers/ui/PublisherActivityStats'
 import logger from '~/shared/libs/logger.server'
 import { PublisherType } from '~/shared/types/publisher-type'
@@ -33,6 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Loading publishers' activities. User ID: ${currentUser.id}.`)
 
   const timeRange = new Date()

--- a/app/features/publishers/routes/publishers/delete-group.tsx
+++ b/app/features/publishers/routes/publishers/delete-group.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,14 +11,13 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const group = await db.publisherGroup.findUnique({
     where: {
       id: requireParamId(params.groupId, '/congregation/publisher-groups'),
@@ -56,14 +55,13 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const group = await db.publisherGroup.delete({
     where: { id: requireParamId(params.groupId, '/congregation/publisher-groups') },
   })

--- a/app/features/publishers/routes/publishers/delete-group.tsx
+++ b/app/features/publishers/routes/publishers/delete-group.tsx
@@ -3,7 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,13 +11,14 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const group = await db.publisherGroup.findUnique({
     where: {
       id: requireParamId(params.groupId, '/congregation/publisher-groups'),
@@ -55,12 +56,14 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
+
+  restoreCongregationContext(currentUser.congregationId)
   const group = await db.publisherGroup.delete({
     where: { id: requireParamId(params.groupId, '/congregation/publisher-groups') },
   })

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -3,7 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -14,13 +14,14 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/edit-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const brothers = await db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: Prisma OR operator
@@ -133,7 +134,7 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
@@ -141,6 +142,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect(previousPage ?? '/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -1,9 +1,9 @@
 import { Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -14,14 +14,13 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/edit-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const brothers = await db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: Prisma OR operator
@@ -134,15 +133,14 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { currentUser } = await verifySession(request)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect(previousPage ?? '/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -1,13 +1,13 @@
 import { Archive, IdCard } from 'lucide-react'
 import { Form, redirect } from 'react-router'
-import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -19,14 +19,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const result = await db.user.findUnique({
     where: {
       id: requireParamId(params.publisherId, '/congregation/publishers'),
@@ -92,9 +91,7 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { currentUser } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -7,7 +7,7 @@ import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldSe
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -19,13 +19,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const result = await db.user.findUnique({
     where: {
       id: requireParamId(params.publisherId, '/congregation/publishers'),
@@ -91,7 +92,9 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -3,7 +3,7 @@ import { Link, redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -34,6 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading publisher groups. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const groups = await db.publisherGroup.findMany({
     include: {
       responsible: true,

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -1,9 +1,8 @@
 import { Eye, Pencil, UsersRound } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -18,9 +17,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager])
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canViewPublishers) {
     logger.warn(
@@ -34,7 +33,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading publisher groups. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const groups = await db.publisherGroup.findMany({
     include: {
       responsible: true,

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -1,10 +1,10 @@
 import { BarChart3, Eye, Mail, Pencil, Plus } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroup } from '~/features/publishers/server/groups'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -15,16 +15,15 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~
 import type { Route } from './+types/group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
-  const canManageActivity = await verifyRole(request, Role.ActivityManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityManager])
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManagePublisher = can(Role.PublisherManager)
+  const canManageActivity = can(Role.ActivityManager)
 
   if (!canViewPublishers) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const group = await getGroup(requireParamId(params.groupId, '/congregation/publisher-groups'))
   if (group == null) {
     throw redirect('/congregation/publisher-groups/')
@@ -230,15 +229,14 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { currentUser } = await verifySession(request)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect(previousPage ?? '/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -4,7 +4,7 @@ import { commitSession, getSession, verifySession } from '~/features/authenticat
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getGroup } from '~/features/publishers/server/groups'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -24,6 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const group = await getGroup(requireParamId(params.groupId, '/congregation/publisher-groups'))
   if (group == null) {
     throw redirect('/congregation/publisher-groups/')
@@ -229,7 +230,7 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
@@ -237,6 +238,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect(previousPage ?? '/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -13,14 +13,13 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/new-group'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const brothers = await db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: Prisma OR operator
@@ -109,15 +108,14 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect(previousPage ?? '/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -3,7 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -13,13 +13,14 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/new-group'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const brothers = await db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: Prisma OR operator
@@ -108,7 +109,7 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
   const previousPage = request.headers.get('referer')
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
@@ -116,6 +117,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect(previousPage ?? '/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const name = form.get('name')
   const address = form.get('address')

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -1,11 +1,11 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, getSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -17,14 +17,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const groups = await db.publisherGroup.findMany()
 
   return { groups, hideAuxiliaryPioneer: false }
@@ -51,9 +50,7 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { congregation } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -5,7 +5,7 @@ import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -17,13 +17,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const groups = await db.publisherGroup.findMany()
 
   return { groups, hideAuxiliaryPioneer: false }
@@ -50,7 +51,9 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))

--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -1,10 +1,8 @@
 import { BarChart3, Eye, Mail, Pencil, Users } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishersWithGroup } from '~/features/publishers/server/publishers'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -19,10 +17,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
-  const canViewActivities = await verifyRole(request, Role.ActivityViewer)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityViewer])
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManagePublisher = can(Role.PublisherManager)
+  const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewPublishers) {
     logger.warn(
@@ -32,7 +30,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading publishers. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )

--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getPublishersWithGroup } from '~/features/publishers/server/publishers'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -31,6 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading publishers. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )

--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -5,7 +5,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { PublisherActivityDownloadLink } from '~/features/publishers/ui/PublisherActivityDownloadLink'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -34,6 +34,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     `Loading publisher file for ${params.publisherId}. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage publishers.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const today = new Date()
   const yearBegining = new Date(today.getFullYear(), 8, 1)
   if (today < yearBegining) {

--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -1,11 +1,10 @@
 import { Archive, Download, IdCard, Pencil } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { PublisherActivityDownloadLink } from '~/features/publishers/ui/PublisherActivityDownloadLink'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -20,10 +19,10 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-  const canViewPublisher = await verifyRole(request, Role.PublisherViewer)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
-  const canManageActivity = await verifyRole(request, Role.ActivityManager)
+  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityManager])
+  const canViewPublisher = can(Role.PublisherViewer)
+  const canManagePublisher = can(Role.PublisherManager)
+  const canManageActivity = can(Role.ActivityManager)
 
   if (!canViewPublisher) {
     logger.warn(`Tried to load publisher file. User ID: ${currentUser.id}. Does NOT have rights to view publishers.`)
@@ -34,7 +33,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     `Loading publisher file for ${params.publisherId}. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage publishers.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const today = new Date()
   const yearBegining = new Date(today.getFullYear(), 8, 1)
   if (today < yearBegining) {

--- a/app/features/settings/routes/_layout.tsx
+++ b/app/features/settings/routes/_layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 import type { Route } from './+types/_layout'
 
@@ -10,13 +9,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
-  const canManageUsers = await verifyRole(request, Role.SettingsUserManager)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManageSettings = await verifyRole(request, Role.Admin)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager, Role.SettingsUserManager, Role.PublisherViewer, Role.Admin, Role.ProspectionViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canManageUsers = can(Role.SettingsUserManager)
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManageSettings = can(Role.Admin)
+  const canViewProspection = can(Role.ProspectionViewer)
 
   if (!canManageUsers && !canManageSettings) {
     throw redirect('/')

--- a/app/features/settings/routes/congregation/event-kind-list.tsx
+++ b/app/features/settings/routes/congregation/event-kind-list.tsx
@@ -3,6 +3,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getAllEventType } from '~/features/events/server/event-kind.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { Badge } from '~/shared/ui/badge'
 
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -14,13 +15,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageSettings = await verifyRole(request, Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const kinds = await getAllEventType()
 
   return {

--- a/app/features/settings/routes/congregation/event-kind-list.tsx
+++ b/app/features/settings/routes/congregation/event-kind-list.tsx
@@ -1,9 +1,7 @@
 import { redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getAllEventType } from '~/features/events/server/event-kind.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { Badge } from '~/shared/ui/badge'
 
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -15,14 +13,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageSettings = await verifyRole(request, Role.Admin)
+  const { can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const kinds = await getAllEventType()
 
   return {

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -1,10 +1,9 @@
 import { ArrowRight } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting, setSetting } from '~/features/settings/server/settings'
-import { db, restoreCongregationContext, unscopedDb } from '~/shared/libs/db.server'
+import { db, unscopedDb } from '~/shared/libs/db.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -20,8 +19,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { congregation } = await verifySession(request)
-  const canManageSettings = await verifyRole(request, Role.Admin)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
@@ -107,14 +106,13 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-  const canManageSettings = await verifyRole(request, Role.Admin)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const displayName = form.get('displayName')
   const auxiliaryPioneerProfileActivated = String(

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -4,7 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting, setSetting } from '~/features/settings/server/settings'
-import { db, unscopedDb } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext, unscopedDb } from '~/shared/libs/db.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -107,13 +107,14 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
   const canManageSettings = await verifyRole(request, Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const displayName = form.get('displayName')
   const auxiliaryPioneerProfileActivated = String(

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -3,6 +3,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting, getSetting, setSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getTerritoryPolygon } from '~/features/territories/server/get-territory-polygon.server'
 import {
   getAllowedZips,
@@ -27,13 +28,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const territory = await getTerritoryPolygon()
   const zips = await getAllowedZips()
   const banoUrl = await getSetting(TerritorySettingKey.BanoUrl)
@@ -135,13 +137,14 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { currentUser, congregation } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const zips = parseZips(String(form.get('zips')))
   const territory = parseTerritoryPolygon(String(form.get('territory')))

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -1,9 +1,7 @@
 import { Form, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting, getSetting, setSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getTerritoryPolygon } from '~/features/territories/server/get-territory-polygon.server'
 import {
   getAllowedZips,
@@ -28,14 +26,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const territory = await getTerritoryPolygon()
   const zips = await getAllowedZips()
   const banoUrl = await getSetting(TerritorySettingKey.BanoUrl)
@@ -137,14 +134,13 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, congregation } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const zips = parseZips(String(form.get('zips')))
   const territory = parseTerritoryPolygon(String(form.get('territory')))

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -1,9 +1,9 @@
 import { IdCard, UserPlus } from 'lucide-react'
 import { data, Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -21,15 +21,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageUser = await verifyRole(request, Role.SettingsUserManager)
-  const isAdmin = await verifyRole(request, Role.Admin)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.Admin])
+  const canManageUser = can(Role.SettingsUserManager)
+  const isAdmin = can(Role.Admin)
 
   if (!canManageUser) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.findUnique({
     where: {
       id: requireParamId(params.userId, '/settings/users'),
@@ -211,14 +210,13 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-  const canManageUser = await verifyRole(request, Role.SettingsUserManager)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -3,7 +3,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +21,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageUser = await verifyRole(request, Role.SettingsUserManager)
   const isAdmin = await verifyRole(request, Role.Admin)
 
@@ -29,6 +29,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.findUnique({
     where: {
       id: requireParamId(params.userId, '/settings/users'),
@@ -210,13 +211,14 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
   const canManageUser = await verifyRole(request, Role.SettingsUserManager)
 
   if (!canManageUser) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/settings/routes/users/make-publisher.tsx
+++ b/app/features/settings/routes/users/make-publisher.tsx
@@ -1,22 +1,20 @@
 import { redirect } from 'react-router'
 
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/make-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.update({
     where: { id: requireParamId(params.userId, '/settings/users') },
     data: {

--- a/app/features/settings/routes/users/make-publisher.tsx
+++ b/app/features/settings/routes/users/make-publisher.tsx
@@ -3,19 +3,20 @@ import { redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/make-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.update({
     where: { id: requireParamId(params.userId, '/settings/users') },
     data: {

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -1,10 +1,9 @@
 import { Form, redirect } from 'react-router'
 import { createPasswordResetToken } from '~/features/authentication/server/invalidate-user-password.server'
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,8 +17,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
-  const canManageUser = await verifyRole(request, Role.SettingsUserManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) {
     throw redirect('/')
@@ -61,9 +60,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-
-  restoreCongregationContext(currentUser.congregationId)
+  const { congregation } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -4,7 +4,7 @@ import { sendResetUserPasswordEmail } from '~/features/authentication/server/sen
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -61,7 +61,9 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
+
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))

--- a/app/features/settings/routes/users/unmake-publisher.tsx
+++ b/app/features/settings/routes/users/unmake-publisher.tsx
@@ -1,22 +1,20 @@
 import { redirect } from 'react-router'
 
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/unmake-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.update({
     where: { id: requireParamId(params.userId, '/settings/users') },
     data: {

--- a/app/features/settings/routes/users/unmake-publisher.tsx
+++ b/app/features/settings/routes/users/unmake-publisher.tsx
@@ -3,19 +3,20 @@ import { redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/unmake-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManagePublisher = await verifyRole(request, Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.update({
     where: { id: requireParamId(params.userId, '/settings/users') },
     data: {

--- a/app/features/settings/routes/users/user-list.tsx
+++ b/app/features/settings/routes/users/user-list.tsx
@@ -4,7 +4,7 @@ import { Form, Link, redirect } from 'react-router'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Badge } from '~/shared/ui/badge'
 import { Button } from '~/shared/ui/button'
@@ -34,6 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading users. User ID: ${currentUser.id}. ${canManageUser ? 'Has' : 'Does NOT have'} rights to manage users.`,
   )
 
+  restoreCongregationContext(currentUser.congregationId)
   const users = await db.user.findMany({
     include: {
       congregationRoles: { include: { role: true } },

--- a/app/features/settings/routes/users/user-list.tsx
+++ b/app/features/settings/routes/users/user-list.tsx
@@ -1,10 +1,9 @@
 import { BadgeCheck, BadgeMinus, IdCard, Pencil, UserPlus } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Badge } from '~/shared/ui/badge'
 import { Button } from '~/shared/ui/button'
@@ -19,10 +18,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageUser = await verifyRole(request, Role.SettingsUserManager)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canManagePublishers = await verifyRole(request, Role.PublisherManager)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.PublisherViewer, Role.PublisherManager])
+  const canManageUser = can(Role.SettingsUserManager)
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canManagePublishers = can(Role.PublisherManager)
 
   if (!canManageUser) {
     logger.warn(`Tried to load users. User ID: ${currentUser.id}. Does NOT have rights to manage users.`)
@@ -34,7 +33,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading users. User ID: ${currentUser.id}. ${canManageUser ? 'Has' : 'Does NOT have'} rights to manage users.`,
   )
 
-  restoreCongregationContext(currentUser.congregationId)
   const users = await db.user.findMany({
     include: {
       congregationRoles: { include: { role: true } },

--- a/app/features/territories/routes/_layout.tsx
+++ b/app/features/territories/routes/_layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 import type { Route } from './+types/_layout'
 
@@ -10,12 +9,12 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
-  const canManageSettings = await verifyRole(request, Role.SettingsUserManager)
-  const canViewPublishers = await verifyRole(request, Role.PublisherViewer)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager, Role.SettingsUserManager, Role.PublisherViewer, Role.ProspectionViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canManageSettings = can(Role.SettingsUserManager)
+  const canViewPublishers = can(Role.PublisherViewer)
+  const canViewProspection = can(Role.ProspectionViewer)
 
   if (!canViewTerritories && !canViewProspection) {
     throw redirect('/')

--- a/app/features/territories/routes/attributions/delete.tsx
+++ b/app/features/territories/routes/attributions/delete.tsx
@@ -3,7 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,13 +11,14 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const attribution = await db.attribution.findUnique({
     where: { id: requireParamId(params.attributionId, '/territories/attributions') },
     include: { publisher: true, territory: true },
@@ -58,13 +59,14 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const attribution = await db.attribution.delete({
     where: { id: requireParamId(params.attributionId, '/territories/attributions') },
     include: { publisher: true },

--- a/app/features/territories/routes/attributions/delete.tsx
+++ b/app/features/territories/routes/attributions/delete.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,14 +11,13 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const attribution = await db.attribution.findUnique({
     where: { id: requireParamId(params.attributionId, '/territories/attributions') },
     include: { publisher: true, territory: true },
@@ -59,14 +58,13 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const attribution = await db.attribution.delete({
     where: { id: requireParamId(params.attributionId, '/territories/attributions') },
     include: { publisher: true },

--- a/app/features/territories/routes/attributions/edit.tsx
+++ b/app/features/territories/routes/attributions/edit.tsx
@@ -2,15 +2,14 @@ import { ArrowDownToLine, X } from 'lucide-react'
 import { useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishers } from '~/features/publishers/server/publishers'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -26,14 +25,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const attribution = await db.attribution.findUnique({
@@ -188,14 +186,13 @@ export default function EditAttributionPage({ loaderData }: Route.ComponentProps
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const publisherId = Number(form.get('publisher'))
   const startDateText = String(form.get('start-date'))

--- a/app/features/territories/routes/attributions/edit.tsx
+++ b/app/features/territories/routes/attributions/edit.tsx
@@ -10,7 +10,7 @@ import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -26,13 +26,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const attribution = await db.attribution.findUnique({
@@ -187,13 +188,14 @@ export default function EditAttributionPage({ loaderData }: Route.ComponentProps
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const publisherId = Number(form.get('publisher'))
   const startDateText = String(form.get('start-date'))

--- a/app/features/territories/routes/attributions/excel-export.tsx
+++ b/app/features/territories/routes/attributions/excel-export.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { generateS13ExportExcel } from '~/features/territories/server/s13-export.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -23,6 +24,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating S-13 XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/territories/routes/attributions/excel-export.tsx
+++ b/app/features/territories/routes/attributions/excel-export.tsx
@@ -1,10 +1,8 @@
 import { redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { generateS13ExportExcel } from '~/features/territories/server/s13-export.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -14,8 +12,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     logger.warn(
@@ -24,7 +22,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating S-13 XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -1,11 +1,10 @@
 import { CalendarCheck, Pencil, X } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroups } from '~/features/publishers/server/groups'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { computeFilters } from '~/features/territories/server/attribution-filters'
 import { findActiveAttributionsPaginated } from '~/features/territories/server/attributions'
@@ -29,12 +28,12 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManagePublisher = await verifyRole(request, Role.PublisherManager)
-  const canViewPublisher = await verifyRole(request, Role.PublisherViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
+  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.PublisherManager, Role.PublisherViewer, Role.TerritoriesManager, Role.ProspectionViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManagePublisher = can(Role.PublisherManager)
+  const canViewPublisher = can(Role.PublisherViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canViewProspection = can(Role.ProspectionViewer)
 
   if (!canViewTerritories) {
     if (canViewProspection) {
@@ -48,7 +47,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading territory attributions. User ID: ${currentUser.id}. ${canManageTerritories ? 'Has' : 'Does NOT have'} rights to manage territories.`,
   )

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getGroups } from '~/features/publishers/server/groups'
 import { getBoolSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { computeFilters } from '~/features/territories/server/attribution-filters'
 import { findActiveAttributionsPaginated } from '~/features/territories/server/attributions'
@@ -47,6 +48,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading territory attributions. User ID: ${currentUser.id}. ${canManageTerritories ? 'Has' : 'Does NOT have'} rights to manage territories.`,
   )

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -6,7 +6,7 @@ import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -21,13 +21,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)
@@ -124,13 +125,14 @@ export default function CreateAttributionPage({ loaderData }: Route.ComponentPro
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const territoryId = Number(form.get('territory'))
   const publisherId = Number(form.get('publisher'))

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -1,12 +1,11 @@
 import { Form, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -21,14 +20,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)
@@ -125,14 +123,13 @@ export default function CreateAttributionPage({ loaderData }: Route.ComponentPro
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const territoryId = Number(form.get('territory'))
   const publisherId = Number(form.get('publisher'))

--- a/app/features/territories/routes/attributions/pdf-export.tsx
+++ b/app/features/territories/routes/attributions/pdf-export.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
 import { TerritoryAttributionDocument } from '~/features/territories/ui/TerritoryAttributionDocument'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -24,6 +25,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating S-13 PDF report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/territories/routes/attributions/pdf-export.tsx
+++ b/app/features/territories/routes/attributions/pdf-export.tsx
@@ -1,11 +1,9 @@
 import { pdf } from '@react-pdf/renderer'
 import { redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
 import { TerritoryAttributionDocument } from '~/features/territories/ui/TerritoryAttributionDocument'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -15,8 +13,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     logger.warn(
@@ -25,7 +23,6 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Generating S-13 PDF report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -3,6 +3,7 @@ import { data, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import { findAvailableTerritoriesPaginated } from '~/features/territories/server/territories'
@@ -33,6 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Loading territories available for attribution. User ID: ${currentUser.id}.`)
 
   const url = new URL(request.url)

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -1,9 +1,8 @@
 import { ExternalLink, Send } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import { findAvailableTerritoriesPaginated } from '~/features/territories/server/territories'
@@ -24,8 +23,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     logger.warn(
@@ -34,7 +33,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(`Loading territories available for attribution. User ID: ${currentUser.id}.`)
 
   const url = new URL(request.url)

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -1,13 +1,13 @@
 import { Map as MapIcon, RefreshCw } from 'lucide-react'
 import { data, Form, Link, NavLink, Outlet, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getSetting } from '~/features/settings/server/settings'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -20,16 +20,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -7,7 +7,7 @@ import { getSetting } from '~/features/settings/server/settings'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -20,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
@@ -29,6 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)

--- a/app/features/territories/routes/prospection/active-building-list.tsx
+++ b/app/features/territories/routes/prospection/active-building-list.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
@@ -25,6 +26,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const staleDate = await getProspectionStaleDate()
   const { buildings, pagination } = await findBuildingsPaginated({ active: true }, url)

--- a/app/features/territories/routes/prospection/active-building-list.tsx
+++ b/app/features/territories/routes/prospection/active-building-list.tsx
@@ -1,10 +1,8 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -17,16 +15,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const staleDate = await getProspectionStaleDate()
   const { buildings, pagination } = await findBuildingsPaginated({ active: true }, url)

--- a/app/features/territories/routes/prospection/building-list.tsx
+++ b/app/features/territories/routes/prospection/building-list.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
@@ -26,6 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   const staleDate = await getProspectionStaleDate()

--- a/app/features/territories/routes/prospection/building-list.tsx
+++ b/app/features/territories/routes/prospection/building-list.tsx
@@ -1,11 +1,9 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -18,16 +16,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.TerritoriesManager, Role.ProspectionManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canManageProspection = can(Role.ProspectionManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   const staleDate = await getProspectionStaleDate()

--- a/app/features/territories/routes/prospection/building.tsx
+++ b/app/features/territories/routes/prospection/building.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { setBuildingNotes } from '~/features/territories/server/set-building-notes.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import ArchiveBuildingToggleButton from '~/features/territories/ui/ArchiveBuildingToggleButton'
 import BuildingProspectionInfo from '~/features/territories/ui/BuildingProspectionInfo'
 import BuildingTerritoryInfo from '~/features/territories/ui/BuildingTerritoryInfo'
@@ -35,6 +36,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading building data for building nº${params.buildingId}. User ID: ${currentUser.id}. ${canManageProspection ? 'Has' : 'Does NOT have'} rights to modify prospection data.`,
   )
@@ -123,13 +125,14 @@ export default function BuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const notes = form.get('notes')
   const importantNotes = form.get('important-notes')

--- a/app/features/territories/routes/prospection/building.tsx
+++ b/app/features/territories/routes/prospection/building.tsx
@@ -1,11 +1,10 @@
 import { Pencil, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { setBuildingNotes } from '~/features/territories/server/set-building-notes.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import ArchiveBuildingToggleButton from '~/features/territories/ui/ArchiveBuildingToggleButton'
 import BuildingProspectionInfo from '~/features/territories/ui/BuildingProspectionInfo'
 import BuildingTerritoryInfo from '~/features/territories/ui/BuildingTerritoryInfo'
@@ -23,11 +22,11 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesViewer, Role.TerritoriesManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageProspection = can(Role.ProspectionManager)
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canViewProspection) {
     logger.warn(
@@ -36,7 +35,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   logger.info(
     `Loading building data for building nº${params.buildingId}. User ID: ${currentUser.id}. ${canManageProspection ? 'Has' : 'Does NOT have'} rights to modify prospection data.`,
   )
@@ -125,14 +123,13 @@ export default function BuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const notes = form.get('notes')
   const importantNotes = form.get('important-notes')

--- a/app/features/territories/routes/prospection/delete-building.tsx
+++ b/app/features/territories/routes/prospection/delete-building.tsx
@@ -1,9 +1,9 @@
 import { Form, redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,14 +11,13 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete-building'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionManager])
+  const canManageProspection = can(Role.ProspectionManager)
 
   if (!canManageProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.findUnique({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
   })
@@ -58,14 +57,13 @@ export default function DeleteBuilding({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.delete({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
   })

--- a/app/features/territories/routes/prospection/delete-building.tsx
+++ b/app/features/territories/routes/prospection/delete-building.tsx
@@ -3,7 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,13 +11,14 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete-building'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
 
   if (!canManageProspection) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.findUnique({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
   })
@@ -57,13 +58,14 @@ export default function DeleteBuilding({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.delete({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
   })

--- a/app/features/territories/routes/prospection/disable-building.tsx
+++ b/app/features/territories/routes/prospection/disable-building.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/disable-building'
@@ -13,13 +13,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.update({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
     data: { active: false },

--- a/app/features/territories/routes/prospection/disable-building.tsx
+++ b/app/features/territories/routes/prospection/disable-building.tsx
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/disable-building'
@@ -13,14 +13,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.update({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
     data: { active: false },

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -4,6 +4,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { getBuildings } from '~/features/territories/server/get-buildings.server'
 import { serializeSharedEntranceFromBuilding } from '~/features/territories/server/serialize-shared-entrance-from-building.server'
@@ -29,7 +30,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
@@ -37,6 +38,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
@@ -124,7 +126,7 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, congregation } = await verifySession(request)
+  const { session, congregation, currentUser } = await verifySession(request)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
@@ -132,6 +134,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const previousPage = request.headers.get('referer') ?? '/territories/buildings'
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -1,10 +1,9 @@
 import { Pencil } from 'lucide-react'
 import { useState } from 'react'
 import { data, Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { getBuildings } from '~/features/territories/server/get-buildings.server'
 import { serializeSharedEntranceFromBuilding } from '~/features/territories/server/serialize-shared-entrance-from-building.server'
@@ -30,15 +29,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.ProspectionManager, Role.TerritoriesManager])
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
@@ -126,15 +124,14 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, congregation, currentUser } = await verifySession(request)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.ProspectionManager, Role.TerritoriesManager])
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const previousPage = request.headers.get('referer') ?? '/territories/buildings'
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {

--- a/app/features/territories/routes/prospection/edit-building.tsx
+++ b/app/features/territories/routes/prospection/edit-building.tsx
@@ -1,11 +1,10 @@
 import { Trash2 } from 'lucide-react'
 import { data, Form, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { editBuilding } from '~/features/territories/server/edit-building.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -26,14 +25,13 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
@@ -123,14 +121,13 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const street = form.get('street')

--- a/app/features/territories/routes/prospection/edit-building.tsx
+++ b/app/features/territories/routes/prospection/edit-building.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { editBuilding } from '~/features/territories/server/edit-building.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -25,13 +26,14 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
@@ -121,13 +123,14 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const street = form.get('street')

--- a/app/features/territories/routes/prospection/enable-building.tsx
+++ b/app/features/territories/routes/prospection/enable-building.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/enable-building'
@@ -13,13 +13,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.update({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
     data: { active: true },

--- a/app/features/territories/routes/prospection/enable-building.tsx
+++ b/app/features/territories/routes/prospection/enable-building.tsx
@@ -1,9 +1,9 @@
 import { redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/enable-building'
@@ -13,14 +13,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const building = await db.building.update({
     where: { id: requireParamId(params.buildingId, '/territories/buildings') },
     data: { active: true },

--- a/app/features/territories/routes/prospection/missing-building-list.tsx
+++ b/app/features/territories/routes/prospection/missing-building-list.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
@@ -26,6 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const staleDate = await getProspectionStaleDate()
 
   const selectors = { inOpenData: false, active: true }

--- a/app/features/territories/routes/prospection/missing-building-list.tsx
+++ b/app/features/territories/routes/prospection/missing-building-list.tsx
@@ -1,10 +1,8 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -18,16 +16,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const staleDate = await getProspectionStaleDate()
 
   const selectors = { inOpenData: false, active: true }

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -5,6 +5,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { findBuildingsWithEntrancePaginated } from '~/features/territories/server/buildings'
 import { BuildingCheckReason } from '~/features/territories/ui/BuildingCheckReason'
@@ -21,7 +22,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
@@ -30,6 +31,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -1,11 +1,9 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { findBuildingsWithEntrancePaginated } from '~/features/territories/server/buildings'
 import { BuildingCheckReason } from '~/features/territories/ui/BuildingCheckReason'
@@ -22,16 +20,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageProspection = can(Role.ProspectionManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)

--- a/app/features/territories/routes/prospection/new-building-list.tsx
+++ b/app/features/territories/routes/prospection/new-building-list.tsx
@@ -4,6 +4,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   const canManageProspection = await verifyRole(request, Role.ProspectionManager)
@@ -26,6 +27,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const staleDate = await getProspectionStaleDate()
 
   const selectors = { inOpenData: true, active: true, prospectionDate: null }

--- a/app/features/territories/routes/prospection/new-building-list.tsx
+++ b/app/features/territories/routes/prospection/new-building-list.tsx
@@ -1,10 +1,8 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { Button } from '~/shared/ui/button'
 
@@ -18,16 +16,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewProspection = await verifyRole(request, Role.ProspectionViewer)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
-  const canManageProspection = await verifyRole(request, Role.ProspectionManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.TerritoriesManager, Role.ProspectionManager])
+  const canViewProspection = can(Role.ProspectionViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canManageProspection = can(Role.ProspectionManager)
 
   if (!canViewProspection) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const staleDate = await getProspectionStaleDate()
 
   const selectors = { inOpenData: true, active: true, prospectionDate: null }

--- a/app/features/territories/routes/prospection/new-building.tsx
+++ b/app/features/territories/routes/prospection/new-building.tsx
@@ -1,9 +1,8 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { createBuilding } from '~/features/territories/server/create-building.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -17,8 +16,8 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
@@ -68,14 +67,13 @@ export default function CreateBuildingPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, currentUser } = await verifySession(request)
+  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const street = form.get('street')

--- a/app/features/territories/routes/prospection/new-building.tsx
+++ b/app/features/territories/routes/prospection/new-building.tsx
@@ -3,6 +3,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { createBuilding } from '~/features/territories/server/create-building.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -67,13 +68,14 @@ export default function CreateBuildingPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation } = await verifySession(request)
+  const { session, congregation, currentUser } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const street = form.get('street')

--- a/app/features/territories/routes/prospection/sync-buildings.tsx
+++ b/app/features/territories/routes/prospection/sync-buildings.tsx
@@ -1,10 +1,10 @@
 import { redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { syncQueue } from '~/features/territories/server/sync-queue.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 
 import type { Route } from './+types/sync-buildings'
 
@@ -17,14 +17,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.findUnique({
     where: {
       id: Number(session.get('userId')) ?? 0,

--- a/app/features/territories/routes/prospection/sync-buildings.tsx
+++ b/app/features/territories/routes/prospection/sync-buildings.tsx
@@ -4,7 +4,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { syncQueue } from '~/features/territories/server/sync-queue.server'
-import { congregationContext, db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 
 import type { Route } from './+types/sync-buildings'
 
@@ -17,13 +17,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const user = await db.user.findUnique({
     where: {
       id: Number(session.get('userId')) ?? 0,
@@ -34,12 +35,10 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/')
   }
 
-  const ctx = congregationContext.getStore()
-
   await syncQueue.add('sync', {
     userName: user.firstname ?? undefined,
     userEmail: user.email,
-    congregationId: ctx?.congregationId ?? user.congregationId,
+    congregationId: currentUser.congregationId,
   })
 
   session.flash(

--- a/app/features/territories/routes/split-tool/_layout.tsx
+++ b/app/features/territories/routes/split-tool/_layout.tsx
@@ -1,12 +1,12 @@
 import { data, NavLink, Outlet, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -18,14 +18,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const totalBuildingsForDoors = await db.building.count({
     where: {

--- a/app/features/territories/routes/split-tool/_layout.tsx
+++ b/app/features/territories/routes/split-tool/_layout.tsx
@@ -6,7 +6,7 @@ import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -18,13 +18,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const totalBuildingsForDoors = await db.building.count({
     where: {

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -4,6 +4,7 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -20,13 +21,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -21,14 +19,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -1,10 +1,10 @@
 import { redirect } from 'react-router'
 
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 
 import type { Route } from './+types/create'
@@ -14,14 +14,13 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const type = form.get('type')
   const entrances = form.get('entranceIds')

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -4,7 +4,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 
 import type { Route } from './+types/create'
@@ -14,13 +14,14 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation } = await verifySession(request)
+  const { session, congregation, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const type = form.get('type')
   const entrances = form.get('entranceIds')

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -4,6 +4,7 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -20,13 +21,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -21,14 +19,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -5,6 +5,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -22,13 +23,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -23,14 +21,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
 

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -23,14 +21,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   if (!phoneTypeActive) {

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -5,6 +5,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -22,13 +23,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   if (!phoneTypeActive) {

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -4,6 +4,7 @@ import type { Prisma } from '~/database/generated/client'
 import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -20,13 +21,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
@@ -21,14 +19,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -1,11 +1,9 @@
 import { Info } from 'lucide-react'
 import { redirect } from 'react-router'
 import { Cell, Pie, PieChart } from 'recharts'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroups } from '~/features/publishers/server/groups'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { countActiveWorkingTerritories } from '~/features/territories/server/active-working-territories.server'
 import { countAvailableTerritories } from '~/features/territories/server/available-territories.server'
@@ -48,14 +46,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const params = url.searchParams
 

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -5,6 +5,7 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getGroups } from '~/features/publishers/server/groups'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { countActiveWorkingTerritories } from '~/features/territories/server/active-working-territories.server'
 import { countAvailableTerritories } from '~/features/territories/server/available-territories.server'
@@ -47,13 +48,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const url = new URL(request.url)
   const params = url.searchParams
 

--- a/app/features/territories/routes/territory/delete.tsx
+++ b/app/features/territories/routes/territory/delete.tsx
@@ -2,7 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -10,13 +10,14 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.findUnique({ where: { id: requireParamId(params.territoryId, '/territories') } })
 
   if (territory == null) {
@@ -53,13 +54,14 @@ export default function DeleteTerritory({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.delete({ where: { id: requireParamId(params.territoryId, '/territories') } })
 
   session.flash('success', `Le territoire nº${territory.number} a été correctement supprimé`)

--- a/app/features/territories/routes/territory/delete.tsx
+++ b/app/features/territories/routes/territory/delete.tsx
@@ -1,8 +1,8 @@
 import { Form, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -10,14 +10,13 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.findUnique({ where: { id: requireParamId(params.territoryId, '/territories') } })
 
   if (territory == null) {
@@ -54,14 +53,13 @@ export default function DeleteTerritory({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.delete({ where: { id: requireParamId(params.territoryId, '/territories') } })
 
   session.flash('success', `Le territoire nº${territory.number} a été correctement supprimé`)

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -1,9 +1,8 @@
 import { Download, ExternalLink, Trash2, X } from 'lucide-react'
 import { useState } from 'react'
 import { Form, Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
@@ -17,7 +16,7 @@ import {
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -32,14 +31,13 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.findUnique({
     where: {
       id: requireParamId(params.territoryId, '/territories'),
@@ -315,14 +313,13 @@ export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const entrances = form.getAll('entrances')
   const notes = form.get('notes')

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -17,7 +17,7 @@ import {
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -32,13 +32,14 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const territory = await db.territory.findUnique({
     where: {
       id: requireParamId(params.territoryId, '/territories'),
@@ -314,13 +315,14 @@ export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const entrances = form.getAll('entrances')
   const notes = form.get('notes')

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -1,10 +1,9 @@
 import { Map as MapIcon, Pencil, Trash2 } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
@@ -29,16 +28,15 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, currentUser } = await verifySession(request)
-  const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
+  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager])
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
     throw redirect('/')
   }
 
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const canManageTerritories = can(Role.TerritoriesManager)
 
-  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -4,6 +4,7 @@ import { commitSession, verifySession } from '~/features/authentication/server/s
 import { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
+import { restoreCongregationContext } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
@@ -28,7 +29,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session } = await verifySession(request)
+  const { session, currentUser } = await verifySession(request)
   const canViewTerritories = await verifyRole(request, Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -37,6 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
+  restoreCongregationContext(currentUser.congregationId)
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -10,7 +10,7 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
-import { db } from '~/shared/libs/db.server'
+import { db, restoreCongregationContext } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -26,13 +26,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  await verifySession(request)
+  const { currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const url = new URL(request.url)
@@ -156,13 +157,14 @@ export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await verifySession(request)
+  const { congregation, currentUser } = await verifySession(request)
   const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
+  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const type = form.get('type')

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -1,16 +1,15 @@
 import { ExternalLink, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Form, Link, redirect } from 'react-router'
-import { verifySession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
-import { db, restoreCongregationContext } from '~/shared/libs/db.server'
+import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -26,14 +25,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
   const url = new URL(request.url)
@@ -157,14 +155,13 @@ export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, currentUser } = await verifySession(request)
-  const canManageTerritories = await verifyRole(request, Role.TerritoriesManager)
+  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  restoreCongregationContext(currentUser.congregationId)
   const form = await request.formData()
   const number = form.get('number')
   const type = form.get('type')

--- a/app/routes/_authenticated-layout.tsx
+++ b/app/routes/_authenticated-layout.tsx
@@ -1,38 +1,25 @@
 import { useEffect } from 'react'
 import { data } from 'react-router'
 import { toast } from 'sonner'
-import { commitSession, verifySession } from '~/features/authentication/server/session.server'
+import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { verifyRole } from '~/features/authorization/server/verify-role.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { AppLayout } from '~/shared/ui/AppLayout'
 
 import type { Route } from './+types/_authenticated-layout'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, congregation, currentUser } = await verifySession(request)
-
-  const [
-    canUploadDocument,
-    canManageBoard,
-    canViewPublishers,
-    canViewTerritories,
-    canViewProspection,
-    canManageTerritories,
-    canManageSettings,
-    canManageUsers,
-    canViewPrograms,
-    canViewActivity,
-  ] = await Promise.all([
-    verifyRole(request, Role.BoardUploader),
-    verifyRole(request, Role.BoardValidator),
-    verifyRole(request, Role.PublisherViewer),
-    verifyRole(request, Role.TerritoriesViewer),
-    verifyRole(request, Role.ProspectionViewer),
-    verifyRole(request, Role.TerritoriesManager),
-    verifyRole(request, Role.Admin),
-    verifyRole(request, Role.SettingsUserManager),
-    verifyRole(request, Role.ProgramViewer),
-    verifyRole(request, Role.ActivityViewer),
+  const { session, congregation, currentUser, can } = await authenticateAndAuthorize(request, [
+    Role.BoardUploader,
+    Role.BoardValidator,
+    Role.PublisherViewer,
+    Role.TerritoriesViewer,
+    Role.ProspectionViewer,
+    Role.TerritoriesManager,
+    Role.Admin,
+    Role.SettingsUserManager,
+    Role.ProgramViewer,
+    Role.ActivityViewer,
   ])
 
   const messages = { success: session.get('success'), error: session.get('error') }
@@ -41,16 +28,16 @@ export async function loader({ request }: Route.LoaderArgs) {
     {
       permissions: {
         canViewBoard: true,
-        canUploadDocument,
-        canManageBoard,
-        canViewPublishers,
-        canViewTerritories,
-        canViewProspection,
-        canManageTerritories,
-        canManageSettings,
-        canManageUsers,
-        canViewPrograms,
-        canViewActivity,
+        canUploadDocument: can(Role.BoardUploader),
+        canManageBoard: can(Role.BoardValidator),
+        canViewPublishers: can(Role.PublisherViewer),
+        canViewTerritories: can(Role.TerritoriesViewer),
+        canViewProspection: can(Role.ProspectionViewer),
+        canManageTerritories: can(Role.TerritoriesManager),
+        canManageSettings: can(Role.Admin),
+        canManageUsers: can(Role.SettingsUserManager),
+        canViewPrograms: can(Role.ProgramViewer),
+        canViewActivity: can(Role.ActivityViewer),
         isPlatformAdmin: currentUser.platformAdmin ?? false,
       },
       congregationName: congregation.displayName ?? congregation.name,

--- a/app/shared/libs/auth.server.test.ts
+++ b/app/shared/libs/auth.server.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Role } from '~/features/authorization/model/roles.type'
+
+vi.mock('~/features/authentication/server/session.server', () => ({
+  verifySession: vi.fn(),
+}))
+
+vi.mock('~/features/authorization/server/verify-role.server', () => ({
+  verifyRole: vi.fn(),
+}))
+
+vi.mock('~/shared/libs/db.server', () => ({
+  restoreCongregationContext: vi.fn(),
+}))
+
+const { authenticateAndAuthorize } = await import('./auth.server')
+const { verifySession } = await import('~/features/authentication/server/session.server')
+const { verifyRole } = await import('~/features/authorization/server/verify-role.server')
+const { restoreCongregationContext } = await import('~/shared/libs/db.server')
+
+function makeRequest() {
+  return new Request('http://localhost/')
+}
+
+const fakeSessionResult = {
+  currentUser: { id: 1, congregationId: 5, firstname: 'Test', lastname: 'User' },
+  congregation: { id: 5, name: 'Test', slug: 'test' },
+  session: {},
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(verifySession).mockResolvedValue(fakeSessionResult as never)
+})
+
+describe('authenticateAndAuthorize', () => {
+  it('retourne les données de verifySession', async () => {
+    const result = await authenticateAndAuthorize(makeRequest())
+
+    expect(result.currentUser).toBe(fakeSessionResult.currentUser)
+    expect(result.congregation).toBe(fakeSessionResult.congregation)
+    expect(result.session).toBe(fakeSessionResult.session)
+  })
+
+  it('résout les permissions via verifyRole', async () => {
+    vi.mocked(verifyRole).mockImplementation((_req, role) => {
+      return Promise.resolve(role === Role.Admin)
+    })
+
+    const result = await authenticateAndAuthorize(makeRequest(), [Role.Admin, Role.BoardUploader])
+
+    expect(result.can(Role.Admin)).toBe(true)
+    expect(result.can(Role.BoardUploader)).toBe(false)
+  })
+
+  it('retourne false pour un rôle non demandé', async () => {
+    vi.mocked(verifyRole).mockResolvedValue(true as never)
+
+    const result = await authenticateAndAuthorize(makeRequest(), [Role.Admin])
+
+    expect(result.can(Role.TerritoriesViewer)).toBe(false)
+  })
+
+  it('fonctionne sans rôles', async () => {
+    const result = await authenticateAndAuthorize(makeRequest())
+
+    expect(verifyRole).not.toHaveBeenCalled()
+    expect(result.can(Role.Admin)).toBe(false)
+  })
+
+  it('appelle restoreCongregationContext après la résolution des rôles', async () => {
+    vi.mocked(verifyRole).mockResolvedValue(true as never)
+
+    await authenticateAndAuthorize(makeRequest(), [Role.Admin])
+
+    expect(restoreCongregationContext).toHaveBeenCalledWith(5)
+  })
+})

--- a/app/shared/libs/auth.server.ts
+++ b/app/shared/libs/auth.server.ts
@@ -1,0 +1,29 @@
+import { verifySession } from '~/features/authentication/server/session.server'
+import type { Role } from '~/features/authorization/model/roles.type'
+import { verifyRole } from '~/features/authorization/server/verify-role.server'
+
+import { restoreCongregationContext } from './db.server'
+
+/**
+ * Authenticates the user, checks roles, and restores the congregation context.
+ *
+ * Combines verifySession + verifyRole + restoreCongregationContext into a single call.
+ * Use this in all authenticated route loaders and actions.
+ */
+export async function authenticateAndAuthorize(request: Request, roles: Role[] = []) {
+  const { currentUser, congregation, session } = await verifySession(request)
+
+  const resolved = await Promise.all(roles.map(async (role) => [role, await verifyRole(request, role)] as const))
+  const permissions = new Set(resolved.filter(([, granted]) => granted).map(([role]) => role))
+
+  // Restore ALS context after all auth/role Prisma queries.
+  // The Prisma 7 pg adapter breaks AsyncLocalStorage propagation after async operations.
+  restoreCongregationContext(currentUser.congregationId)
+
+  return {
+    currentUser,
+    congregation,
+    session,
+    can: (role: Role) => permissions.has(role),
+  }
+}

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -11,7 +11,7 @@ vi.mock('~/shared/libs/db.server', () => ({
 
 vi.mock('react-router', () => ({
   redirect: vi.fn((url: string) => {
-    // biome-ignore lint/style/useNamingConvention: en-tête HTTP standard
+    // biome-ignore lint/style/useNamingConvention: standard HTTP header
     throw new Response(null, { status: 302, headers: { Location: url } })
   }),
 }))

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -73,10 +73,10 @@ export function getPlatformName(): string {
 }
 
 /**
- * Résout l'assemblée locale correspondant au sous-domaine ou domaine personnalisé de la requête.
+ * Resolves the congregation matching the subdomain or custom domain from the request.
  *
- * - Retourne `null` en mode mono-tenant ou si aucun slug n'est extrait de l'URL (domaine racine).
- * - Redirige vers `/congregation-not-found` si un slug est présent mais ne correspond à aucune assemblée.
+ * - Returns `null` in single-tenant mode or if no slug is extracted from the URL (root domain).
+ * - Redirects to `/congregation-not-found` if a slug is present but doesn't match any congregation.
  */
 export async function resolveCongregationFromRequest(
   request: Request,
@@ -94,18 +94,18 @@ export async function resolveCongregationFromRequest(
     })
     if (congregation) return congregation
 
-    // Le slug est présent dans l'URL mais ne correspond à aucune assemblée
+    // Slug is present in the URL but doesn't match any congregation
     throw redirect('/congregation-not-found')
   }
 
-  // Pas de slug — tenter la résolution par domaine personnalisé
+  // No slug — try resolving by custom domain
   const congregation = await unscopedDb.congregation.findFirst({
     where: { domain: hostname },
     select: { id: true, slug: true },
   })
   if (congregation) return congregation
 
-  // Domaine racine ou domaine inconnu sans slug — pas d'assemblée à résoudre
+  // Root domain or unknown domain without slug — no congregation to resolve
   return null
 }
 

--- a/app/shared/libs/db.server.ts
+++ b/app/shared/libs/db.server.ts
@@ -14,6 +14,17 @@ type CongregationContext = {
 }
 export const congregationContext = new AsyncLocalStorage<CongregationContext>()
 
+/**
+ * Restaure le contexte de congrégation dans l'AsyncLocalStorage.
+ *
+ * L'adaptateur pg de Prisma 7 casse la propagation d'AsyncLocalStorage après
+ * les requêtes async. Appeler cette fonction dans les loaders après verifySession()
+ * et verifyRole() pour garantir que les requêtes `db` suivantes soient bien scopées.
+ */
+export function restoreCongregationContext(congregationId: number) {
+  congregationContext.enterWith({ congregationId })
+}
+
 const SCOPED_MODELS = new Set([
   'User',
   'Territory',

--- a/app/shared/libs/db.server.ts
+++ b/app/shared/libs/db.server.ts
@@ -14,14 +14,20 @@ type CongregationContext = {
 }
 export const congregationContext = new AsyncLocalStorage<CongregationContext>()
 
+// Fallback congregation ID when ALS context is lost. Used by the db extension
+// as a safety net when concurrent loaders (run in parallel by React Router)
+// break each other's ALS context via the Prisma 7 pg adapter.
+let fallbackCongregationId: number | null = null
+
 /**
- * Restaure le contexte de congrégation dans l'AsyncLocalStorage.
+ * Restores the congregation context in AsyncLocalStorage.
  *
- * L'adaptateur pg de Prisma 7 casse la propagation d'AsyncLocalStorage après
- * les requêtes async. Appeler cette fonction dans les loaders après verifySession()
- * et verifyRole() pour garantir que les requêtes `db` suivantes soient bien scopées.
+ * The Prisma 7 pg adapter breaks AsyncLocalStorage propagation after async queries.
+ * Also stores the congregation ID in a module-level fallback for cases where
+ * concurrent loaders break each other's ALS context.
  */
 export function restoreCongregationContext(congregationId: number) {
+  fallbackCongregationId = congregationId
   congregationContext.enterWith({ congregationId })
 }
 
@@ -60,7 +66,16 @@ const db = unscopedDb.$extends({
     async $allOperations({ model, operation, args, query }) {
       if (!model || !SCOPED_MODELS.has(model)) return query(args)
 
-      const ctx = congregationContext.getStore()
+      let ctx = congregationContext.getStore()
+
+      // If ALS context is lost (Prisma 7 pg adapter issue), recover from the fallback.
+      // This handles concurrent loaders run in parallel by React Router where one loader's
+      // Prisma queries break another loader's ALS context.
+      if (!ctx && fallbackCongregationId) {
+        ctx = { congregationId: fallbackCongregationId }
+        congregationContext.enterWith(ctx)
+      }
+
       if (!ctx) {
         throw new Error(
           `Congregation context is required for ${model}.${operation} but was not set. ` +
@@ -91,8 +106,8 @@ const db = unscopedDb.$extends({
 
       const result = await query(args)
 
-      // Restaurer le contexte ALS après la requête — l'adaptateur pg de Prisma 7
-      // peut casser la propagation d'AsyncLocalStorage lors des opérations async.
+      // Restore ALS context after query — the Prisma 7 pg adapter can break
+      // AsyncLocalStorage propagation during async operations.
       congregationContext.enterWith(ctx)
 
       return result


### PR DESCRIPTION
## Summary

- **Subdomain validation**: unauthenticated routes (login, password-forgot, password-reset) now validate the subdomain and redirect to `/congregation-not-found` for unknown subdomains
- **Data scoping fix**: the Prisma 7 pg adapter breaks `AsyncLocalStorage` after awaited queries, causing the scoped `db` client to silently return unscoped data. The extension now throws on missing context (fail-safe) and re-enters context after each query
- **`authenticateAndAuthorize()` wrapper**: replaces the fragile 3-step pattern (`verifySession` + `verifyRole` + `restoreCongregationContext`) across 83 route files with a single function call. Returns a `can(Role)` function for cleaner permission checks. Role checks run via `Promise.all` (faster than sequential)
- **Fallback for concurrent loaders**: module-level fallback in the `db` extension handles cases where React Router runs parallel loaders that break each other's ALS context
- **Code comments in English**: translated all French comments introduced in this branch

Builds on #11 which handled session/login tenant validation.

## Test plan

- [ ] Log into congregation A, navigate to congregation B → see B's login page (session destroyed)
- [ ] On congregation B's login, use congregation A's credentials → "Email ou mot de passe invalide"
- [ ] Visit unknown subdomain → "Assemblée non trouvée" error page
- [ ] Log into congregation A → see only congregation A's data (users, territories, publishers)
- [ ] Navigate all pages — no context errors in console
- [ ] Single-tenant mode (`MULTI_TENANT` unset) → no behavioral change
- [ ] `pnpm test:unit` — 321 tests pass
- [ ] `pnpm test:typecheck` — clean
- [ ] `pnpm test:lint` — clean