### PR TITLE
fix: replace ALS-based db scoping with closure-based scoped client

### DIFF
--- a/app/features/authentication/routes/login.tsx
+++ b/app/features/authentication/routes/login.tsx
@@ -1,6 +1,4 @@
 import { data, Form, Link, redirect } from 'react-router'
-
-import { getBrandingName, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { needSetupProcess } from '~/features/authentication/server/need-setup-process.server'
 import {
   checkLoginRateLimit,
@@ -9,6 +7,7 @@ import {
 } from '~/features/authentication/server/rate-limit.server'
 import { commitSession, destroySession, getSession } from '~/features/authentication/server/session.server'
 import { validateCredentials } from '~/features/authentication/server/validate-credentials.server'
+import { getBrandingName, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { unscopedDb } from '~/shared/libs/db.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'

--- a/app/features/authentication/routes/password-reset.tsx
+++ b/app/features/authentication/routes/password-reset.tsx
@@ -1,12 +1,11 @@
 import { Form, redirect } from 'react-router'
-
-import { getBrandingName, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import {
   consumePasswordResetToken,
   verifyPasswordResetToken,
 } from '~/features/authentication/server/invalidate-user-password.server'
 import { resetUserPassword } from '~/features/authentication/server/reset-user-password.server'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
+import { getBrandingName, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'

--- a/app/features/authentication/routes/register.tsx
+++ b/app/features/authentication/routes/register.tsx
@@ -112,7 +112,7 @@ export async function action({ request }: Route.ActionArgs) {
   const repeatPassword = String(form.get('repeat-password'))
 
   if (congregationName.length < 2) {
-    session.flash('error', 'Le nom de l\'assemblée locale doit faire au moins 2 caractères.')
+    session.flash('error', "Le nom de l'assemblée locale doit faire au moins 2 caractères.")
     return redirect('/register', { headers: { 'Set-Cookie': await commitSession(session) } })
   }
 
@@ -133,7 +133,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const slug = slugify(congregationName)
   if (slug.length < 2) {
-    session.flash('error', 'Le nom de l\'assemblée locale génère un identifiant invalide.')
+    session.flash('error', "Le nom de l'assemblée locale génère un identifiant invalide.")
     return redirect('/register', { headers: { 'Set-Cookie': await commitSession(session) } })
   }
 

--- a/app/features/authentication/routes/user/_layout.tsx
+++ b/app/features/authentication/routes/user/_layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from 'react-router'
-
-import type { Route } from './+types/_layout'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import type { Route } from './+types/_layout'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mon compte - Unitae' }]

--- a/app/features/authentication/routes/user/profile.tsx
+++ b/app/features/authentication/routes/user/profile.tsx
@@ -1,6 +1,7 @@
 import { Form, redirect } from 'react-router'
 import { changeUserPassword } from '~/features/authentication/server/change-user-password.server'
 import { commitSession } from '~/features/authentication/server/session.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -8,9 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
 import { Label } from '~/shared/ui/label'
 import { PageHeader } from '~/shared/ui/PageHeader'
-
 import type { Route } from './+types/profile'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mon profil - Unitae' }]

--- a/app/features/authentication/server/change-user-password.server.test.ts
+++ b/app/features/authentication/server/change-user-password.server.test.ts
@@ -34,7 +34,7 @@ describe('changeUserPassword', () => {
     expect(result).toBe(true)
   })
 
-  it('retourne false quand l\'utilisateur n\'existe pas', async () => {
+  it("retourne false quand l'utilisateur n'existe pas", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue(null as never)
 
     const result = await changeUserPassword(999, 'ancien', 'nouveau')

--- a/app/features/authentication/server/invalidate-user-password.server.test.ts
+++ b/app/features/authentication/server/invalidate-user-password.server.test.ts
@@ -29,7 +29,12 @@ afterEach(() => {
 describe('createPasswordResetToken', () => {
   it('retourne un token non vide', async () => {
     vi.mocked(db.passwordResetToken.deleteMany).mockResolvedValue({ count: 0 } as never)
-    vi.mocked(db.passwordResetToken.create).mockResolvedValue({ id: 1, token: 'abc', userId: 42, expiresAt: new Date() } as never)
+    vi.mocked(db.passwordResetToken.create).mockResolvedValue({
+      id: 1,
+      token: 'abc',
+      userId: 42,
+      expiresAt: new Date(),
+    } as never)
 
     const token = await createPasswordResetToken(42)
     expect(token).toBeTruthy()
@@ -39,7 +44,7 @@ describe('createPasswordResetToken', () => {
 })
 
 describe('verifyPasswordResetToken', () => {
-  it('retourne l\'utilisateur pour un token valide non expiré', async () => {
+  it("retourne l'utilisateur pour un token valide non expiré", async () => {
     const futureDate = new Date()
     futureDate.setHours(futureDate.getHours() + 12) // expire dans 12h
 
@@ -82,7 +87,7 @@ describe('verifyPasswordResetToken', () => {
 })
 
 describe('consumePasswordResetToken', () => {
-  it('ne lance pas d\'erreur pour un token existant', async () => {
+  it("ne lance pas d'erreur pour un token existant", async () => {
     vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue({
       id: 1,
       token: 'to-consume',
@@ -94,7 +99,7 @@ describe('consumePasswordResetToken', () => {
     await expect(consumePasswordResetToken('to-consume')).resolves.toBeUndefined()
   })
 
-  it('ne lance pas d\'erreur pour un token inexistant', async () => {
+  it("ne lance pas d'erreur pour un token inexistant", async () => {
     vi.mocked(db.passwordResetToken.findUnique).mockResolvedValue(null as never)
 
     await expect(consumePasswordResetToken('inexistant')).resolves.toBeUndefined()

--- a/app/features/authentication/server/need-setup-process.server.test.ts
+++ b/app/features/authentication/server/need-setup-process.server.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 })
 
 describe('needSetupProcess', () => {
-  it('retourne true quand il n\'y a aucun utilisateur', async () => {
+  it("retourne true quand il n'y a aucun utilisateur", async () => {
     vi.mocked(db.user.count).mockResolvedValue(0)
 
     expect(await needSetupProcess()).toBe(true)

--- a/app/features/authentication/server/rate-limit.server.test.ts
+++ b/app/features/authentication/server/rate-limit.server.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 })
 
 describe('checkLoginRateLimit', () => {
-  it('retourne true quand aucune tentative n\'a été enregistrée', async () => {
+  it("retourne true quand aucune tentative n'a été enregistrée", async () => {
     vi.mocked(redis.get).mockResolvedValue(null)
 
     const result = await checkLoginRateLimit('test@example.com')
@@ -51,14 +51,14 @@ describe('checkLoginRateLimit', () => {
     expect(result).toBe(false)
   })
 
-  it('retourne true en cas d\'erreur Redis (dégradation gracieuse)', async () => {
+  it("retourne true en cas d'erreur Redis (dégradation gracieuse)", async () => {
     vi.mocked(redis.get).mockRejectedValue(new Error('Redis down'))
 
     const result = await checkLoginRateLimit('test@example.com')
     expect(result).toBe(true)
   })
 
-  it('normalise l\'email en minuscules', async () => {
+  it("normalise l'email en minuscules", async () => {
     vi.mocked(redis.get).mockResolvedValue('4')
 
     // Les deux doivent retourner le même résultat car la clé est normalisée
@@ -69,14 +69,14 @@ describe('checkLoginRateLimit', () => {
 })
 
 describe('recordLoginAttempt', () => {
-  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+  it("ne lance pas d'erreur en fonctionnement normal", async () => {
     vi.mocked(redis.incr).mockResolvedValue(1)
     vi.mocked(redis.expire).mockResolvedValue(1)
 
     await expect(recordLoginAttempt('test@example.com')).resolves.toBeUndefined()
   })
 
-  it('ne lance pas d\'erreur en cas d\'erreur Redis', async () => {
+  it("ne lance pas d'erreur en cas d'erreur Redis", async () => {
     vi.mocked(redis.incr).mockRejectedValue(new Error('Redis down'))
 
     await expect(recordLoginAttempt('test@example.com')).resolves.toBeUndefined()
@@ -84,13 +84,13 @@ describe('recordLoginAttempt', () => {
 })
 
 describe('clearLoginAttempts', () => {
-  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+  it("ne lance pas d'erreur en fonctionnement normal", async () => {
     vi.mocked(redis.del).mockResolvedValue(1)
 
     await expect(clearLoginAttempts('test@example.com')).resolves.toBeUndefined()
   })
 
-  it('ne lance pas d\'erreur en cas d\'erreur Redis', async () => {
+  it("ne lance pas d'erreur en cas d'erreur Redis", async () => {
     vi.mocked(redis.del).mockRejectedValue(new Error('Redis down'))
 
     await expect(clearLoginAttempts('test@example.com')).resolves.toBeUndefined()

--- a/app/features/authentication/server/register-congregation.server.test.ts
+++ b/app/features/authentication/server/register-congregation.server.test.ts
@@ -44,7 +44,7 @@ describe('registerCongregation', () => {
     expect(result.error).toContain('déjà pris')
   })
 
-  it('retourne une erreur si l\'email existe déjà', async () => {
+  it("retourne une erreur si l'email existe déjà", async () => {
     vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' } as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')
@@ -53,7 +53,7 @@ describe('registerCongregation', () => {
     expect(result.error).toContain('email')
   })
 
-  it('normalise l\'email en minuscules pour la vérification', async () => {
+  it("normalise l'email en minuscules pour la vérification", async () => {
     // Simule un utilisateur existant avec l'email en minuscules
     vi.mocked(db.user.findUnique).mockResolvedValue({ id: 1, email: 'admin@test.com' } as never)
 
@@ -62,7 +62,7 @@ describe('registerCongregation', () => {
     expect(result).toHaveProperty('error')
   })
 
-  it('fonctionne même si le rôle admin n\'existe pas', async () => {
+  it("fonctionne même si le rôle admin n'existe pas", async () => {
     vi.mocked(db.userRole.findUnique).mockResolvedValue(null as never)
 
     const result = await registerCongregation('Ma Congrégation', 'test-congre', 'admin@test.com', 'motdepasse')

--- a/app/features/authentication/server/register-congregation.server.ts
+++ b/app/features/authentication/server/register-congregation.server.ts
@@ -10,7 +10,7 @@ export async function registerCongregation(
 ) {
   const existingCongregation = await db.congregation.findUnique({ where: { slug: congregationSlug } })
   if (existingCongregation) {
-    return { error: 'Ce nom d\'assemblée locale est déjà pris.' }
+    return { error: "Ce nom d'assemblée locale est déjà pris." }
   }
 
   const existingUser = await db.user.findUnique({ where: { email: adminEmail.toLowerCase() } })

--- a/app/features/authentication/server/reset-user-password.server.test.ts
+++ b/app/features/authentication/server/reset-user-password.server.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 })
 
 describe('resetUserPassword', () => {
-  it('ne lance pas d\'erreur en fonctionnement normal', async () => {
+  it("ne lance pas d'erreur en fonctionnement normal", async () => {
     await expect(resetUserPassword(1, 'nouveau-mdp')).resolves.toBeUndefined()
   })
 })

--- a/app/features/authentication/server/sanitize-user.server.test.ts
+++ b/app/features/authentication/server/sanitize-user.server.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { sanitizeUser } from './sanitize-user.server'
 
 describe('sanitizeUser', () => {
-  it('supprime le mot de passe de l\'objet utilisateur', () => {
+  it("supprime le mot de passe de l'objet utilisateur", () => {
     const user = {
       id: 1,
       email: 'test@example.com',

--- a/app/features/authentication/server/send-reset-user-password-email.server.test.ts
+++ b/app/features/authentication/server/send-reset-user-password-email.server.test.ts
@@ -32,14 +32,14 @@ beforeEach(() => {
 })
 
 describe('sendResetUserPasswordEmail', () => {
-  it('retourne false quand l\'utilisateur n\'existe pas', async () => {
+  it("retourne false quand l'utilisateur n'existe pas", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue(null as never)
 
     const result = await sendResetUserPasswordEmail(999, 'email-template' as never)
     expect(result).toBe(false)
   })
 
-  it('envoie l\'email quand l\'utilisateur existe', async () => {
+  it("envoie l'email quand l'utilisateur existe", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 } as never)
     vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' } as never)
     vi.mocked(mailer.emails.send).mockResolvedValue({} as never)
@@ -52,7 +52,7 @@ describe('sendResetUserPasswordEmail', () => {
     expect(result).not.toBe(false)
   })
 
-  it('ne lance pas d\'erreur quand l\'envoi d\'email échoue', async () => {
+  it("ne lance pas d'erreur quand l'envoi d'email échoue", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue({ id: 1, email: 'test@example.com', congregationId: 5 } as never)
     vi.mocked(resolveCongregation).mockResolvedValue({ emailFrom: 'Congré <noreply@test.org>' } as never)
     vi.mocked(mailer.emails.send).mockRejectedValue(new Error('SMTP error'))

--- a/app/features/authentication/server/setup-first-user.server.test.ts
+++ b/app/features/authentication/server/setup-first-user.server.test.ts
@@ -25,12 +25,12 @@ beforeEach(() => {
 })
 
 describe('setupFirstUser', () => {
-  it('retourne l\'id de l\'utilisateur créé', async () => {
+  it("retourne l'id de l'utilisateur créé", async () => {
     const result = await setupFirstUser('admin@test.com', 'motdepasse', 'Ma Congré', 'ma-congre')
     expect(result).toBe(42)
   })
 
-  it('fonctionne même si le rôle admin n\'existe pas', async () => {
+  it("fonctionne même si le rôle admin n'existe pas", async () => {
     vi.mocked(db.userRole.findUnique).mockResolvedValue(null as never)
 
     const result = await setupFirstUser('admin@test.com', 'motdepasse', 'Ma Congré', 'ma-congre')

--- a/app/features/authentication/server/validate-credentials.server.test.ts
+++ b/app/features/authentication/server/validate-credentials.server.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 describe('validateCredentials', () => {
   const fakeUser = { id: 42, email: 'test@example.com', password: 'hashed.password', active: true }
 
-  it('retourne l\'id de l\'utilisateur pour des identifiants valides', async () => {
+  it("retourne l'id de l'utilisateur pour des identifiants valides", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
     vi.mocked(compare).mockResolvedValue(true as never)
 
@@ -29,7 +29,7 @@ describe('validateCredentials', () => {
     expect(result).toBe(42)
   })
 
-  it('normalise l\'email en minuscules', async () => {
+  it("normalise l'email en minuscules", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
     vi.mocked(compare).mockResolvedValue(true as never)
 
@@ -89,7 +89,7 @@ describe('validateCredentials', () => {
     })
   })
 
-  it('ne filtre pas par congregationId quand il n\'est pas fourni', async () => {
+  it("ne filtre pas par congregationId quand il n'est pas fourni", async () => {
     vi.mocked(db.user.findFirst).mockResolvedValue(fakeUser as never)
     vi.mocked(compare).mockResolvedValue(true as never)
 

--- a/app/features/authorization/server/verify-role.server.test.ts
+++ b/app/features/authorization/server/verify-role.server.test.ts
@@ -37,21 +37,21 @@ beforeEach(() => {
 })
 
 describe('verifyRole', () => {
-  it('retourne false quand userId n\'est pas dans la session', async () => {
+  it("retourne false quand userId n'est pas dans la session", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession(undefined) as never)
 
     const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
-  it('retourne false quand userId n\'est pas un nombre', async () => {
+  it("retourne false quand userId n'est pas un nombre", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('abc') as never)
 
     const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
-  it('retourne true quand l\'utilisateur a le rôle admin', async () => {
+  it("retourne true quand l'utilisateur a le rôle admin", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → trouvé
@@ -61,7 +61,7 @@ describe('verifyRole', () => {
     expect(result).toBe(true)
   })
 
-  it('retourne true quand l\'utilisateur a le rôle demandé (pas admin)', async () => {
+  it("retourne true quand l'utilisateur a le rôle demandé (pas admin)", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → pas trouvé
@@ -73,7 +73,7 @@ describe('verifyRole', () => {
     expect(result).toBe(true)
   })
 
-  it('retourne false quand l\'utilisateur n\'a ni admin ni le rôle demandé', async () => {
+  it("retourne false quand l'utilisateur n'a ni admin ni le rôle demandé", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
     vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValue(null as never)
@@ -87,13 +87,15 @@ describe('verifyRole', () => {
     vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 5 } as never)
     // admin check → non, role check → oui
-    vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null as never).mockResolvedValueOnce({ id: 3 } as never)
+    vi.mocked(unscopedDb.congregationUserRole.findFirst)
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce({ id: 3 } as never)
 
     const result = await verifyRole(makeRequest(), 'territories-manager' as never)
     expect(result).toBe(true)
   })
 
-  it('retourne false quand le fallback ne trouve pas l\'utilisateur', async () => {
+  it("retourne false quand le fallback ne trouve pas l'utilisateur", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null as never)

--- a/app/features/board/routes/_layout.tsx
+++ b/app/features/board/routes/_layout.tsx
@@ -9,7 +9,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.TerritoriesViewer, Role.SettingsUserManager, Role.PublisherViewer, Role.BoardValidator, Role.ProspectionViewer])
+  const { session, can } = await authenticateAndAuthorize(request, [
+    Role.BoardUploader,
+    Role.TerritoriesViewer,
+    Role.SettingsUserManager,
+    Role.PublisherViewer,
+    Role.BoardValidator,
+    Role.ProspectionViewer,
+  ])
   const canUploadDocument = can(Role.BoardUploader)
   const canViewTerritories = can(Role.TerritoriesViewer)
   const canManageSettings = can(Role.SettingsUserManager)

--- a/app/features/board/routes/documents/delete.tsx
+++ b/app/features/board/routes/documents/delete.tsx
@@ -1,9 +1,8 @@
 import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { deleteFile } from '~/features/board/server/document'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -12,7 +11,7 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
@@ -48,7 +47,7 @@ export default function DeleteDocumentPage({ loaderData }: Route.ComponentProps)
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { session, currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {

--- a/app/features/board/routes/documents/edit.tsx
+++ b/app/features/board/routes/documents/edit.tsx
@@ -3,7 +3,6 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
@@ -156,7 +155,7 @@ export default function EditDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   const form = await request.formData()

--- a/app/features/board/routes/documents/list.tsx
+++ b/app/features/board/routes/documents/list.tsx
@@ -1,9 +1,8 @@
 import { ChevronDown, ChevronUp, Eye, FileText, Pencil, Trash2 } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { DocumentVisibility } from '~/features/board/ui/DocumentVisibility'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -18,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {

--- a/app/features/board/routes/documents/move-down.tsx
+++ b/app/features/board/routes/documents/move-down.tsx
@@ -2,7 +2,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,7 +11,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/documents/move-up.tsx
+++ b/app/features/board/routes/documents/move-up.tsx
@@ -2,7 +2,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,7 +11,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/documents/new.tsx
+++ b/app/features/board/routes/documents/new.tsx
@@ -2,10 +2,9 @@ import { type FileUpload, parseFormData } from '@mjackson/form-data-parser'
 import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { saveFile } from '~/features/board/server/document'
 import { sendNewDocumentNotificationEmail } from '~/features/board/server/notifications'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
@@ -132,7 +131,10 @@ export default function NewDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { currentUser, session, congregation, can, db } = await authenticateAndAuthorize(request, [
+    Role.BoardUploader,
+    Role.BoardValidator,
+  ])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
@@ -188,7 +190,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/documents/new')
   }
 
-  const limits = new LimitService(congregation)
+  const limits = new LimitService(db, congregation)
   await limits.errorIfWouldGoOverLimit('boardDocuments')
 
   const storageKey = await saveFile(file)
@@ -240,7 +242,7 @@ export async function action({ request }: Route.ActionArgs) {
   })
 
   if (!canManageBoard) {
-    sendNewDocumentNotificationEmail({ document })
+    sendNewDocumentNotificationEmail(db, { document })
   }
 
   return redirect(`/board/documents/${document.id}/edit`, {

--- a/app/features/board/routes/documents/pdf-loader.tsx
+++ b/app/features/board/routes/documents/pdf-loader.tsx
@@ -1,18 +1,16 @@
 import { redirect } from 'react-router'
 import { getFileStream } from '~/features/board/server/document'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
-
 import type { Route } from './+types/pdf-loader'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: `Tableau d'affichage - Unitae` }]
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser } = await authenticateAndAuthorize(request)
+  const { currentUser, db } = await authenticateAndAuthorize(request)
   logger.info(`Loading document ID: ${params.documentId}. User ID: ${currentUser.id}.`, { currentUser })
 
   const document = await db.boardDocument.update({

--- a/app/features/board/routes/index.tsx
+++ b/app/features/board/routes/index.tsx
@@ -1,8 +1,7 @@
 import { FileText } from 'lucide-react'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { DocumentCard } from '~/features/board/ui/DocumentCard'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { EmptyState } from '~/shared/ui/EmptyState'
 
@@ -13,7 +12,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 

--- a/app/features/board/routes/sections/delete.tsx
+++ b/app/features/board/routes/sections/delete.tsx
@@ -2,7 +2,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -10,7 +9,7 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
@@ -46,7 +45,7 @@ export default function DeleteSectionPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/sections/edit.tsx
+++ b/app/features/board/routes/sections/edit.tsx
@@ -3,7 +3,6 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -18,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
@@ -77,7 +76,7 @@ export default function EditSectionPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session } = await authenticateAndAuthorize(request)
+  const { session, db } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 

--- a/app/features/board/routes/sections/list.tsx
+++ b/app/features/board/routes/sections/list.tsx
@@ -2,7 +2,6 @@ import { ChevronDown, ChevronUp, FolderOpen, Pencil, Trash2 } from 'lucide-react
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +16,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/sections/move-down.tsx
+++ b/app/features/board/routes/sections/move-down.tsx
@@ -2,7 +2,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -12,7 +11,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/sections/move-up.tsx
+++ b/app/features/board/routes/sections/move-up.tsx
@@ -2,7 +2,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -12,7 +11,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {

--- a/app/features/board/routes/sections/new.tsx
+++ b/app/features/board/routes/sections/new.tsx
@@ -2,7 +2,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -49,7 +48,7 @@ export default function NewSectionPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation } = await authenticateAndAuthorize(request)
+  const { session, congregation, db } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 

--- a/app/features/board/server/notifications.tsx
+++ b/app/features/board/server/notifications.tsx
@@ -2,11 +2,11 @@ import NewDocumentInBoard from 'emails/notifications/new-document-in-board'
 import type { BoardDocument } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
 import { requireCongregation } from '~/shared/libs/congregation.server'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { mailer } from '~/shared/libs/mailer.server'
 
-export async function sendNewDocumentNotificationEmail({ document }: { document: BoardDocument }) {
+export async function sendNewDocumentNotificationEmail(db: ScopedDb, { document }: { document: BoardDocument }) {
   const users = await db.user.findMany({
     where: {
       congregationRoles: {

--- a/app/features/events/routes/days-off/delete.tsx
+++ b/app/features/events/routes/days-off/delete.tsx
@@ -2,17 +2,15 @@ import { Form, redirect } from 'react-router'
 
 import { commitSession } from '~/features/authentication/server/session.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
-
 import type { Route } from './+types/delete'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser } = await authenticateAndAuthorize(request)
+  const { currentUser, db } = await authenticateAndAuthorize(request)
   logger.info(`Trying to remove days off. User ID: ${currentUser.id}. Event: ${params.eventId}`)
 
   const event = await db.event.findUnique({
@@ -55,7 +53,7 @@ export default function DeleteDayOff({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser } = await authenticateAndAuthorize(request)
+  const { session, currentUser, db } = await authenticateAndAuthorize(request)
   const event = await db.event.findUnique({
     where: { id: requireParamId(params.eventId, '/me/days-off') },
     include: { createdBy: true },

--- a/app/features/events/routes/days-off/list.tsx
+++ b/app/features/events/routes/days-off/list.tsx
@@ -1,22 +1,21 @@
 import { CalendarOff, X } from 'lucide-react'
 import { Link } from 'react-router'
 import { getNextDaysOffs } from '~/features/events/server/days-off.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { EmptyState } from '~/shared/ui/EmptyState'
 import { PageHeader } from '~/shared/ui/PageHeader'
-
 import type { Route } from './+types/list'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Mes absences - Unitae' }]
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session } = await authenticateAndAuthorize(request)
-  const events = await getNextDaysOffs(currentUser.id)
+  const { currentUser, session, db } = await authenticateAndAuthorize(request)
+  const events = await getNextDaysOffs(db, currentUser.id)
 
   logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)
 

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -2,15 +2,14 @@ import { useState } from 'react'
 import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { createDayOff } from '~/features/events/server/days-off.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
 import { Label } from '~/shared/ui/label'
 import { PageHeader } from '~/shared/ui/PageHeader'
-
 import type { Route } from './+types/new'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 export const meta: Route.MetaFunction = () => {
   return [{ title: 'Ajouter une absence - Unitae' }]
@@ -75,14 +74,14 @@ export default function DaysOffPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation } = await authenticateAndAuthorize(request)
+  const { currentUser, session, congregation, db } = await authenticateAndAuthorize(request)
   const formData = await request.formData()
   const startDate = new Date(String(formData.get('start_date')))
   const endDate = new Date(String(formData.get('end_date')))
 
   logger.info(`Creating new days off. User ID: ${currentUser.id}.`)
 
-  const event = await createDayOff(currentUser.id, startDate, endDate, congregation.id)
+  const event = await createDayOff(db, currentUser.id, startDate, endDate, congregation.id)
   if (event == null) {
     session.flash('error', `Impossible d'ajouter cette absence. Les dates sont invalides.`)
     logger.info(`Failed to creating new days off. User ID: ${currentUser.id}.`)

--- a/app/features/events/routes/programs/days-off.tsx
+++ b/app/features/events/routes/programs/days-off.tsx
@@ -1,11 +1,10 @@
 import { CalendarOff } from 'lucide-react'
 import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -20,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
   const canViewPrograms = can(Role.ProgramViewer)
   const canManagePrograms = can(Role.ProgramManager)
 

--- a/app/features/events/routes/programs/list.tsx
+++ b/app/features/events/routes/programs/list.tsx
@@ -1,10 +1,9 @@
 import { CalendarOff } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Button } from '~/shared/ui/button'
@@ -19,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
   const canViewPrograms = can(Role.ProgramViewer)
   const canManagePrograms = can(Role.ProgramManager)
 

--- a/app/features/events/server/days-off.server.test.ts
+++ b/app/features/events/server/days-off.server.test.ts
@@ -16,22 +16,22 @@ beforeEach(() => {
 
 describe('createDayOff', () => {
   it('retourne null quand startDate est null', async () => {
-    const result = await createDayOff(1, null, new Date(2025, 3, 10), 1)
+    const result = await createDayOff(db, 1, null, new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand endDate est null', async () => {
-    const result = await createDayOff(1, new Date(2025, 3, 8), null, 1)
+    const result = await createDayOff(db, 1, new Date(2025, 3, 8), null, 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand startDate est undefined', async () => {
-    const result = await createDayOff(1, undefined, new Date(2025, 3, 10), 1)
+    const result = await createDayOff(db, 1, undefined, new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
   it('retourne null quand startDate > endDate', async () => {
-    const result = await createDayOff(1, new Date(2025, 3, 15), new Date(2025, 3, 10), 1)
+    const result = await createDayOff(db, 1, new Date(2025, 3, 15), new Date(2025, 3, 10), 1)
     expect(result).toBeNull()
   })
 
@@ -40,7 +40,7 @@ describe('createDayOff', () => {
     vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' } as never)
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
-    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
+    const result = await createDayOff(db, 1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)
   })
 
@@ -50,16 +50,16 @@ describe('createDayOff', () => {
     vi.mocked(db.eventKind.findFirst).mockResolvedValue({ id: 5, key: 'off' } as never)
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
-    const result = await createDayOff(1, sameDate, sameDate, 1)
+    const result = await createDayOff(db, 1, sameDate, sameDate, 1)
     expect(result).toEqual(fakeEvent)
   })
 
-  it('crée l\'événement même sans eventKind trouvé', async () => {
+  it("crée l'événement même sans eventKind trouvé", async () => {
     const fakeEvent = { id: 3, name: 'Absence' }
     vi.mocked(db.eventKind.findFirst).mockResolvedValue(null as never)
     vi.mocked(db.event.create).mockResolvedValue(fakeEvent as never)
 
-    const result = await createDayOff(1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
+    const result = await createDayOff(db, 1, new Date(2025, 3, 8), new Date(2025, 3, 10), 1)
     expect(result).toEqual(fakeEvent)
   })
 })

--- a/app/features/events/server/days-off.server.ts
+++ b/app/features/events/server/days-off.server.ts
@@ -1,7 +1,7 @@
 import { EventKind } from '~/features/events/model/event-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export function getNextDaysOffs(userId: number) {
+export function getNextDaysOffs(db: ScopedDb, userId: number) {
   return db.event.findMany({
     where: {
       createdBy: { id: userId },
@@ -18,6 +18,7 @@ export function getNextDaysOffs(userId: number) {
 }
 
 export async function createDayOff(
+  db: ScopedDb,
   userId: number,
   startDate: Date | null | undefined,
   endDate: Date | null | undefined,

--- a/app/features/events/server/event-kind.server.test.ts
+++ b/app/features/events/server/event-kind.server.test.ts
@@ -14,21 +14,21 @@ beforeEach(() => {
 })
 
 describe('getAllEventType', () => {
-  it('retourne tous les types d\'événements', async () => {
+  it("retourne tous les types d'événements", async () => {
     const fakeEventKinds = [
       { id: 1, key: 'off', name: 'Absence' },
       { id: 2, key: 'meeting', name: 'Réunion' },
     ]
     vi.mocked(db.eventKind.findMany).mockResolvedValue(fakeEventKinds as never)
 
-    const result = await getAllEventType()
+    const result = await getAllEventType(db)
     expect(result).toEqual(fakeEventKinds)
   })
 
-  it('retourne un tableau vide quand il n\'y a pas de types', async () => {
+  it("retourne un tableau vide quand il n'y a pas de types", async () => {
     vi.mocked(db.eventKind.findMany).mockResolvedValue([] as never)
 
-    const result = await getAllEventType()
+    const result = await getAllEventType(db)
     expect(result).toEqual([])
   })
 })

--- a/app/features/events/server/event-kind.server.ts
+++ b/app/features/events/server/event-kind.server.ts
@@ -1,5 +1,5 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getAllEventType() {
+export async function getAllEventType(db: ScopedDb) {
   return await db.eventKind.findMany()
 }

--- a/app/features/platform-admin/server/verify-platform-admin.server.test.ts
+++ b/app/features/platform-admin/server/verify-platform-admin.server.test.ts
@@ -57,7 +57,7 @@ describe('verifyPlatformAdmin', () => {
     }
   })
 
-  it('lance une redirection vers / quand l\'utilisateur n\'est pas admin plateforme', async () => {
+  it("lance une redirection vers / quand l'utilisateur n'est pas admin plateforme", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({
       id: 42,
@@ -75,7 +75,7 @@ describe('verifyPlatformAdmin', () => {
     }
   })
 
-  it('lance une redirection vers / quand l\'utilisateur n\'existe pas', async () => {
+  it("lance une redirection vers / quand l'utilisateur n'existe pas", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null as never)
 

--- a/app/features/publishers/routes/_layout.tsx
+++ b/app/features/publishers/routes/_layout.tsx
@@ -10,7 +10,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.SettingsUserManager, Role.PublisherViewer, Role.ProgramViewer, Role.ProspectionViewer])
+  const { session, can } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.SettingsUserManager,
+    Role.PublisherViewer,
+    Role.ProgramViewer,
+    Role.ProspectionViewer,
+  ])
   const canViewTerritories = can(Role.TerritoriesViewer)
   const canManageSettings = can(Role.SettingsUserManager)
   const canViewPublishers = can(Role.PublisherViewer)

--- a/app/features/publishers/routes/activity/delete.tsx
+++ b/app/features/publishers/routes/activity/delete.tsx
@@ -3,7 +3,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,7 +10,7 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.ActivityManager])
   const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {
@@ -64,7 +63,7 @@ export default function DeleteActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.ActivityManager])
   const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {

--- a/app/features/publishers/routes/activity/edit.tsx
+++ b/app/features/publishers/routes/activity/edit.tsx
@@ -4,7 +4,6 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -20,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -170,7 +169,7 @@ export default function EditActivity({ loaderData }: Route.ComponentProps) {
 
 export async function action({ request, params }: Route.ActionArgs) {
   const previousPage = request.headers.get('referer')
-  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =

--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { generatePublishersYearlyActivityXlsx } from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -12,7 +12,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
   const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
@@ -25,7 +25,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   logger.info(`Generating publishers' activities XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })
-  const file = await generatePublishersYearlyActivityXlsx(Number(params.year))
+  const file = await generatePublishersYearlyActivityXlsx(db, Number(params.year))
 
   return new Response(file, {
     status: 200,

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -3,9 +3,8 @@ import { Form, redirect, useSearchParams } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishers } from '~/features/publishers/server/publishers'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -19,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -31,7 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const groupFilter = canManageMyGroupActivity && !canManagePublisher ? currentUser.publisherGroupId : undefined
-  const publishers = await getPublishers({ groupId: groupFilter })
+  const publishers = await getPublishers(db, { groupId: groupFilter })
 
   const timeRange = new Date()
   const searchParams = new URL(request.url).searchParams
@@ -274,7 +273,9 @@ export default function NewActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, session, congregation, can, db } = await authenticateAndAuthorize(request, [
+    Role.PublisherManager,
+  ])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { renderActivityPdfZip } from '~/features/publishers/server/render-activity-pdf-zip.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -12,7 +12,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
   const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
@@ -27,7 +27,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   })
 
   const today = new Date()
-  const file = await renderActivityPdfZip(Number(params.year))
+  const file = await renderActivityPdfZip(db, Number(params.year))
 
   return new Response(file, {
     status: 200,

--- a/app/features/publishers/routes/activity/publisher-list.tsx
+++ b/app/features/publishers/routes/activity/publisher-list.tsx
@@ -2,10 +2,10 @@ import { ChevronLeft, ChevronRight, Download, Pencil, Plus, Users } from 'lucide
 import { Link, redirect, useSearchParams } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublisherStats } from '~/features/publishers/server/get-publisher-stats.server'
 import { getPublisherWithActivities } from '~/features/publishers/server/get-publisher-with-activities.server'
 import PublisherActivityStats from '~/features/publishers/ui/PublisherActivityStats'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +21,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.ActivityViewer, Role.ActivityManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer, Role.ActivityManager])
   const canViewActivities = can(Role.ActivityViewer)
   const canManageActivities = can(Role.ActivityManager)
 
@@ -39,7 +39,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const month = Number(searchParams.get('month') ?? timeRange.getMonth())
   const year = Number(searchParams.get('year') ?? timeRange.getFullYear())
 
-  const users = await getPublisherWithActivities(month, year)
+  const users = await getPublisherWithActivities(db, month, year)
 
   return {
     firstMonth: {
@@ -50,7 +50,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       month,
       year,
     },
-    stats: await getPublisherStats(month, year),
+    stats: await getPublisherStats(db, month, year),
     publishers: users
       .map(sanitizeUser)
       .map(({ activities, ...member }) => ({

--- a/app/features/publishers/routes/publishers/delete-group.tsx
+++ b/app/features/publishers/routes/publishers/delete-group.tsx
@@ -3,7 +3,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -11,7 +10,7 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
@@ -55,7 +54,7 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -3,7 +3,6 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -14,7 +13,7 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/edit-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
@@ -133,7 +132,7 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -2,12 +2,11 @@ import { Archive, IdCard } from 'lucide-react'
 import { Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -19,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
@@ -34,7 +33,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   if (result == null) throw redirect('/congregation/publishers')
 
-  const showAuxiliaryPioneer = await getBoolSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated)
+  const showAuxiliaryPioneer = await getBoolSetting(db, CongregationSettingKey.AuxiliaryPioneerProfileActivated)
   const groups = await db.publisherGroup.findMany()
   const { email, password, ...user } = result
   return {
@@ -91,7 +90,7 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  await authenticateAndAuthorize(request)
+  const { db } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -2,7 +2,6 @@ import { Eye, Pencil, UsersRound } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +16,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+    Role.PublisherViewer,
+    Role.PublisherManager,
+  ])
   const canViewPublishers = can(Role.PublisherViewer)
   const canManagePublisher = can(Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -2,9 +2,8 @@ import { BarChart3, Eye, Mail, Pencil, Plus } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroup } from '~/features/publishers/server/groups'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -15,7 +14,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~
 import type { Route } from './+types/group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+    Role.PublisherViewer,
+    Role.PublisherManager,
+    Role.ActivityManager,
+  ])
   const canViewPublishers = can(Role.PublisherViewer)
   const canManagePublisher = can(Role.PublisherManager)
   const canManageActivity = can(Role.ActivityManager)
@@ -24,7 +27,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const group = await getGroup(requireParamId(params.groupId, '/congregation/publisher-groups'))
+  const group = await getGroup(db, requireParamId(params.groupId, '/congregation/publisher-groups'))
   if (group == null) {
     throw redirect('/congregation/publisher-groups/')
   }
@@ -229,7 +232,7 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -3,7 +3,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -13,7 +12,7 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/new-group'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
@@ -108,7 +107,7 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -1,11 +1,10 @@
 import { Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldServiceForm'
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -17,7 +16,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
@@ -50,7 +49,7 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await authenticateAndAuthorize(request)
+  const { congregation, db } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -68,7 +67,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/congregation/publishers/new')
   }
 
-  const limits = new LimitService(congregation)
+  const limits = new LimitService(db, congregation)
   await limits.errorIfWouldGoOverLimit('publishers')
 
   const user = await db.user.create({

--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -1,8 +1,8 @@
 import { BarChart3, Eye, Mail, Pencil, Users } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishersWithGroup } from '~/features/publishers/server/publishers'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +17,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityViewer])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+    Role.PublisherViewer,
+    Role.PublisherManager,
+    Role.ActivityViewer,
+  ])
   const canViewPublishers = can(Role.PublisherViewer)
   const canManagePublisher = can(Role.PublisherManager)
   const canViewActivities = can(Role.ActivityViewer)
@@ -34,7 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading publishers. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )
 
-  const users = await getPublishersWithGroup()
+  const users = await getPublishersWithGroup(db)
 
   return {
     users: users.map(user => ({

--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -2,9 +2,8 @@ import { Archive, Download, IdCard, Pencil } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { PublisherActivityDownloadLink } from '~/features/publishers/ui/PublisherActivityDownloadLink'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -19,7 +18,11 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.PublisherViewer, Role.PublisherManager, Role.ActivityManager])
+  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+    Role.PublisherViewer,
+    Role.PublisherManager,
+    Role.ActivityManager,
+  ])
   const canViewPublisher = can(Role.PublisherViewer)
   const canManagePublisher = can(Role.PublisherManager)
   const canManageActivity = can(Role.ActivityManager)

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
@@ -16,10 +16,7 @@ beforeEach(() => {
   vi.mocked(db.publisherActivity.findMany).mockResolvedValue([] as never)
 })
 
-function makeActivity(
-  type: PublisherType,
-  { hours = 0, studies = 0, isPublisher = true, notes = '' } = {},
-) {
+function makeActivity(type: PublisherType, { hours = 0, studies = 0, isPublisher = true, notes = '' } = {}) {
   return {
     type,
     hours,
@@ -43,7 +40,7 @@ async function readWorkbook(buffer: excelJs.Buffer) {
 
 describe('generatePublishersYearlyActivityXlsx', () => {
   it('génère 12 feuilles pour une année théocratique', async () => {
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
 
     expect(workbook.worksheets).toHaveLength(12)
@@ -54,7 +51,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.Normal, { isPublisher: true, hours: 0, studies: 1 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
     const firstSheet = workbook.worksheets[0]
     const dataRow = firstSheet.getRow(2)
@@ -67,7 +64,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierPermanant, { hours: 50 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -79,7 +76,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -91,7 +88,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierSpecial, { hours: 130 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -103,7 +100,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.Missionnaire, { hours: 120 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
@@ -1,10 +1,10 @@
 import excelJs from 'exceljs'
 
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { PublisherType, publisherTypeReportsHours } from '~/shared/types/publisher-type'
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
-export async function generatePublishersYearlyActivityXlsx(year: number) {
+export async function generatePublishersYearlyActivityXlsx(db: ScopedDb, year: number) {
   const months = Array.from({ length: 12 }, (_, i) => (i + 8 > 11 ? i - 4 : i + 8))
   const workbook = new excelJs.Workbook()
 
@@ -13,7 +13,7 @@ export async function generatePublishersYearlyActivityXlsx(year: number) {
     const date = new Date(yearMonth, month, 1)
     const monthName = date.toLocaleString('fr', { month: 'long' })
     const sheetName = `${monthName} ${yearMonth}`.toUpperCase()
-    const activities = await getPublishersMonthlyActivity(month, yearMonth)
+    const activities = await getPublishersMonthlyActivity(db, month, yearMonth)
 
     const worksheet = workbook.addWorksheet(sheetName)
     worksheet.columns = [
@@ -92,7 +92,7 @@ export async function generatePublishersYearlyActivityXlsx(year: number) {
   return await workbook.xlsx.writeBuffer()
 }
 
-function getPublishersMonthlyActivity(month: number, year: number) {
+function getPublishersMonthlyActivity(db: ScopedDb, month: number, year: number) {
   return db.publisherActivity.findMany({
     where: {
       month,

--- a/app/features/publishers/server/get-publisher-stats.server.test.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.test.ts
@@ -32,7 +32,7 @@ describe('getPublisherStats', () => {
       makeFigure(PublisherType.PionnierAuxiliaires, 7, 350, 3),
     ])
 
-    const result = await getPublisherStats(3, 2025)
+    const result = await getPublisherStats(db, 3, 2025)
 
     // all: total
     expect(result.all.count).toBe(25)
@@ -58,7 +58,7 @@ describe('getPublisherStats', () => {
     vi.mocked(db.user.count).mockResolvedValue(0)
     vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([])
 
-    const result = await getPublisherStats(1, 2025)
+    const result = await getPublisherStats(db, 1, 2025)
 
     expect(result.all.count).toBe(0)
     expect(result.all.active).toBe(0)
@@ -72,11 +72,9 @@ describe('getPublisherStats', () => {
 
   it('gère le cas où seuls certains types ont des activités', async () => {
     vi.mocked(db.user.count).mockResolvedValue(10)
-    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([
-      makeFigure(PublisherType.Normal, 10, 0, 2),
-    ])
+    vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([makeFigure(PublisherType.Normal, 10, 0, 2)])
 
-    const result = await getPublisherStats(6, 2025)
+    const result = await getPublisherStats(db, 6, 2025)
 
     expect(result.all.active).toBe(10)
     expect(result.all.hours).toBe(0) // pas de pionniers
@@ -91,7 +89,7 @@ describe('getPublisherStats', () => {
       makeFigure(PublisherType.PionnierPermanant, 2, 50, 0),
     ])
 
-    const result = await getPublisherStats(1, 2025)
+    const result = await getPublisherStats(db, 1, 2025)
 
     // all.hours n'inclut que les pionniers permanents et auxiliaires
     expect(result.all.hours).toBe(50)

--- a/app/features/publishers/server/get-publisher-stats.server.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.ts
@@ -1,7 +1,7 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 
-export async function getPublisherStats(month: number, year: number) {
+export async function getPublisherStats(db: ScopedDb, month: number, year: number) {
   const publishers = await db.user.count({
     where: {
       activities: {
@@ -12,7 +12,7 @@ export async function getPublisherStats(month: number, year: number) {
       },
     },
   })
-  const figureMap = await getFiguresMap(month, year)
+  const figureMap = await getFiguresMap(db, month, year)
 
   return {
     all: getAllStats(publishers, figureMap),
@@ -22,7 +22,7 @@ export async function getPublisherStats(month: number, year: number) {
   }
 }
 
-async function getFiguresMap(month: number, year: number) {
+async function getFiguresMap(db: ScopedDb, month: number, year: number) {
   const figures = await db.publisherActivity.groupBy({
     _count: {
       _all: true,

--- a/app/features/publishers/server/get-publisher-with-activities.server.test.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.test.ts
@@ -15,19 +15,17 @@ beforeEach(() => {
 
 describe('getPublisherWithActivities', () => {
   it('retourne les proclamateurs avec leurs activités du mois', async () => {
-    const fakeResult = [
-      { id: 1, isPublisher: true, activities: [{ month: 3, year: 2025 }] },
-    ]
+    const fakeResult = [{ id: 1, isPublisher: true, activities: [{ month: 3, year: 2025 }] }]
     vi.mocked(db.user.findMany).mockResolvedValue(fakeResult as never)
 
-    const result = await getPublisherWithActivities(3, 2025)
+    const result = await getPublisherWithActivities(db, 3, 2025)
     expect(result).toEqual(fakeResult)
   })
 
-  it('retourne un tableau vide quand il n\'y a pas de résultats', async () => {
+  it("retourne un tableau vide quand il n'y a pas de résultats", async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    const result = await getPublisherWithActivities(1, 2025)
+    const result = await getPublisherWithActivities(db, 1, 2025)
     expect(result).toEqual([])
   })
 })

--- a/app/features/publishers/server/get-publisher-with-activities.server.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.ts
@@ -1,6 +1,6 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export function getPublisherWithActivities(selectedMonth: number, selectedYear: number) {
+export function getPublisherWithActivities(db: ScopedDb, selectedMonth: number, selectedYear: number) {
   return db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: prisma keywords

--- a/app/features/publishers/server/groups.ts
+++ b/app/features/publishers/server/groups.ts
@@ -1,11 +1,11 @@
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getGroups() {
+export async function getGroups(db: ScopedDb) {
   return await db.publisherGroup.findMany()
 }
 
-export async function getGroup(groupId: number) {
+export async function getGroup(db: ScopedDb, groupId: number) {
   const today = new Date()
   const lastMonth = new Date()
   lastMonth.setMonth(today.getMonth() - 1)

--- a/app/features/publishers/server/publishers.server.test.ts
+++ b/app/features/publishers/server/publishers.server.test.ts
@@ -15,24 +15,27 @@ beforeEach(() => {
 
 describe('getPublishers', () => {
   it('retourne les proclamateurs', async () => {
-    const fakePublishers = [{ id: 1, firstname: 'Jean' }, { id: 2, firstname: 'Marie' }]
+    const fakePublishers = [
+      { id: 1, firstname: 'Jean' },
+      { id: 2, firstname: 'Marie' },
+    ]
     vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
-    const result = await getPublishers()
+    const result = await getPublishers(db)
     expect(result).toEqual(fakePublishers)
   })
 
-  it('retourne un tableau vide quand il n\'y a pas de proclamateurs', async () => {
+  it("retourne un tableau vide quand il n'y a pas de proclamateurs", async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    const result = await getPublishers()
+    const result = await getPublishers(db)
     expect(result).toEqual([])
   })
 
   it('accepte un filtre par groupId', async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1 }] as never)
 
-    const result = await getPublishers({ groupId: 3 })
+    const result = await getPublishers(db, { groupId: 3 })
     expect(result).toHaveLength(1)
   })
 })
@@ -42,7 +45,7 @@ describe('getPublishersWithGroup', () => {
     const fakePublishers = [{ id: 1, publisherGroup: { name: 'Groupe 1' } }]
     vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
-    const result = await getPublishersWithGroup()
+    const result = await getPublishersWithGroup(db)
     expect(result).toEqual(fakePublishers)
   })
 })

--- a/app/features/publishers/server/publishers.ts
+++ b/app/features/publishers/server/publishers.ts
@@ -1,6 +1,6 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getPublishers(options?: { groupId?: number | null }) {
+export async function getPublishers(db: ScopedDb, options?: { groupId?: number | null }) {
   return await db.user.findMany({
     where: {
       isPublisher: true,
@@ -10,7 +10,7 @@ export async function getPublishers(options?: { groupId?: number | null }) {
   })
 }
 
-export async function getPublishersWithGroup() {
+export async function getPublishersWithGroup(db: ScopedDb) {
   return await db.user.findMany({
     where: { isPublisher: true },
     include: { publisherGroup: true },

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -43,7 +43,7 @@ describe('renderActivityPdfZip', () => {
   it('filtre les activités de septembre à août (mois 8-11 puis 0-7)', async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    await renderActivityPdfZip(2025)
+    await renderActivityPdfZip(db, 2025)
 
     const call = vi.mocked(db.user.findMany).mock.calls[0][0] as Record<string, unknown>
     const where = (call.where as { activities: { some: Record<string, unknown> } }).activities.some

--- a/app/features/publishers/server/render-activity-pdf-zip.server.tsx
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.tsx
@@ -2,9 +2,9 @@ import { pdf } from '@react-pdf/renderer'
 import JsZip from 'jszip'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { PublisherActivityDocument } from '~/features/publishers/ui/PublisherActivityDocument'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function renderActivityPdfZip(year: number) {
+export async function renderActivityPdfZip(db: ScopedDb, year: number) {
   const yearBegining = new Date(year, 0, 1)
   const users = await db.user.findMany({
     where: {

--- a/app/features/settings/routes/_layout.tsx
+++ b/app/features/settings/routes/_layout.tsx
@@ -9,7 +9,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager, Role.SettingsUserManager, Role.PublisherViewer, Role.Admin, Role.ProspectionViewer])
+  const { session, can } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.TerritoriesManager,
+    Role.SettingsUserManager,
+    Role.PublisherViewer,
+    Role.Admin,
+    Role.ProspectionViewer,
+  ])
   const canViewTerritories = can(Role.TerritoriesViewer)
   const canManageTerritories = can(Role.TerritoriesManager)
   const canManageUsers = can(Role.SettingsUserManager)

--- a/app/features/settings/routes/congregation/event-kind-list.tsx
+++ b/app/features/settings/routes/congregation/event-kind-list.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getAllEventType } from '~/features/events/server/event-kind.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Badge } from '~/shared/ui/badge'
 
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -13,14 +13,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  const kinds = await getAllEventType()
+  const kinds = await getAllEventType(db)
 
   return {
     kinds,

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -1,9 +1,9 @@
 import { ArrowRight } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting, setSetting } from '~/features/settings/server/settings'
-import { db, unscopedDb } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { unscopedDb } from '~/shared/libs/db.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -19,14 +19,17 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  const auxiliaryPioneerProfileActivated = await getBoolSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated)
+  const auxiliaryPioneerProfileActivated = await getBoolSetting(
+    db,
+    CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+  )
 
   return {
     auxiliaryPioneerProfileActivated: auxiliaryPioneerProfileActivated ?? false,
@@ -106,7 +109,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
@@ -124,7 +127,12 @@ export async function action({ request }: Route.ActionArgs) {
     data: { displayName: displayName ? String(displayName) : null },
   })
 
-  await setSetting(CongregationSettingKey.AuxiliaryPioneerProfileActivated, auxiliaryPioneerProfileActivated, congregation.id)
+  await setSetting(
+    db,
+    CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+    auxiliaryPioneerProfileActivated,
+    congregation.id,
+  )
   if (auxiliaryPioneerProfileActivated === 'false') {
     await db.user.updateMany({
       where: {

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -1,6 +1,5 @@
 import { Form, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting, getSetting, setSetting } from '~/features/settings/server/settings'
 import { getTerritoryPolygon } from '~/features/territories/server/get-territory-polygon.server'
 import {
@@ -10,6 +9,7 @@ import {
   serializeTerritoryPolygon,
   serializeZips,
 } from '~/features/territories/server/settings'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -26,18 +26,18 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const territory = await getTerritoryPolygon()
-  const zips = await getAllowedZips()
-  const banoUrl = await getSetting(TerritorySettingKey.BanoUrl)
-  const prospectionValidity = await getSetting(TerritorySettingKey.ProspectionValidity)
-  const phoneTypeActivated = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const territory = await getTerritoryPolygon(db)
+  const zips = await getAllowedZips(db)
+  const banoUrl = await getSetting(db, TerritorySettingKey.BanoUrl)
+  const prospectionValidity = await getSetting(db, TerritorySettingKey.ProspectionValidity)
+  const phoneTypeActivated = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
   return {
     territory: serializeTerritoryPolygon(territory),
@@ -134,7 +134,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -148,11 +148,11 @@ export async function action({ request }: Route.ActionArgs) {
   const prospectionValidity = String(form.get('prospection-validity'))
   const phoneTypeActivated = String(Boolean(form.get('phone-territory-active')))
 
-  await setSetting(TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregation.id)
-  await setSetting(TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregation.id)
-  await setSetting(TerritorySettingKey.BanoUrl, banoUrl, congregation.id)
-  await setSetting(TerritorySettingKey.ProspectionValidity, prospectionValidity, congregation.id)
-  await setSetting(TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregation.id)
+  await setSetting(db, TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregation.id)
+  await setSetting(db, TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregation.id)
+  await setSetting(db, TerritorySettingKey.BanoUrl, banoUrl, congregation.id)
+  await setSetting(db, TerritorySettingKey.ProspectionValidity, prospectionValidity, congregation.id)
+  await setSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregation.id)
 
   return redirect('/settings')
 }

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -3,7 +3,6 @@ import { data, Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.Admin])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.Admin])
   const canManageUser = can(Role.SettingsUserManager)
   const isAdmin = can(Role.Admin)
 
@@ -210,7 +209,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
   const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) {

--- a/app/features/settings/routes/users/make-publisher.tsx
+++ b/app/features/settings/routes/users/make-publisher.tsx
@@ -2,13 +2,12 @@ import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/make-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -3,7 +3,6 @@ import { createPasswordResetToken } from '~/features/authentication/server/inval
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -60,7 +59,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation } = await authenticateAndAuthorize(request)
+  const { congregation, db } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -80,7 +79,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/settings/users/new')
   }
 
-  const limits = new LimitService(congregation)
+  const limits = new LimitService(db, congregation)
   await limits.errorIfWouldGoOverLimit('users')
 
   const user = await db.user.create({

--- a/app/features/settings/routes/users/unmake-publisher.tsx
+++ b/app/features/settings/routes/users/unmake-publisher.tsx
@@ -2,13 +2,12 @@ import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/unmake-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {

--- a/app/features/settings/routes/users/user-list.tsx
+++ b/app/features/settings/routes/users/user-list.tsx
@@ -3,7 +3,6 @@ import { Form, Link, redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Badge } from '~/shared/ui/badge'
 import { Button } from '~/shared/ui/button'
@@ -18,7 +17,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.PublisherViewer, Role.PublisherManager])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+    Role.SettingsUserManager,
+    Role.PublisherViewer,
+    Role.PublisherManager,
+  ])
   const canManageUser = can(Role.SettingsUserManager)
   const canViewPublishers = can(Role.PublisherViewer)
   const canManagePublishers = can(Role.PublisherManager)

--- a/app/features/settings/server/settings.ts
+++ b/app/features/settings/server/settings.ts
@@ -1,22 +1,22 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import type { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import type { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 
 type SettingKey = TerritorySettingKey | CongregationSettingKey
 
-export async function getSetting(key: SettingKey): Promise<string | undefined> {
+export async function getSetting(db: ScopedDb, key: SettingKey): Promise<string | undefined> {
   const setting = await db.setting.findFirst({ where: { key } })
 
   return setting?.value
 }
 
-export async function getBoolSetting(key: SettingKey): Promise<boolean | undefined> {
-  const settingValue = await getSetting(key)
+export async function getBoolSetting(db: ScopedDb, key: SettingKey): Promise<boolean | undefined> {
+  const settingValue = await getSetting(db, key)
 
   return settingValue === 'true'
 }
 
-export async function setSetting(key: SettingKey, value: string, congregationId: number) {
+export async function setSetting(db: ScopedDb, key: SettingKey, value: string, congregationId: number) {
   if (key == null || value.length < 1) {
     return
   }

--- a/app/features/territories/routes/_layout.tsx
+++ b/app/features/territories/routes/_layout.tsx
@@ -9,7 +9,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager, Role.SettingsUserManager, Role.PublisherViewer, Role.ProspectionViewer])
+  const { can } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.TerritoriesManager,
+    Role.SettingsUserManager,
+    Role.PublisherViewer,
+    Role.ProspectionViewer,
+  ])
   const canViewTerritories = can(Role.TerritoriesViewer)
   const canManageTerritories = can(Role.TerritoriesManager)
   const canManageSettings = can(Role.SettingsUserManager)

--- a/app/features/territories/routes/attributions/delete.tsx
+++ b/app/features/territories/routes/attributions/delete.tsx
@@ -3,7 +3,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,7 +10,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -58,7 +57,7 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/attributions/edit.tsx
+++ b/app/features/territories/routes/attributions/edit.tsx
@@ -3,13 +3,12 @@ import { useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getPublishers } from '~/features/publishers/server/publishers'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -25,14 +24,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
   const attribution = await db.attribution.findUnique({
     where: { id: requireParamId(params.attributionId, '/territories/attributions') },
@@ -43,7 +42,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/territories/attributions')
   }
 
-  const users = await getPublishers()
+  const users = await getPublishers(db)
 
   return { users, phoneTypeActive, attribution, entrances: attribution.territory.entrances.map(aggregateEntrance) }
 }
@@ -186,7 +185,7 @@ export default function EditAttributionPage({ loaderData }: Route.ComponentProps
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/attributions/excel-export.tsx
+++ b/app/features/territories/routes/attributions/excel-export.tsx
@@ -1,8 +1,8 @@
 import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { generateS13ExportExcel } from '~/features/territories/server/s13-export.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -12,7 +12,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -25,7 +25,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   logger.info(`Generating S-13 XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })
-  const data = await getTerritoriesExportData(Number(params.year))
+  const data = await getTerritoriesExportData(db, Number(params.year))
   const file = await generateS13ExportExcel(data, params.year)
 
   return new Response(await file.xlsx.writeBuffer(), {

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -2,7 +2,6 @@ import { CalendarCheck, Pencil, X } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroups } from '~/features/publishers/server/groups'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
@@ -11,6 +10,7 @@ import { findActiveAttributionsPaginated } from '~/features/territories/server/a
 import { getCurrentTheocraticYear } from '~/features/territories/server/theocratic-year.server'
 import AttributionFilters from '~/features/territories/ui/AttributionFilters'
 import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -28,7 +28,13 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.PublisherManager, Role.PublisherViewer, Role.TerritoriesManager, Role.ProspectionViewer])
+  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.PublisherManager,
+    Role.PublisherViewer,
+    Role.TerritoriesManager,
+    Role.ProspectionViewer,
+  ])
   const canViewTerritories = can(Role.TerritoriesViewer)
   const canManagePublisher = can(Role.PublisherManager)
   const canViewPublisher = can(Role.PublisherViewer)
@@ -51,16 +57,16 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading territory attributions. User ID: ${currentUser.id}. ${canManageTerritories ? 'Has' : 'Does NOT have'} rights to manage territories.`,
   )
 
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   selectors.endDate = null
 
-  const { attributions, pagination } = await findActiveAttributionsPaginated(selectors, url)
+  const { attributions, pagination } = await findActiveAttributionsPaginated(db, selectors, url)
 
   const messages = { success: session.get('success'), error: session.get('error') }
-  const groups = await getGroups()
+  const groups = await getGroups(db)
   const theocraticYear = getCurrentTheocraticYear()
 
   return data(

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -1,11 +1,10 @@
 import { Form, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -20,14 +19,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)
   if (!url.searchParams.has('territory')) {
@@ -123,7 +122,7 @@ export default function CreateAttributionPage({ loaderData }: Route.ComponentPro
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/attributions/pdf-export.tsx
+++ b/app/features/territories/routes/attributions/pdf-export.tsx
@@ -1,9 +1,9 @@
 import { pdf } from '@react-pdf/renderer'
 import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
 import { TerritoryAttributionDocument } from '~/features/territories/ui/TerritoryAttributionDocument'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -13,7 +13,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -27,7 +27,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     currentUser,
   })
 
-  const territories = await getTerritoriesExportData(Number(params.year))
+  const territories = await getTerritoriesExportData(db, Number(params.year))
   const file = await pdf(<TerritoryAttributionDocument year={Number(params.year)} territories={territories} />).toBlob()
 
   return new Response(file, {

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -2,13 +2,13 @@ import { ExternalLink, Send } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import { findAvailableTerritoriesPaginated } from '~/features/territories/server/territories'
 import { computeFilters } from '~/features/territories/server/territory-filters'
 import { checkAvailabilityStatus, TerritoryAvaibilityStatus } from '~/features/territories/ui/TerritoryAvaibilityStatus'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -23,7 +23,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -39,10 +39,10 @@ export async function loader({ request }: Route.LoaderArgs) {
   const selectors = await computeFilters(url.searchParams)
   selectors.attributions = { none: { endDate: null } }
 
-  const { territories, pagination } = await findAvailableTerritoriesPaginated(selectors, url)
+  const { territories, pagination } = await findAvailableTerritoriesPaginated(db, selectors, url)
 
   const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips()
+  const zips = await getZips(db)
 
   return data(
     {

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -2,12 +2,11 @@ import { Map as MapIcon, RefreshCw } from 'lucide-react'
 import { data, Form, Link, NavLink, Outlet, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getSetting } from '~/features/settings/server/settings'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -20,7 +19,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
@@ -29,7 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
+  const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
   const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
@@ -102,7 +105,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   })
   const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
   const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips()
+  const zips = await getZips(db)
 
   return data(
     {

--- a/app/features/territories/routes/prospection/active-building-list.tsx
+++ b/app/features/territories/routes/prospection/active-building-list.tsx
@@ -1,9 +1,9 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -15,7 +15,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
@@ -25,8 +29,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const url = new URL(request.url)
-  const staleDate = await getProspectionStaleDate()
-  const { buildings, pagination } = await findBuildingsPaginated({ active: true }, url)
+  const staleDate = await getProspectionStaleDate(db)
+  const { buildings, pagination } = await findBuildingsPaginated(db, { active: true }, url)
 
   return {
     buildings,

--- a/app/features/territories/routes/prospection/building-list.tsx
+++ b/app/features/territories/routes/prospection/building-list.tsx
@@ -1,10 +1,10 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +16,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.TerritoriesManager, Role.ProspectionManager])
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.TerritoriesManager,
+    Role.ProspectionManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageTerritories = can(Role.TerritoriesManager)
   const canManageProspection = can(Role.ProspectionManager)
@@ -27,8 +31,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
-  const staleDate = await getProspectionStaleDate()
-  const { buildings, pagination } = await findBuildingsPaginated(selectors, url)
+  const staleDate = await getProspectionStaleDate(db)
+  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
   return {
     buildings,

--- a/app/features/territories/routes/prospection/building.tsx
+++ b/app/features/territories/routes/prospection/building.tsx
@@ -2,12 +2,12 @@ import { Pencil, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { setBuildingNotes } from '~/features/territories/server/set-building-notes.server'
 import ArchiveBuildingToggleButton from '~/features/territories/ui/ArchiveBuildingToggleButton'
 import BuildingProspectionInfo from '~/features/territories/ui/BuildingProspectionInfo'
 import BuildingTerritoryInfo from '~/features/territories/ui/BuildingTerritoryInfo'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -22,7 +22,12 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session, can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesViewer, Role.TerritoriesManager])
+  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.ProspectionManager,
+    Role.TerritoriesViewer,
+    Role.TerritoriesManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageProspection = can(Role.ProspectionManager)
   const canViewTerritories = can(Role.TerritoriesViewer)
@@ -39,7 +44,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     `Loading building data for building nº${params.buildingId}. User ID: ${currentUser.id}. ${canManageProspection ? 'Has' : 'Does NOT have'} rights to modify prospection data.`,
   )
 
-  const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
+  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
   if (!building) {
     throw redirect('../', { status: 404 })
   }
@@ -123,7 +128,7 @@ export default function BuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -135,7 +140,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const importantNotes = form.get('important-notes')
 
   try {
-    await setBuildingNotes(requireParamId(params.buildingId, '/territories/buildings'), {
+    await setBuildingNotes(db, requireParamId(params.buildingId, '/territories/buildings'), {
       notes: String(notes),
       importantNotes: String(importantNotes),
     })

--- a/app/features/territories/routes/prospection/delete-building.tsx
+++ b/app/features/territories/routes/prospection/delete-building.tsx
@@ -3,7 +3,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -11,7 +10,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete-building'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.ProspectionManager])
   const canManageProspection = can(Role.ProspectionManager)
 
   if (!canManageProspection) {
@@ -57,7 +56,7 @@ export default function DeleteBuilding({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/prospection/disable-building.tsx
+++ b/app/features/territories/routes/prospection/disable-building.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/disable-building'
@@ -13,7 +12,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import { data, Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { getBuildings } from '~/features/territories/server/get-buildings.server'
 import { serializeSharedEntranceFromBuilding } from '~/features/territories/server/serialize-shared-entrance-from-building.server'
@@ -14,6 +13,7 @@ import ArchiveBuildingToggleButton from '~/features/territories/ui/ArchiveBuildi
 import BuildingProspectionForDoorToDoorFields from '~/features/territories/ui/BuildingProspectionForDoorToDoorFields'
 import OtherBuildingProspectionFields from '~/features/territories/ui/OtherBuildingProspectionFields'
 import SharedEntranceField from '~/features/territories/ui/SharedEntranceField'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -29,7 +29,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.ProspectionManager, Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
 
@@ -37,12 +40,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
+  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
   }
 
-  const buildings = await getBuildings(building.zip, building.street)
+  const buildings = await getBuildings(db, building.zip, building.street)
   const messages = {
     success: session.get('success'),
     error: session.get('error'),
@@ -124,7 +127,10 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.ProspectionManager, Role.TerritoriesManager])
+  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
 
@@ -133,7 +139,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   const previousPage = request.headers.get('referer') ?? '/territories/buildings'
-  const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
+  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
   }
@@ -148,7 +154,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     if (currentEntranceIdsSerialized !== entranceIdsSerialized) {
       try {
-        await updateBuildingsInEntrance(Number(building.entrance?.id), entranceIds, congregation.id)
+        await updateBuildingsInEntrance(db, Number(building.entrance?.id), entranceIds, congregation.id)
         session.flash('success', 'Le batiment a été correctement modifié')
       } catch (e) {
         logger.error('Error updating building', { error: e, buildingId: params.buildingId })
@@ -165,7 +171,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   // manage changes in classic data
   try {
-    await setBuildingProspectionData(building.id, form)
+    await setBuildingProspectionData(db, building.id, form)
 
     session.flash('success', 'Les données de prospection ont été correctement mise à jour')
   } catch (e) {

--- a/app/features/territories/routes/prospection/edit-building.tsx
+++ b/app/features/territories/routes/prospection/edit-building.tsx
@@ -2,9 +2,9 @@ import { Trash2 } from 'lucide-react'
 import { data, Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { editBuilding } from '~/features/territories/server/edit-building.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -25,14 +25,14 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const building = await getBuildingDetails(requireParamId(params.buildingId, '/territories/buildings'))
+  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
   if (building == null) {
     throw redirect('/territories/buildings', { status: 404 })
   }
@@ -121,7 +121,7 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -140,7 +140,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   try {
-    await editBuilding(requireParamId(params.buildingId, '/territories/buildings'), {
+    await editBuilding(db, requireParamId(params.buildingId, '/territories/buildings'), {
       coordinates: {
         latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
         longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,

--- a/app/features/territories/routes/prospection/enable-building.tsx
+++ b/app/features/territories/routes/prospection/enable-building.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/enable-building'
@@ -13,7 +12,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/prospection/missing-building-list.tsx
+++ b/app/features/territories/routes/prospection/missing-building-list.tsx
@@ -1,9 +1,9 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +16,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
@@ -25,11 +29,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const staleDate = await getProspectionStaleDate()
+  const staleDate = await getProspectionStaleDate(db)
 
   const selectors = { inOpenData: false, active: true }
   const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsPaginated(selectors, url)
+  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
   return {
     buildings,

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -2,12 +2,12 @@ import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getSetting } from '~/features/settings/server/settings'
 import { TerritoryAccess } from '~/features/territories/model/territory-access.type'
 import { findBuildingsWithEntrancePaginated } from '~/features/territories/server/buildings'
 import { BuildingCheckReason } from '~/features/territories/ui/BuildingCheckReason'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 
@@ -20,7 +20,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.ProspectionManager, Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.ProspectionManager,
+    Role.TerritoriesManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageProspection = can(Role.ProspectionManager)
   const canManageTerritories = can(Role.TerritoriesManager)
@@ -29,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = Number(await getSetting(TerritorySettingKey.ProspectionValidity) ?? '0')
+  const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
   const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
   if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
   const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
@@ -93,7 +97,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsWithEntrancePaginated(selector, url)
+  const { buildings, pagination } = await findBuildingsWithEntrancePaginated(db, selector, url)
 
   return {
     buildings,

--- a/app/features/territories/routes/prospection/new-building-list.tsx
+++ b/app/features/territories/routes/prospection/new-building-list.tsx
@@ -1,9 +1,9 @@
 import { Eye, Search } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +16,11 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.ProspectionViewer, Role.TerritoriesManager, Role.ProspectionManager])
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.ProspectionViewer,
+    Role.TerritoriesManager,
+    Role.ProspectionManager,
+  ])
   const canViewProspection = can(Role.ProspectionViewer)
   const canManageTerritories = can(Role.TerritoriesManager)
   const canManageProspection = can(Role.ProspectionManager)
@@ -25,11 +29,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const staleDate = await getProspectionStaleDate()
+  const staleDate = await getProspectionStaleDate(db)
 
   const selectors = { inOpenData: true, active: true, prospectionDate: null }
   const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsPaginated(selectors, url)
+  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
   return {
     buildings,

--- a/app/features/territories/routes/prospection/new-building.tsx
+++ b/app/features/territories/routes/prospection/new-building.tsx
@@ -1,8 +1,8 @@
 import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { createBuilding } from '~/features/territories/server/create-building.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -67,7 +67,7 @@ export default function CreateBuildingPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -85,7 +85,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/buildings/new')
   }
 
-  const building = await createBuilding({
+  const building = await createBuilding(db, {
     address: {
       number: String(number),
       street: String(street),

--- a/app/features/territories/routes/prospection/sync-buildings.tsx
+++ b/app/features/territories/routes/prospection/sync-buildings.tsx
@@ -2,9 +2,8 @@ import { redirect } from 'react-router'
 
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { syncQueue } from '~/features/territories/server/sync-queue.server'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 
 import type { Route } from './+types/sync-buildings'
 
@@ -17,7 +16,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, currentUser, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/split-tool/_layout.tsx
+++ b/app/features/territories/routes/split-tool/_layout.tsx
@@ -1,12 +1,11 @@
 import { data, NavLink, Outlet, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -18,14 +17,14 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
   const totalBuildingsForDoors = await db.building.count({
     where: {
       active: true,
@@ -124,7 +123,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   })
 
   const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips()
+  const zips = await getZips(db)
 
   return data(
     {

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -19,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -39,7 +39,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     hasShops: true,
     entrance: { territories: { none: { type: TerritoryKind.Commerces } } },
   }
-  const { entrances, pagination } = await findEntrancesPaginated(selectors, url)
+  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
   return {
     entrances,

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -2,9 +2,8 @@ import { redirect } from 'react-router'
 
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { LimitService } from '~/shared/libs/limits.server'
 
 import type { Route } from './+types/create'
@@ -14,7 +13,7 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -47,7 +46,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const number = `${prefix}${String(count + 1).padStart(3, '0')}`
 
-  const limits = new LimitService(congregation)
+  const limits = new LimitService(db, congregation)
   await limits.errorIfWouldGoOverLimit('territories')
 
   await db.territory.create({

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -19,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -39,7 +39,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     hasHotel: true,
     entrance: { territories: { none: { type: TerritoryKind.Hotel } } },
   }
-  const { entrances, pagination } = await findEntrancesPaginated(selectors, url)
+  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
   return {
     entrances,

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
@@ -21,7 +21,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -29,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
   const url = new URL(request.url)
   const filters = computeFilters(url.searchParams)
@@ -54,7 +54,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   }
 
-  const { entrances, pagination } = await findEntrancesPaginated(selectors, url)
+  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
   return {
     entrances,

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
@@ -21,7 +21,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -29,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
   if (!phoneTypeActive) {
     throw redirect('/territories/buildings/split-territories')
   }
@@ -54,7 +54,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     ],
     entrance: { territories: { none: { type: TerritoryKind.Phone } } },
   }
-  const { entrances, pagination } = await findEntrancesPaginated(selectors, url)
+  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
   return {
     entrances,

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react'
 import { Form, redirect } from 'react-router'
 import type { Prisma } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { computeFilters } from '~/features/territories/server/building-filters'
 import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
 
@@ -19,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -39,7 +39,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     hasCampus: true,
     entrance: { territories: { none: { type: TerritoryKind.Univ } } },
   }
-  const { entrances, pagination } = await findEntrancesPaginated(selectors, url)
+  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
   return {
     entrances,

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -2,7 +2,6 @@ import { Info } from 'lucide-react'
 import { redirect } from 'react-router'
 import { Cell, Pie, PieChart } from 'recharts'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getGroups } from '~/features/publishers/server/groups'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { countActiveWorkingTerritories } from '~/features/territories/server/active-working-territories.server'
@@ -18,12 +17,15 @@ import { computeRestPeriodUtilization } from '~/features/territories/server/comp
 import { countDelayedWorkingTerritories } from '~/features/territories/server/delayed-working-territories.server'
 import { fetchActiveAttributionsByGroup } from '~/features/territories/server/fetch-attributions-by-group.server'
 import { fetchAttributionsForStats } from '~/features/territories/server/fetch-attributions-for-stats.server'
-import { fetchTerritoryCounts, getTotalTerritoryCount } from '~/features/territories/server/fetch-territory-counts.server'
+import {
+  fetchTerritoryCounts,
+  getTotalTerritoryCount,
+} from '~/features/territories/server/fetch-territory-counts.server'
 import { parseStatsFilterParams } from '~/features/territories/server/parse-stats-filter-params.server'
 import { countRestingTerritories } from '~/features/territories/server/resting-territories.server'
+import { getTerritoriesNeverWorked } from '~/features/territories/server/territories-never-worked.server'
 import { computeTerritoryCoverage } from '~/features/territories/server/territory-coverage.server'
 import { computeTerritoryCoverageTotal } from '~/features/territories/server/territory-coverage-total.server'
-import { getTerritoriesNeverWorked } from '~/features/territories/server/territories-never-worked.server'
 import {
   getBeginingDateOfTheocraticYear,
   getCurrentTheocraticYear,
@@ -32,13 +34,14 @@ import {
 } from '~/features/territories/server/theocratic-year.server'
 import AttributionsPerMonthChart from '~/features/territories/ui/AttributionsPerMonthChart'
 import MonthlyCoverageChart from '~/features/territories/ui/MonthlyCoverageChart'
+import StatsFilters from '~/features/territories/ui/StatsFilters'
 import TerritoriesNeverWorkedList from '~/features/territories/ui/TerritoriesNeverWorkedList'
 import YearOverYearTable from '~/features/territories/ui/YearOverYearTable'
-import StatsFilters from '~/features/territories/ui/StatsFilters'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/shared/ui/tooltip'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import S13ExportButton from '~/shared/ui/S13ExportButton'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/shared/ui/tooltip'
 import type { Route } from './+types/index'
 
 export const meta: Route.MetaFunction = () => {
@@ -46,7 +49,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -83,17 +86,19 @@ export async function loader({ request }: Route.LoaderArgs) {
     attributionsByGroup,
     groups,
   ] = await Promise.all([
-    countActiveWorkingTerritories(),
-    countDelayedWorkingTerritories(),
-    countRestingTerritories(),
-    countAvailableTerritories(),
+    countActiveWorkingTerritories(db),
+    countDelayedWorkingTerritories(db),
+    countRestingTerritories(db),
+    countAvailableTerritories(db),
     computeTerritoryCoverage(
+      db,
       filterParams.territoryKind,
       filterParams.attributionKind,
       filterParams.startDate,
       filterParams.endDate,
     ),
     computeTerritoryCoverageTotal(
+      db,
       filterParams.territoryKind,
       filterParams.attributionKind.length > 0
         ? filterParams.attributionKind
@@ -101,13 +106,13 @@ export async function loader({ request }: Route.LoaderArgs) {
       filterParams.startDate,
       filterParams.endDate,
     ),
-    fetchAttributionsForStats(filterParams),
-    fetchAttributionsForStats(prevParams),
-    fetchTerritoryCounts(filterParams.territoryKind),
-    fetchTerritoryCounts(),
-    getTerritoriesNeverWorked(filterParams),
-    fetchActiveAttributionsByGroup(),
-    getGroups(),
+    fetchAttributionsForStats(db, filterParams),
+    fetchAttributionsForStats(db, prevParams),
+    fetchTerritoryCounts(db, filterParams.territoryKind),
+    fetchTerritoryCounts(db),
+    getTerritoriesNeverWorked(db, filterParams),
+    fetchActiveAttributionsByGroup(db),
+    getGroups(db),
   ])
 
   const workingTerritoriesCount = activeWorkingTerritoriesCount + delayedWorkingTerritoriesCount
@@ -184,12 +189,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 }
 
-const PIE_COLORS = [
-  'var(--color-chart-1)',
-  'var(--color-chart-2)',
-  'var(--color-chart-4)',
-  'var(--color-chart-3)',
-]
+const PIE_COLORS = ['var(--color-chart-1)', 'var(--color-chart-2)', 'var(--color-chart-4)', 'var(--color-chart-3)']
 
 const GROUP_COLORS = [
   'var(--color-chart-1)',
@@ -377,9 +377,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">
-                {progression.ranked.most != null
-                  ? `${progression.ranked.most.number}`
-                  : '-'}
+                {progression.ranked.most != null ? `${progression.ranked.most.number}` : '-'}
               </span>
               {progression.ranked.most != null && (
                 <span className="font-display text-lg text-muted-foreground">
@@ -395,9 +393,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
               <span className="font-black font-display text-5xl max-sm:text-3xl">
-                {progression.ranked.least != null
-                  ? `${progression.ranked.least.number}`
-                  : '-'}
+                {progression.ranked.least != null ? `${progression.ranked.least.number}` : '-'}
               </span>
               {progression.ranked.least != null && (
                 <span className="font-display text-lg text-muted-foreground">
@@ -456,9 +452,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
         <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
-              <span className="font-black font-display text-5xl max-sm:text-3xl">
-                {progression.availabilityGap} j
-              </span>
+              <span className="font-black font-display text-5xl max-sm:text-3xl">{progression.availabilityGap} j</span>
               <StatLabel
                 label="Délai moyen de disponibilité"
                 help="Nombre moyen de jours entre le retour d'un territoire et sa prochaine attribution."
@@ -467,9 +461,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
           </Card>
           <Card>
             <CardContent className="flex flex-col items-center justify-center gap-1 p-6 text-center">
-              <span className="font-black font-display text-5xl max-sm:text-3xl">
-                {progression.restUtilization} j
-              </span>
+              <span className="font-black font-display text-5xl max-sm:text-3xl">{progression.restUtilization} j</span>
               <StatLabel
                 label="Inactivité moy. après repos"
                 help="Nombre moyen de jours d'attente entre la fin de la période de repos et la prochaine attribution."
@@ -501,7 +493,9 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
         {coverageOverTime.coverageByType.length > 0 && (
           <div
             className={`grid gap-3 max-sm:grid-cols-1 ${
-              coverageOverTime.coverageByType.length <= 3 ? `grid-cols-${coverageOverTime.coverageByType.length}` : 'grid-cols-3 max-md:grid-cols-2'
+              coverageOverTime.coverageByType.length <= 3
+                ? `grid-cols-${coverageOverTime.coverageByType.length}`
+                : 'grid-cols-3 max-md:grid-cols-2'
             }`}
           >
             {coverageOverTime.coverageByType.map(ct => (
@@ -510,9 +504,7 @@ export default function TerritoryStatsPage({ loaderData }: Route.ComponentProps)
                   <span className="font-black font-display text-4xl max-sm:text-2xl">
                     {ct.totalCoverage.toFixed(1)} %
                   </span>
-                  <span className="text-muted-foreground text-xs">
-                    ({ct.coverage.toFixed(1)} % d'attributions)
-                  </span>
+                  <span className="text-muted-foreground text-xs">({ct.coverage.toFixed(1)} % d'attributions)</span>
                   <StatLabel
                     label={ct.label}
                     help={`Couverture complète pour les territoires "${ct.label}" : pourcentage de territoires ayant eu au moins une attribution.`}

--- a/app/features/territories/routes/territory/delete.tsx
+++ b/app/features/territories/routes/territory/delete.tsx
@@ -2,7 +2,6 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { db } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -10,7 +9,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -53,7 +52,7 @@ export default function DeleteTerritory({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -2,9 +2,7 @@ import { Download, ExternalLink, Trash2, X } from 'lucide-react'
 import { useState } from 'react'
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import {
@@ -16,7 +14,8 @@ import {
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -31,7 +30,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -55,11 +54,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const zips = await getAvailableZips(territory.type as TerritoryKind)
+  const zips = await getAvailableZips(db, territory.type as TerritoryKind)
   const url = new URL(request.url)
   const entrances = await getAvailableEntrances(
+    db,
     String(url.searchParams.get('zip')),
     String(url.searchParams.get('street')),
     territory.type as TerritoryKind,
@@ -77,7 +77,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }
   }
 
-  const streets = await getAvailableStreets(String(url.searchParams.get('zip')), territory.type as TerritoryKind)
+  const streets = await getAvailableStreets(db, String(url.searchParams.get('zip')), territory.type as TerritoryKind)
   if (!url.searchParams.has('street')) {
     return {
       territory,
@@ -313,7 +313,7 @@ export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -2,9 +2,7 @@ import { Map as MapIcon, Pencil, Trash2 } from 'lucide-react'
 import { data, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
@@ -12,6 +10,8 @@ import { findTerritoriesWithDetailsPaginated } from '~/features/territories/serv
 import { computeFilters } from '~/features/territories/server/territory-filters'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -28,7 +28,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer, Role.TerritoriesManager])
+  const { session, can, db } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.TerritoriesManager,
+  ])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -37,19 +40,19 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const canManageTerritories = can(Role.TerritoriesManager)
 
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
 
   const url = new URL(request.url)
   const selectors = await computeFilters(url.searchParams)
-  const { territories, pagination } = await findTerritoriesWithDetailsPaginated(selectors, url)
+  const { territories, pagination } = await findTerritoriesWithDetailsPaginated(db, selectors, url)
 
   const messages = {
     success: session.get('success'),
     error: session.get('error'),
   }
-  const zips = await getZips()
+  const zips = await getZips(db)
 
   return data(
     {

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -2,14 +2,13 @@ import { ExternalLink, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
-import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { getBoolSetting } from '~/features/settings/server/settings'
-import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
-import { db } from '~/shared/libs/db.server'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -25,7 +24,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -33,7 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(TerritorySettingKey.TerritoryTypePhoneActive)
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
   const url = new URL(request.url)
   const zips = await db.building.groupBy({
     by: ['zip'],
@@ -155,7 +154,7 @@ export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -171,7 +170,7 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/territory/new')
   }
 
-  const limits = new LimitService(congregation)
+  const limits = new LimitService(db, congregation)
   await limits.errorIfWouldGoOverLimit('territories')
 
   await db.territory.create({

--- a/app/features/territories/server/active-working-territories.server.test.ts
+++ b/app/features/territories/server/active-working-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countActiveWorkingTerritories', () => {
   it('retourne le nombre de territoires en cours de travail', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
 
-    const result = await countActiveWorkingTerritories()
+    const result = await countActiveWorkingTerritories(db)
     expect(result).toBe(5)
   })
 
-  it('retourne 0 quand aucun territoire n\'est actif', async () => {
+  it("retourne 0 quand aucun territoire n'est actif", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countActiveWorkingTerritories()
+    const result = await countActiveWorkingTerritories(db)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/active-working-territories.server.ts
+++ b/app/features/territories/server/active-working-territories.server.ts
@@ -1,6 +1,6 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function countActiveWorkingTerritories() {
+export async function countActiveWorkingTerritories(db: ScopedDb) {
   return await db.territory.count({
     where: {
       attributions: {

--- a/app/features/territories/server/attributions.ts
+++ b/app/features/territories/server/attributions.ts
@@ -1,8 +1,8 @@
 import type { Prisma } from '~/database/generated/client'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 
-export async function findActiveAttributionsPaginated(selectors: Prisma.AttributionWhereInput, url: URL) {
+export async function findActiveAttributionsPaginated(db: ScopedDb, selectors: Prisma.AttributionWhereInput, url: URL) {
   const total = await db.attribution.count({ where: selectors })
   const pagination = paginationFromUrl(url, total)
 

--- a/app/features/territories/server/available-territories.server.test.ts
+++ b/app/features/territories/server/available-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countAvailableTerritories', () => {
   it('retourne le nombre de territoires disponibles', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(12)
 
-    const result = await countAvailableTerritories()
+    const result = await countAvailableTerritories(db)
     expect(result).toBe(12)
   })
 
-  it('retourne 0 quand aucun territoire n\'est disponible', async () => {
+  it("retourne 0 quand aucun territoire n'est disponible", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countAvailableTerritories()
+    const result = await countAvailableTerritories(db)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/available-territories.server.ts
+++ b/app/features/territories/server/available-territories.server.ts
@@ -1,12 +1,12 @@
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import {
   RESTING_PERIOD_FOR_CAMPAIGN,
   RESTING_PERIOD_FOR_DOORS_TO_DOORS,
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countAvailableTerritories() {
+export async function countAvailableTerritories(db: ScopedDb) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()

--- a/app/features/territories/server/buildings.server.test.ts
+++ b/app/features/territories/server/buildings.server.test.ts
@@ -20,24 +20,24 @@ afterEach(() => {
 })
 
 describe('getProspectionStaleDate', () => {
-  it('retourne epoch (1970) quand le setting n\'est pas configuré', async () => {
+  it("retourne epoch (1970) quand le setting n'est pas configuré", async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
-    const result = await getProspectionStaleDate()
+    const result = await getProspectionStaleDate(db)
     expect(result.getTime()).toBe(0)
   })
 
   it('retourne epoch quand la valeur est "0"', async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '0' } as never)
 
-    const result = await getProspectionStaleDate()
+    const result = await getProspectionStaleDate(db)
     expect(result.getTime()).toBe(0)
   })
 
   it('retourne une date dans le passé quand la valeur est positive', async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
-    const result = await getProspectionStaleDate()
+    const result = await getProspectionStaleDate(db)
     // 8 avril 2026 - 6 mois = 8 octobre 2025
     expect(result.getFullYear()).toBe(2025)
     expect(result.getMonth()).toBe(9) // octobre
@@ -46,7 +46,7 @@ describe('getProspectionStaleDate', () => {
   it('ne considère jamais une date du jour comme périmée quand non configuré', async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
-    const staleDate = await getProspectionStaleDate()
+    const staleDate = await getProspectionStaleDate(db)
     const today = new Date(2026, 3, 8)
 
     // Une date d'aujourd'hui ne doit PAS être < staleDate
@@ -56,7 +56,7 @@ describe('getProspectionStaleDate', () => {
   it('considère une date ancienne comme périmée quand configuré à 6 mois', async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
-    const staleDate = await getProspectionStaleDate()
+    const staleDate = await getProspectionStaleDate(db)
     const sevenMonthsAgo = new Date(2025, 8, 1) // 1er septembre 2025
 
     expect(sevenMonthsAgo < staleDate).toBe(true)
@@ -65,7 +65,7 @@ describe('getProspectionStaleDate', () => {
   it('ne considère pas une date récente comme périmée quand configuré à 6 mois', async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue({ id: 1, key: 'prospection-validity', value: '6' } as never)
 
-    const staleDate = await getProspectionStaleDate()
+    const staleDate = await getProspectionStaleDate(db)
     const twoMonthsAgo = new Date(2026, 1, 8) // 8 février 2026
 
     expect(twoMonthsAgo < staleDate).toBe(false)

--- a/app/features/territories/server/buildings.ts
+++ b/app/features/territories/server/buildings.ts
@@ -1,6 +1,6 @@
 import type { Building, Prisma } from '~/database/generated/client'
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import type { AggregatedEntrance, Entrance } from '~/shared/types/entrance'
 
@@ -27,7 +27,7 @@ function sortEntrancesByAddress(entrances: Entrance[]) {
   return entrances
 }
 
-export async function findBuildingsPaginated(selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findBuildingsPaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -43,7 +43,7 @@ export async function findBuildingsPaginated(selectors: Prisma.BuildingWhereInpu
   return { buildings, pagination }
 }
 
-export async function findBuildingsWithEntrancePaginated(selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findBuildingsWithEntrancePaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -60,7 +60,7 @@ export async function findBuildingsWithEntrancePaginated(selectors: Prisma.Build
   return { buildings, pagination }
 }
 
-export async function findEntrancesPaginated(selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findEntrancesPaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -78,7 +78,7 @@ export async function findEntrancesPaginated(selectors: Prisma.BuildingWhereInpu
   return { entrances: sortEntrancesByAddress(entrances), pagination }
 }
 
-export async function getProspectionStaleDate(): Promise<Date> {
+export async function getProspectionStaleDate(db: ScopedDb): Promise<Date> {
   const prospectionValidity = Number(
     (await db.setting.findFirst({ where: { key: 'prospection-validity' } }))?.value ?? '0',
   )
@@ -112,7 +112,7 @@ export function aggregateEntrance(entrance: Entrance): AggregatedEntrance {
   }
 }
 
-export async function getZips(territoryType?: TerritoryKind) {
+export async function getZips(db: ScopedDb, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (territoryType != null) {
@@ -128,7 +128,7 @@ export async function getZips(territoryType?: TerritoryKind) {
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getAvailableZips(territoryType?: TerritoryKind) {
+export async function getAvailableZips(db: ScopedDb, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (territoryType != null) {
@@ -144,7 +144,7 @@ export async function getAvailableZips(territoryType?: TerritoryKind) {
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getStreets(zip?: string, territoryType?: TerritoryKind) {
+export async function getStreets(db: ScopedDb, zip?: string, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {
@@ -164,7 +164,7 @@ export async function getStreets(zip?: string, territoryType?: TerritoryKind) {
   return await db.building.groupBy({ by: 'street', where: selectors })
 }
 
-export async function getAvailableStreets(zip?: string, territoryType?: TerritoryKind) {
+export async function getAvailableStreets(db: ScopedDb, zip?: string, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {
@@ -183,7 +183,12 @@ export async function getAvailableStreets(zip?: string, territoryType?: Territor
   return await db.building.groupBy({ by: 'street', where: selectors })
 }
 
-export async function getEntrances(zip?: string, street?: string, territoryType?: TerritoryKind): Promise<Entrance[]> {
+export async function getEntrances(
+  db: ScopedDb,
+  zip?: string,
+  street?: string,
+  territoryType?: TerritoryKind,
+): Promise<Entrance[]> {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {
@@ -214,6 +219,7 @@ export async function getEntrances(zip?: string, street?: string, territoryType?
 }
 
 export async function getAvailableEntrances(
+  db: ScopedDb,
   zip?: string,
   street?: string,
   territoryType?: TerritoryKind,
@@ -247,14 +253,14 @@ export async function getAvailableEntrances(
   return buildings.map(building => building.entrance).filter(entrance => entrance != null)
 }
 
-export async function getEntrance(entranceId: number): Promise<Entrance | null> {
+export async function getEntrance(db: ScopedDb, entranceId: number): Promise<Entrance | null> {
   return await db.buildingEntrance.findUnique({
     where: { id: entranceId },
     include: { buildings: true },
   })
 }
 
-export async function getBuilding(buildingId: number): Promise<Building | null> {
+export async function getBuilding(db: ScopedDb, buildingId: number): Promise<Building | null> {
   return await db.building.findUnique({
     where: { id: buildingId },
     include: { entrance: { include: { buildings: true } } },

--- a/app/features/territories/server/compute-attributions-per-month.server.test.ts
+++ b/app/features/territories/server/compute-attributions-per-month.server.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeAttributionsPerMonth } from './compute-attributions-per-month.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
 function makeAttribution(startDate: Date, id = 1): StatsAttribution {
   return {
@@ -45,7 +45,7 @@ describe('computeAttributionsPerMonth', () => {
     ])
   })
 
-  it('génère les 12 mois d\'une année théocratique complète', () => {
+  it("génère les 12 mois d'une année théocratique complète", () => {
     const result = computeAttributionsPerMonth([], new Date(2025, 8, 1), new Date(2026, 7, 31))
     expect(result).toHaveLength(12)
     expect(result[0].month).toBe('2025-09')

--- a/app/features/territories/server/compute-availability-gap.server.test.ts
+++ b/app/features/territories/server/compute-availability-gap.server.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeAvailabilityGap } from './compute-availability-gap.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
-function makeAttribution(
-  territoryId: number,
-  startDate: Date,
-  endDate: Date | null,
-  id = 1,
-): StatsAttribution {
+function makeAttribution(territoryId: number, startDate: Date, endDate: Date | null, id = 1): StatsAttribution {
   return {
     id,
     territoryId,
@@ -23,11 +18,11 @@ function makeAttribution(
 }
 
 describe('computeAvailabilityGap', () => {
-  it('retourne 0 quand il n\'y a aucune attribution', () => {
+  it("retourne 0 quand il n'y a aucune attribution", () => {
     expect(computeAvailabilityGap([])).toBe(0)
   })
 
-  it('retourne 0 quand il n\'y a qu\'une seule attribution par territoire', () => {
+  it("retourne 0 quand il n'y a qu'une seule attribution par territoire", () => {
     const attributions = [
       makeAttribution(1, new Date(2025, 0, 1), new Date(2025, 1, 1)),
       makeAttribution(2, new Date(2025, 0, 1), new Date(2025, 1, 1)),

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './territory-count-by-type.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeCoverageByTerritoryType } from './compute-coverage-by-territory-type.server'
+import type { StatsAttribution } from './stats-attribution.type'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 
-function makeAttribution(
-  territoryId: number,
-  territoryType: TerritoryKind,
-): StatsAttribution {
+function makeAttribution(territoryId: number, territoryType: TerritoryKind): StatsAttribution {
   return {
     id: territoryId,
     territoryId,
@@ -22,7 +19,7 @@ function makeAttribution(
 }
 
 describe('computeCoverageByTerritoryType', () => {
-  it('retourne des couvertures à 0 quand il n\'y a aucune attribution', () => {
+  it("retourne des couvertures à 0 quand il n'y a aucune attribution", () => {
     const counts: TerritoryCountByType[] = [{ type: TerritoryKind.Classical, count: 10 }]
     const result = computeCoverageByTerritoryType([], counts)
 

--- a/app/features/territories/server/compute-coverage-by-territory-type.server.ts
+++ b/app/features/territories/server/compute-coverage-by-territory-type.server.ts
@@ -1,6 +1,6 @@
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './territory-count-by-type.type'
 import type { StatsAttribution } from './stats-attribution.type'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 
 export interface CoverageByType {
   kind: TerritoryKind

--- a/app/features/territories/server/compute-duration-stats.server.test.ts
+++ b/app/features/territories/server/compute-duration-stats.server.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeDurationStats } from './compute-duration-stats.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
 function makeAttribution(startDate: Date, endDate: Date | null): StatsAttribution {
   return {
@@ -18,7 +18,7 @@ function makeAttribution(startDate: Date, endDate: Date | null): StatsAttributio
 }
 
 describe('computeDurationStats', () => {
-  it('retourne des zéros quand il n\'y a aucune attribution', () => {
+  it("retourne des zéros quand il n'y a aucune attribution", () => {
     expect(computeDurationStats([])).toEqual({ averageDays: 0, longestDays: 0, shortestDays: 0 })
   })
 

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.test.ts
@@ -1,15 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { TerritoryCountByType } from './territory-count-by-type.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeMonthlyCoverageEvolution } from './compute-monthly-coverage-evolution.server'
+import type { StatsAttribution } from './stats-attribution.type'
+import type { TerritoryCountByType } from './territory-count-by-type.type'
 
-function makeAttribution(
-  territoryId: number,
-  startDate: Date,
-  endDate: Date | null,
-): StatsAttribution {
+function makeAttribution(territoryId: number, startDate: Date, endDate: Date | null): StatsAttribution {
   return {
     id: territoryId,
     territoryId,
@@ -25,18 +21,13 @@ function makeAttribution(
 describe('computeMonthlyCoverageEvolution', () => {
   const counts: TerritoryCountByType[] = [{ type: TerritoryKind.Classical, count: 10 }]
 
-  it('retourne un tableau vide quand il n\'y a aucun territoire', () => {
+  it("retourne un tableau vide quand il n'y a aucun territoire", () => {
     const result = computeMonthlyCoverageEvolution([], [], new Date(2025, 8, 1), new Date(2025, 10, 30))
     expect(result).toEqual([])
   })
 
   it('retourne 0% pour chaque mois sans attributions', () => {
-    const result = computeMonthlyCoverageEvolution(
-      [],
-      counts,
-      new Date(2025, 8, 1),
-      new Date(2025, 10, 30),
-    )
+    const result = computeMonthlyCoverageEvolution([], counts, new Date(2025, 8, 1), new Date(2025, 10, 30))
 
     expect(result).toHaveLength(3)
     expect(result.every(m => m.coverage === 0)).toBe(true)
@@ -48,12 +39,7 @@ describe('computeMonthlyCoverageEvolution', () => {
       makeAttribution(2, new Date(2025, 9, 10), new Date(2025, 9, 25)),
     ]
 
-    const result = computeMonthlyCoverageEvolution(
-      attributions,
-      counts,
-      new Date(2025, 8, 1),
-      new Date(2025, 10, 30),
-    )
+    const result = computeMonthlyCoverageEvolution(attributions, counts, new Date(2025, 8, 1), new Date(2025, 10, 30))
 
     // Sept : territoire 1 touché = 10%
     expect(result[0].coverage).toBe(10)

--- a/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
+++ b/app/features/territories/server/compute-monthly-coverage-evolution.server.ts
@@ -1,6 +1,6 @@
+import type { StatsAttribution } from './stats-attribution.type'
 import type { TerritoryCountByType } from './territory-count-by-type.type'
 import { getTotalTerritoryCount } from './territory-count-by-type.type'
-import type { StatsAttribution } from './stats-attribution.type'
 
 export interface MonthlyCoverage {
   month: string

--- a/app/features/territories/server/compute-overdue-rate.server.test.ts
+++ b/app/features/territories/server/compute-overdue-rate.server.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeOverdueRate } from './compute-overdue-rate.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
 function makeAttribution(endDate: Date | null, lateDate: Date): StatsAttribution {
   return {
@@ -18,7 +18,7 @@ function makeAttribution(endDate: Date | null, lateDate: Date): StatsAttribution
 }
 
 describe('computeOverdueRate', () => {
-  it('retourne 0 quand il n\'y a aucune attribution', () => {
+  it("retourne 0 quand il n'y a aucune attribution", () => {
     expect(computeOverdueRate([])).toBe(0)
   })
 
@@ -27,7 +27,7 @@ describe('computeOverdueRate', () => {
     expect(computeOverdueRate(attributions)).toBe(0)
   })
 
-  it('retourne 0 quand aucune attribution n\'est en retard', () => {
+  it("retourne 0 quand aucune attribution n'est en retard", () => {
     const attributions = [
       makeAttribution(new Date(2025, 4, 1), new Date(2025, 5, 1)), // rendue avant la date limite
     ]

--- a/app/features/territories/server/compute-ranked-territories.server.test.ts
+++ b/app/features/territories/server/compute-ranked-territories.server.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeRankedTerritories } from './compute-ranked-territories.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
 function makeAttribution(overrides: Partial<StatsAttribution> = {}): StatsAttribution {
   return {
@@ -19,7 +19,7 @@ function makeAttribution(overrides: Partial<StatsAttribution> = {}): StatsAttrib
 }
 
 describe('computeRankedTerritories', () => {
-  it('retourne null quand il n\'y a aucune attribution', () => {
+  it("retourne null quand il n'y a aucune attribution", () => {
     const result = computeRankedTerritories([])
     expect(result).toEqual({ most: null, least: null })
   })

--- a/app/features/territories/server/compute-rest-period-utilization.server.test.ts
+++ b/app/features/territories/server/compute-rest-period-utilization.server.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { StatsAttribution } from './stats-attribution.type'
 import { computeRestPeriodUtilization } from './compute-rest-period-utilization.server'
+import type { StatsAttribution } from './stats-attribution.type'
 
 function makeAttribution(
   territoryId: number,
@@ -24,11 +24,11 @@ function makeAttribution(
 }
 
 describe('computeRestPeriodUtilization', () => {
-  it('retourne 0 quand il n\'y a aucune attribution', () => {
+  it("retourne 0 quand il n'y a aucune attribution", () => {
     expect(computeRestPeriodUtilization([])).toBe(0)
   })
 
-  it('retourne 0 quand il n\'y a qu\'une seule attribution par territoire', () => {
+  it("retourne 0 quand il n'y a qu'une seule attribution par territoire", () => {
     const attributions = [
       makeAttribution(1, TerritoryAttributionKind.Default, new Date(2025, 0, 1), new Date(2025, 1, 1)),
     ]
@@ -47,7 +47,7 @@ describe('computeRestPeriodUtilization', () => {
     expect(computeRestPeriodUtilization(attributions)).toBe(0)
   })
 
-  it('calcule les jours d\'inactivité après la fin du repos (campagne, 15j)', () => {
+  it("calcule les jours d'inactivité après la fin du repos (campagne, 15j)", () => {
     // Le repos pour campagne est de 15 jours
     // Attribution se termine le 1er jan, repos finit le 16 jan
     // Prochaine attribution commence le 26 jan = 10 jours d'inactivité post-repos

--- a/app/features/territories/server/create-building.server.test.ts
+++ b/app/features/territories/server/create-building.server.test.ts
@@ -28,7 +28,7 @@ describe('createBuilding', () => {
   it('crée un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
     vi.mocked(db.building.create).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
-    const result = await createBuilding({
+    const result = await createBuilding(db, {
       address: { number: '12', street: 'Rue Test', zip: '75001' },
       congregationId: 1,
     })
@@ -39,11 +39,16 @@ describe('createBuilding', () => {
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([
+      [0, 0],
+      [0, 10],
+      [10, 10],
+      [10, 0],
+    ] as never)
     vi.mocked(pointInPolygon).mockReturnValue(true as never)
     vi.mocked(db.building.create).mockResolvedValue({ id: 2, inTerritory: true } as never)
 
-    const result = await createBuilding({
+    const result = await createBuilding(db, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5, longitude: 5 },
       congregationId: 1,
@@ -53,7 +58,7 @@ describe('createBuilding', () => {
   })
 
   it('ne vérifie pas le polygone quand seulement latitude est fournie', async () => {
-    await createBuilding({
+    await createBuilding(db, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5 },
       congregationId: 1,
@@ -65,7 +70,7 @@ describe('createBuilding', () => {
   })
 
   it('ne vérifie pas le polygone quand seulement longitude est fournie', async () => {
-    await createBuilding({
+    await createBuilding(db, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { longitude: 5 },
       congregationId: 1,
@@ -78,7 +83,7 @@ describe('createBuilding', () => {
     vi.mocked(getTerritoryPolygon).mockResolvedValue([] as never)
     vi.mocked(db.building.create).mockResolvedValue({ id: 4, inTerritory: true } as never)
 
-    await createBuilding({
+    await createBuilding(db, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5, longitude: 5 },
       congregationId: 1,
@@ -89,11 +94,16 @@ describe('createBuilding', () => {
   })
 
   it('marque inTerritory false quand le point est hors du polygone', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([
+      [0, 0],
+      [0, 10],
+      [10, 10],
+      [10, 0],
+    ] as never)
     vi.mocked(pointInPolygon).mockReturnValue(false as never)
     vi.mocked(db.building.create).mockResolvedValue({ id: 3, inTerritory: false } as never)
 
-    const result = await createBuilding({
+    const result = await createBuilding(db, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 50, longitude: 50 },
       congregationId: 1,

--- a/app/features/territories/server/create-building.server.ts
+++ b/app/features/territories/server/create-building.server.ts
@@ -1,20 +1,23 @@
 import type { DetailedBuilding } from '~/features/territories/model/detailed-building.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 import { getTerritoryPolygon } from './get-territory-polygon.server'
 
-export async function createBuilding({
-  address,
-  coordinates = {},
-  congregationId,
-}: {
-  address: { number: string; street: string; zip: string }
-  coordinates?: { latitude?: number; longitude?: number }
-  congregationId: number
-}): Promise<DetailedBuilding> {
+export async function createBuilding(
+  db: ScopedDb,
+  {
+    address,
+    coordinates = {},
+    congregationId,
+  }: {
+    address: { number: string; street: string; zip: string }
+    coordinates?: { latitude?: number; longitude?: number }
+    congregationId: number
+  },
+): Promise<DetailedBuilding> {
   let isInTerritory = true
   if (coordinates.latitude != null && coordinates.longitude != null) {
-    const polygon = await getTerritoryPolygon()
+    const polygon = await getTerritoryPolygon(db)
     if (polygon.length > 0) {
       isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
     }

--- a/app/features/territories/server/delayed-working-territories.server.test.ts
+++ b/app/features/territories/server/delayed-working-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countDelayedWorkingTerritories', () => {
   it('retourne le nombre de territoires en retard', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(3)
 
-    const result = await countDelayedWorkingTerritories()
+    const result = await countDelayedWorkingTerritories(db)
     expect(result).toBe(3)
   })
 
-  it('retourne 0 quand aucun territoire n\'est en retard', async () => {
+  it("retourne 0 quand aucun territoire n'est en retard", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countDelayedWorkingTerritories()
+    const result = await countDelayedWorkingTerritories(db)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/delayed-working-territories.server.ts
+++ b/app/features/territories/server/delayed-working-territories.server.ts
@@ -1,6 +1,6 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function countDelayedWorkingTerritories() {
+export async function countDelayedWorkingTerritories(db: ScopedDb) {
   return await db.territory.count({
     where: {
       attributions: {

--- a/app/features/territories/server/edit-building.server.test.ts
+++ b/app/features/territories/server/edit-building.server.test.ts
@@ -28,7 +28,7 @@ describe('editBuilding', () => {
   it('met à jour un bâtiment sans coordonnées (inTerritory = true par défaut)', async () => {
     vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
-    await editBuilding(1, {
+    await editBuilding(db, 1, {
       address: { number: '12', street: 'Rue Test', zip: '75001' },
     })
 
@@ -37,11 +37,16 @@ describe('editBuilding', () => {
   })
 
   it('vérifie les coordonnées contre le polygone du territoire', async () => {
-    vi.mocked(getTerritoryPolygon).mockResolvedValue([[0, 0], [0, 10], [10, 10], [10, 0]] as never)
+    vi.mocked(getTerritoryPolygon).mockResolvedValue([
+      [0, 0],
+      [0, 10],
+      [10, 10],
+      [10, 0],
+    ] as never)
     vi.mocked(pointInPolygon).mockReturnValue(true as never)
     vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
-    const result = await editBuilding(1, {
+    const result = await editBuilding(db, 1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5, longitude: 5 },
     })
@@ -52,7 +57,7 @@ describe('editBuilding', () => {
   it('ne vérifie pas le polygone avec coordonnées partielles', async () => {
     vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
-    await editBuilding(1, {
+    await editBuilding(db, 1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5 },
     })
@@ -65,7 +70,7 @@ describe('editBuilding', () => {
     vi.mocked(getTerritoryPolygon).mockResolvedValue([] as never)
     vi.mocked(db.building.update).mockResolvedValue({ id: 1, inTerritory: true } as never)
 
-    await editBuilding(1, {
+    await editBuilding(db, 1, {
       address: { number: '5', street: 'Rue Test', zip: '75001' },
       coordinates: { latitude: 5, longitude: 5 },
     })

--- a/app/features/territories/server/edit-building.server.ts
+++ b/app/features/territories/server/edit-building.server.ts
@@ -2,10 +2,11 @@ import type { Building } from '~/database/generated/client'
 
 import { getTerritoryPolygon } from '~/features/territories/server/get-territory-polygon.server'
 
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 
 export async function editBuilding(
+  db: ScopedDb,
   buildingId: number,
   {
     address,
@@ -17,7 +18,7 @@ export async function editBuilding(
 ): Promise<Building> {
   let isInTerritory = true
   if (coordinates.latitude != null && coordinates.longitude != null) {
-    const polygon = await getTerritoryPolygon()
+    const polygon = await getTerritoryPolygon(db)
     if (polygon.length > 0) {
       isInTerritory = pointInPolygon([coordinates.latitude, coordinates.longitude], polygon)
     }

--- a/app/features/territories/server/fetch-attributions-by-group.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.test.ts
@@ -21,7 +21,7 @@ describe('fetchActiveAttributionsByGroup', () => {
       { publisher: { publisherGroup: { name: 'Groupe B' } } },
     ] as never)
 
-    const result = await fetchActiveAttributionsByGroup()
+    const result = await fetchActiveAttributionsByGroup(db)
 
     expect(result).toEqual([
       { groupName: 'Groupe A', count: 2 },
@@ -35,7 +35,7 @@ describe('fetchActiveAttributionsByGroup', () => {
       { publisher: { publisherGroup: { name: 'Groupe A' } } },
     ] as never)
 
-    const result = await fetchActiveAttributionsByGroup()
+    const result = await fetchActiveAttributionsByGroup(db)
 
     expect(result).toEqual([
       { groupName: 'Sans groupe', count: 1 },
@@ -43,10 +43,10 @@ describe('fetchActiveAttributionsByGroup', () => {
     ])
   })
 
-  it('retourne un tableau vide quand il n\'y a aucune attribution active', async () => {
+  it("retourne un tableau vide quand il n'y a aucune attribution active", async () => {
     vi.mocked(db.attribution.findMany).mockResolvedValue([])
 
-    const result = await fetchActiveAttributionsByGroup()
+    const result = await fetchActiveAttributionsByGroup(db)
     expect(result).toEqual([])
   })
 })

--- a/app/features/territories/server/fetch-attributions-by-group.server.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.ts
@@ -1,4 +1,4 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 export interface AttributionsByGroup {
   groupName: string
@@ -6,7 +6,7 @@ export interface AttributionsByGroup {
 }
 
 // Compte les attributions actives (en cours) regroupées par groupe de prédication
-export async function fetchActiveAttributionsByGroup(): Promise<AttributionsByGroup[]> {
+export async function fetchActiveAttributionsByGroup(db: ScopedDb): Promise<AttributionsByGroup[]> {
   const attributions = await db.attribution.findMany({
     where: { endDate: null },
     select: {

--- a/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
@@ -29,7 +29,7 @@ describe('fetchAttributionsForStats', () => {
       },
     ] as never)
 
-    const result = await fetchAttributionsForStats({
+    const result = await fetchAttributionsForStats(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
@@ -50,10 +50,10 @@ describe('fetchAttributionsForStats', () => {
     ])
   })
 
-  it('retourne un tableau vide quand il n\'y a aucune attribution', async () => {
+  it("retourne un tableau vide quand il n'y a aucune attribution", async () => {
     vi.mocked(db.attribution.findMany).mockResolvedValue([])
 
-    const result = await fetchAttributionsForStats({
+    const result = await fetchAttributionsForStats(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
@@ -66,7 +66,7 @@ describe('fetchAttributionsForStats', () => {
   it('fonctionne avec un filtre de groupe', async () => {
     vi.mocked(db.attribution.findMany).mockResolvedValue([])
 
-    const result = await fetchAttributionsForStats({
+    const result = await fetchAttributionsForStats(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),

--- a/app/features/territories/server/fetch-attributions-for-stats.server.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from '~/database/generated/client'
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import type { StatsAttribution } from './stats-attribution.type'
 import type { StatsFilterParams } from './stats-filter-params.type'
 
@@ -12,7 +12,7 @@ function buildDateOverlapWhere(startDate: Date, endDate: Date): Prisma.Attributi
   }
 }
 
-export async function fetchAttributionsForStats(params: StatsFilterParams): Promise<StatsAttribution[]> {
+export async function fetchAttributionsForStats(db: ScopedDb, params: StatsFilterParams): Promise<StatsAttribution[]> {
   const attributions = await db.attribution.findMany({
     where: {
       territory: {

--- a/app/features/territories/server/fetch-open-data.server.ts
+++ b/app/features/territories/server/fetch-open-data.server.ts
@@ -1,9 +1,9 @@
 import { Readable } from 'node:stream'
 import type { ReadableStream } from 'node:stream/web'
 import { parse } from 'csv'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function fetchOpenData() {
+export async function fetchOpenData(db: ScopedDb) {
   const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
   if (!banoUrl?.value || banoUrl.value === '') {
     return new Readable().pipe(parse({ delimiter: ',' }))

--- a/app/features/territories/server/fetch-territory-counts.server.test.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.test.ts
@@ -22,7 +22,7 @@ describe('fetchTerritoryCounts', () => {
       { type: 'commerces', _count: { id: 5 } },
     ] as never)
 
-    const result = await fetchTerritoryCounts([TerritoryKind.Classical, TerritoryKind.Commerces])
+    const result = await fetchTerritoryCounts(db, [TerritoryKind.Classical, TerritoryKind.Commerces])
 
     expect(result).toEqual([
       { type: TerritoryKind.Classical, count: 30 },
@@ -31,11 +31,9 @@ describe('fetchTerritoryCounts', () => {
   })
 
   it('fonctionne sans filtre de types', async () => {
-    vi.mocked(db.territory.groupBy).mockResolvedValue([
-      { type: 'doors-to-doors', _count: { id: 20 } },
-    ] as never)
+    vi.mocked(db.territory.groupBy).mockResolvedValue([{ type: 'doors-to-doors', _count: { id: 20 } }] as never)
 
-    const result = await fetchTerritoryCounts()
+    const result = await fetchTerritoryCounts(db)
 
     expect(result).toEqual([{ type: TerritoryKind.Classical, count: 20 }])
   })

--- a/app/features/territories/server/fetch-territory-counts.server.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.ts
@@ -1,11 +1,14 @@
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import type { TerritoryCountByType } from './territory-count-by-type.type'
 
 export type { TerritoryCountByType } from './territory-count-by-type.type'
 export { getTotalTerritoryCount } from './territory-count-by-type.type'
 
-export async function fetchTerritoryCounts(territoryKinds?: TerritoryKind[]): Promise<TerritoryCountByType[]> {
+export async function fetchTerritoryCounts(
+  db: ScopedDb,
+  territoryKinds?: TerritoryKind[],
+): Promise<TerritoryCountByType[]> {
   const groups = await db.territory.groupBy({
     by: ['type'],
     _count: { id: true },

--- a/app/features/territories/server/get-building-details.server.test.ts
+++ b/app/features/territories/server/get-building-details.server.test.ts
@@ -18,14 +18,14 @@ describe('getBuildingDetails', () => {
     const fakeBuilding = { id: 1, number: '12', entrance: { buildings: [], territories: [] } }
     vi.mocked(db.building.findUnique).mockResolvedValue(fakeBuilding as never)
 
-    const result = await getBuildingDetails(1)
+    const result = await getBuildingDetails(db, 1)
     expect(result).toEqual(fakeBuilding)
   })
 
-  it('retourne null quand le bâtiment n\'existe pas', async () => {
+  it("retourne null quand le bâtiment n'existe pas", async () => {
     vi.mocked(db.building.findUnique).mockResolvedValue(null as never)
 
-    const result = await getBuildingDetails(999)
+    const result = await getBuildingDetails(db, 999)
     expect(result).toBeNull()
   })
 })

--- a/app/features/territories/server/get-building-details.server.ts
+++ b/app/features/territories/server/get-building-details.server.ts
@@ -1,7 +1,7 @@
 import type { DetailedBuilding } from '~/features/territories/model/detailed-building.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getBuildingDetails(buildingId: number): Promise<DetailedBuilding | null> {
+export async function getBuildingDetails(db: ScopedDb, buildingId: number): Promise<DetailedBuilding | null> {
   return await db.building.findUnique({
     where: { id: buildingId },
     include: {

--- a/app/features/territories/server/get-buildings.server.test.ts
+++ b/app/features/territories/server/get-buildings.server.test.ts
@@ -18,14 +18,14 @@ describe('getBuildings', () => {
     const fakeBuildings = [{ id: 1, zip: '75001', street: 'Rue Test' }]
     vi.mocked(db.building.findMany).mockResolvedValue(fakeBuildings as never)
 
-    const result = await getBuildings('75001', 'Rue Test')
+    const result = await getBuildings(db, '75001', 'Rue Test')
     expect(result).toEqual(fakeBuildings)
   })
 
   it('retourne un tableau vide quand aucun bâtiment ne correspond', async () => {
     vi.mocked(db.building.findMany).mockResolvedValue([] as never)
 
-    const result = await getBuildings('00000', 'Rue Inexistante')
+    const result = await getBuildings(db, '00000', 'Rue Inexistante')
     expect(result).toEqual([])
   })
 })

--- a/app/features/territories/server/get-buildings.server.ts
+++ b/app/features/territories/server/get-buildings.server.ts
@@ -1,8 +1,8 @@
 import type { Building, Prisma } from '~/database/generated/client'
 
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getBuildings(zip: string, street: string): Promise<Building[]> {
+export async function getBuildings(db: ScopedDb, zip: string, street: string): Promise<Building[]> {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {

--- a/app/features/territories/server/get-territory-polygon.server.test.ts
+++ b/app/features/territories/server/get-territory-polygon.server.test.ts
@@ -14,21 +14,25 @@ beforeEach(() => {
 })
 
 describe('getTerritoryPolygon', () => {
-  it('retourne un tableau vide quand le setting n\'existe pas', async () => {
+  it("retourne un tableau vide quand le setting n'existe pas", async () => {
     vi.mocked(db.setting.findFirst).mockResolvedValue(null as never)
 
-    const result = await getTerritoryPolygon()
+    const result = await getTerritoryPolygon(db)
     expect(result).toEqual([])
   })
 
   it('parse le JSON du setting en polygone', async () => {
-    const polygon = [[48.8566, 2.3522], [48.8567, 2.3523], [48.8568, 2.3524]]
+    const polygon = [
+      [48.8566, 2.3522],
+      [48.8567, 2.3523],
+      [48.8568, 2.3524],
+    ]
     vi.mocked(db.setting.findFirst).mockResolvedValue({
       key: 'territory',
       value: JSON.stringify(polygon),
     } as never)
 
-    const result = await getTerritoryPolygon()
+    const result = await getTerritoryPolygon(db)
     expect(result).toEqual(polygon)
   })
 })

--- a/app/features/territories/server/get-territory-polygon.server.ts
+++ b/app/features/territories/server/get-territory-polygon.server.ts
@@ -1,6 +1,6 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export async function getTerritoryPolygon(): Promise<[number, number][]> {
+export async function getTerritoryPolygon(db: ScopedDb): Promise<[number, number][]> {
   const territory = await db.setting.findFirst({
     where: { key: 'territory' },
   })

--- a/app/features/territories/server/handle-sync-work.server.ts
+++ b/app/features/territories/server/handle-sync-work.server.ts
@@ -1,6 +1,6 @@
 import type { Job } from 'bullmq'
 import { resolveCongregation } from '~/shared/libs/congregation.server'
-import { congregationContext } from '~/shared/libs/db.server'
+import { congregationContext, createScopedDb } from '~/shared/libs/db.server'
 import { createLogger } from '~/shared/libs/logger.server'
 import { importOpenData } from './import-open-data.server'
 import { sendMailAfterDataSync } from './send-mail-after-data-sync.server'
@@ -15,11 +15,13 @@ export async function handleSyncWork(job: Job<SyncJobData>): Promise<void> {
   const congregation = await resolveCongregation(congregationId)
   congregationContext.enterWith({ congregationId, congregation })
 
+  const db = createScopedDb(congregationId)
+
   try {
     await job.updateProgress(0)
     logger.info(`Starting sync job ${job.id}`, { userEmail, congregationId })
 
-    await importOpenData(congregationId, (percent: number) => {
+    await importOpenData(db, congregationId, (percent: number) => {
       logger.info(`Sync job ${job.id} progress: ${percent}%`, { userEmail })
       if (percent < 99) {
         job.updateProgress(percent)

--- a/app/features/territories/server/import-open-data.server.ts
+++ b/app/features/territories/server/import-open-data.server.ts
@@ -1,13 +1,17 @@
 import { getAllowedZips } from '~/features/territories/server/settings'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 
 import { fetchOpenData } from './fetch-open-data.server'
 import { getTerritoryPolygon } from './get-territory-polygon.server'
 
-export async function importOpenData(congregationId: number, progressCallback: (percent: number) => void = () => {}) {
-  const wantedZips = await getAllowedZips()
-  const territory = await getTerritoryPolygon()
+export async function importOpenData(
+  db: ScopedDb,
+  congregationId: number,
+  progressCallback: (percent: number) => void = () => {},
+) {
+  const wantedZips = await getAllowedZips(db)
+  const territory = await getTerritoryPolygon(db)
   await db.building.updateMany({
     where: {
       inOpenData: true,
@@ -17,7 +21,7 @@ export async function importOpenData(congregationId: number, progressCallback: (
     },
   })
 
-  const parser = await fetchOpenData()
+  const parser = await fetchOpenData(db)
 
   return new Promise<void>((resolve, reject) => {
     let totalItems = 0

--- a/app/features/territories/server/parse-stats-filter-params.server.test.ts
+++ b/app/features/territories/server/parse-stats-filter-params.server.test.ts
@@ -4,7 +4,7 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { parseStatsFilterParams } from './parse-stats-filter-params.server'
 
 describe('parseStatsFilterParams', () => {
-  it('retourne les valeurs par défaut quand aucun paramètre n\'est fourni', () => {
+  it("retourne les valeurs par défaut quand aucun paramètre n'est fourni", () => {
     const params = new URLSearchParams()
     const result = parseStatsFilterParams(params, 2025)
 

--- a/app/features/territories/server/parse-stats-filter-params.server.ts
+++ b/app/features/territories/server/parse-stats-filter-params.server.ts
@@ -10,14 +10,14 @@ export function parseStatsFilterParams(params: URLSearchParams, theocraticYear: 
   return {
     territoryKind: kinds.length > 0 ? kinds : [TerritoryKind.Classical],
     attributionKind: attributionKinds.length > 0 ? attributionKinds : [TerritoryAttributionKind.Default],
-    startDate: params.get('startDate') != null
-      ? new Date(String(params.get('startDate')))
-      : getBeginingDateOfTheocraticYear(theocraticYear),
-    endDate: params.get('endDate') != null
-      ? new Date(String(params.get('endDate')))
-      : getEndDateOfTheocraticYear(theocraticYear),
-    groupId: params.get('group') != null && params.get('group') !== 'none'
-      ? Number(params.get('group'))
-      : undefined,
+    startDate:
+      params.get('startDate') != null
+        ? new Date(String(params.get('startDate')))
+        : getBeginingDateOfTheocraticYear(theocraticYear),
+    endDate:
+      params.get('endDate') != null
+        ? new Date(String(params.get('endDate')))
+        : getEndDateOfTheocraticYear(theocraticYear),
+    groupId: params.get('group') != null && params.get('group') !== 'none' ? Number(params.get('group')) : undefined,
   }
 }

--- a/app/features/territories/server/resting-territories.server.test.ts
+++ b/app/features/territories/server/resting-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countRestingTerritories', () => {
   it('retourne le nombre de territoires au repos', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(7)
 
-    const result = await countRestingTerritories()
+    const result = await countRestingTerritories(db)
     expect(result).toBe(7)
   })
 
   it('retourne 0 quand aucun territoire ne se repose', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countRestingTerritories()
+    const result = await countRestingTerritories(db)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/resting-territories.server.ts
+++ b/app/features/territories/server/resting-territories.server.ts
@@ -1,12 +1,12 @@
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import {
   RESTING_PERIOD_FOR_CAMPAIGN,
   RESTING_PERIOD_FOR_DOORS_TO_DOORS,
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countRestingTerritories() {
+export async function countRestingTerritories(db: ScopedDb) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()

--- a/app/features/territories/server/set-building-notes.server.test.ts
+++ b/app/features/territories/server/set-building-notes.server.test.ts
@@ -18,7 +18,7 @@ describe('setBuildingNotes', () => {
     const fakeBuilding = { id: 1, notes: 'Nouvelle note', importantNotes: 'Important!' }
     vi.mocked(db.building.update).mockResolvedValue(fakeBuilding as never)
 
-    const result = await setBuildingNotes(1, { notes: 'Nouvelle note', importantNotes: 'Important!' })
+    const result = await setBuildingNotes(db, 1, { notes: 'Nouvelle note', importantNotes: 'Important!' })
     expect(result).toEqual(fakeBuilding)
   })
 })

--- a/app/features/territories/server/set-building-notes.server.ts
+++ b/app/features/territories/server/set-building-notes.server.ts
@@ -1,8 +1,9 @@
 import type { Building } from '~/database/generated/client'
 
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 export function setBuildingNotes(
+  db: ScopedDb,
   buildingId: number,
   { notes, importantNotes }: { notes: string; importantNotes: string },
 ): Promise<Building> {

--- a/app/features/territories/server/set-building-prospection-data.server.test.ts
+++ b/app/features/territories/server/set-building-prospection-data.server.test.ts
@@ -30,7 +30,7 @@ describe('setBuildingProspectionData', () => {
       liberals: '2',
     })
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.homes).toBe(15)
@@ -41,7 +41,7 @@ describe('setBuildingProspectionData', () => {
   it('retourne null pour les champs numériques vides', async () => {
     const formData = makeFormData({})
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.homes).toBeNull()
@@ -57,7 +57,7 @@ describe('setBuildingProspectionData', () => {
       landromat: 'on',
     })
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.hasShops).toBe(true)
@@ -69,7 +69,7 @@ describe('setBuildingProspectionData', () => {
   it('les champs booléens sont false par défaut', async () => {
     const formData = makeFormData({})
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.hasShops).toBe(false)
@@ -83,7 +83,7 @@ describe('setBuildingProspectionData', () => {
       shopkinds: 'boulangerie',
     })
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.shopKind).toBe('boulangerie')
@@ -92,7 +92,7 @@ describe('setBuildingProspectionData', () => {
   it('shopKind est une chaîne vide par défaut', async () => {
     const formData = makeFormData({})
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.shopKind).toBe('')
@@ -103,7 +103,7 @@ describe('setBuildingProspectionData', () => {
       'prospection-date': '2025-04-08',
     })
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.prospectionDate).toBeInstanceOf(Date)
@@ -112,13 +112,13 @@ describe('setBuildingProspectionData', () => {
   it('la date de prospection est null par défaut', async () => {
     const formData = makeFormData({})
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     expect(callArgs.data.prospectionDate).toBeNull()
   })
 
-  it('parse les données d\'entrée (access, PMR, portes, boîtes aux lettres)', async () => {
+  it("parse les données d'entrée (access, PMR, portes, boîtes aux lettres)", async () => {
     const formData = makeFormData({
       access: '3',
       pmr: 'on',
@@ -126,7 +126,7 @@ describe('setBuildingProspectionData', () => {
       mailboxes: 'on',
     })
 
-    await setBuildingProspectionData(1, formData)
+    await setBuildingProspectionData(db, 1, formData)
 
     const callArgs = vi.mocked(db.building.update).mock.calls[0][0]
     const entrance = callArgs.data.entrance as { update: Record<string, unknown> }

--- a/app/features/territories/server/set-building-prospection-data.server.ts
+++ b/app/features/territories/server/set-building-prospection-data.server.ts
@@ -1,7 +1,7 @@
 import type { Building, Prisma } from '~/database/generated/client'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
-export function setBuildingProspectionData(buildingId: number, formData: FormData): Promise<Building> {
+export function setBuildingProspectionData(db: ScopedDb, buildingId: number, formData: FormData): Promise<Building> {
   const data: Prisma.BuildingUpdateInput = {}
 
   data.homes = formData.get('homes') ? Number(formData.get('homes')) : null

--- a/app/features/territories/server/settings.ts
+++ b/app/features/territories/server/settings.ts
@@ -1,4 +1,4 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 export function parseTerritoryPolygon(text: string): [number, number][] {
   return text.split(',').map(coord =>
@@ -22,7 +22,7 @@ export function serializeZips(zips: string[]) {
   return zips.join(', ')
 }
 
-export async function getAllowedZips(): Promise<string[]> {
+export async function getAllowedZips(db: ScopedDb): Promise<string[]> {
   const zips = await db.setting.findFirst({
     where: { key: 'zips' },
   })

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -27,17 +27,17 @@ describe('getTerritoriesExportData', () => {
     const fakeTerritories = [{ id: 1, attributions: [] }]
     vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories as never)
 
-    const result = await getTerritoriesExportData(2025)
+    const result = await getTerritoriesExportData(db as any, 2025)
     expect(result).toEqual(fakeTerritories)
   })
 
   it("retourne un tableau vide quand il n'y a pas de territoires", async () => {
-    const result = await getTerritoriesExportData(2025)
+    const result = await getTerritoriesExportData(db as any, 2025)
     expect(result).toEqual([])
   })
 
   it("passe l'année théocratique aux fonctions de date", async () => {
-    await getTerritoriesExportData(2024)
+    await getTerritoriesExportData(db as any, 2024)
 
     // Vérifier que les fonctions de date ont été utilisées (via le résultat)
     expect(vi.mocked(getBeginingDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
@@ -45,7 +45,7 @@ describe('getTerritoriesExportData', () => {
   })
 
   it('inclut les attributions anciennes encore actives (sans date de fin)', async () => {
-    await getTerritoriesExportData(2025)
+    await getTerritoriesExportData(db as any, 2025)
 
     const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as Record<string, unknown>
     const attrWhere = (call.include as { attributions: { where: Record<string, unknown> } }).attributions.where

--- a/app/features/territories/server/territories-export-data.server.ts
+++ b/app/features/territories/server/territories-export-data.server.ts
@@ -1,7 +1,7 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } from './theocratic-year.server'
 
-export async function getTerritoriesExportData(theocraticYear?: number) {
+export async function getTerritoriesExportData(db: ScopedDb, theocraticYear?: number) {
   const startDate = getBeginingDateOfTheocraticYear(theocraticYear)
   const endDate = getEndDateOfTheocraticYear(theocraticYear)
 

--- a/app/features/territories/server/territories-never-worked.server.test.ts
+++ b/app/features/territories/server/territories-never-worked.server.test.ts
@@ -22,7 +22,7 @@ describe('getTerritoriesNeverWorked', () => {
       { id: 12, number: 'T-12' },
     ] as never)
 
-    const result = await getTerritoriesNeverWorked({
+    const result = await getTerritoriesNeverWorked(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
@@ -38,7 +38,7 @@ describe('getTerritoriesNeverWorked', () => {
   it('retourne un tableau vide quand tous les territoires ont été travaillés', async () => {
     vi.mocked(db.territory.findMany).mockResolvedValue([])
 
-    const result = await getTerritoriesNeverWorked({
+    const result = await getTerritoriesNeverWorked(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
@@ -49,11 +49,9 @@ describe('getTerritoriesNeverWorked', () => {
   })
 
   it('fonctionne avec un filtre de groupe', async () => {
-    vi.mocked(db.territory.findMany).mockResolvedValue([
-      { id: 3, number: 'T-3' },
-    ] as never)
+    vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3, number: 'T-3' }] as never)
 
-    const result = await getTerritoriesNeverWorked({
+    const result = await getTerritoriesNeverWorked(db, {
       territoryKind: [TerritoryKind.Classical],
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),

--- a/app/features/territories/server/territories-never-worked.server.ts
+++ b/app/features/territories/server/territories-never-worked.server.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '~/database/generated/client'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import type { StatsFilterParams } from './stats-filter-params.type'
 
 export interface NeverWorkedTerritory {
@@ -7,7 +7,10 @@ export interface NeverWorkedTerritory {
   number: string
 }
 
-export async function getTerritoriesNeverWorked(params: StatsFilterParams): Promise<NeverWorkedTerritory[]> {
+export async function getTerritoriesNeverWorked(
+  db: ScopedDb,
+  params: StatsFilterParams,
+): Promise<NeverWorkedTerritory[]> {
   const dateOverlap: Prisma.AttributionWhereInput = {
     startDate: { lte: params.endDate },
     // biome-ignore lint/style/useNamingConvention: Prisma OR operator

--- a/app/features/territories/server/territories.server.test.ts
+++ b/app/features/territories/server/territories.server.test.ts
@@ -18,18 +18,18 @@ describe('findTerritoriesWithDetailsPaginated', () => {
     vi.mocked(db.territory.count).mockResolvedValue(50 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
 
-    const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/?page=1&pageSize=25'))
+    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/?page=1&pageSize=25'))
 
     expect(result.territories).toHaveLength(2)
     expect(result.pagination.total).toBe(50)
     expect(result.pagination.pages).toBe(2)
   })
 
-  it('retourne un résultat vide quand il n\'y a pas de territoires', async () => {
+  it("retourne un résultat vide quand il n'y a pas de territoires", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([] as never)
 
-    const result = await findTerritoriesWithDetailsPaginated({}, new URL('http://localhost/'))
+    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/'))
 
     expect(result.territories).toEqual([])
     expect(result.pagination.total).toBe(0)
@@ -41,7 +41,7 @@ describe('findAvailableTerritoriesPaginated', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3 }] as never)
 
-    const result = await findAvailableTerritoriesPaginated({}, new URL('http://localhost/'))
+    const result = await findAvailableTerritoriesPaginated(db, {}, new URL('http://localhost/'))
 
     expect(result.territories).toHaveLength(1)
     expect(result.pagination.total).toBe(10)

--- a/app/features/territories/server/territories.ts
+++ b/app/features/territories/server/territories.ts
@@ -1,8 +1,12 @@
 import type { Prisma } from '~/database/generated/client'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 
-export async function findTerritoriesWithDetailsPaginated(selectors: Prisma.TerritoryWhereInput, url: URL) {
+export async function findTerritoriesWithDetailsPaginated(
+  db: ScopedDb,
+  selectors: Prisma.TerritoryWhereInput,
+  url: URL,
+) {
   const total = await db.territory.count({ where: selectors })
   const pagination = paginationFromUrl(url, total)
 
@@ -19,7 +23,7 @@ export async function findTerritoriesWithDetailsPaginated(selectors: Prisma.Terr
   return { territories, pagination }
 }
 
-export async function findAvailableTerritoriesPaginated(selectors: Prisma.TerritoryWhereInput, url: URL) {
+export async function findAvailableTerritoriesPaginated(db: ScopedDb, selectors: Prisma.TerritoryWhereInput, url: URL) {
   const total = await db.territory.count({ where: selectors })
   const pagination = paginationFromUrl(url, total)
 

--- a/app/features/territories/server/territory-coverage-total.server.test.ts
+++ b/app/features/territories/server/territory-coverage-total.server.test.ts
@@ -18,21 +18,21 @@ describe('computeTerritoryCoverageTotal', () => {
     // Premier appel: total, deuxième appel: territoires avec attributions
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(4)
 
-    const result = await computeTerritoryCoverageTotal()
+    const result = await computeTerritoryCoverageTotal(db)
     expect(result).toBe(40)
   })
 
-  it('retourne 0 quand il n\'y a aucun territoire', async () => {
+  it("retourne 0 quand il n'y a aucun territoire", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await computeTerritoryCoverageTotal()
+    const result = await computeTerritoryCoverageTotal(db)
     expect(result).toBe(0)
   })
 
   it('retourne 100 quand tous les territoires ont des attributions', async () => {
     vi.mocked(db.territory.count).mockResolvedValueOnce(5).mockResolvedValueOnce(5)
 
-    const result = await computeTerritoryCoverageTotal()
+    const result = await computeTerritoryCoverageTotal(db)
     expect(result).toBe(100)
   })
 
@@ -40,7 +40,7 @@ describe('computeTerritoryCoverageTotal', () => {
     // Chaque territoire ne peut être compté qu'une fois
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(10)
 
-    const result = await computeTerritoryCoverageTotal()
+    const result = await computeTerritoryCoverageTotal(db)
     expect(result).toBe(100)
   })
 
@@ -48,7 +48,7 @@ describe('computeTerritoryCoverageTotal', () => {
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(3)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverageTotal(undefined, undefined, startDate)
+    const result = await computeTerritoryCoverageTotal(db as any, undefined, undefined, startDate)
     expect(result).toBe(30)
   })
 
@@ -57,7 +57,7 @@ describe('computeTerritoryCoverageTotal', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverageTotal(undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverageTotal(db as any, undefined, undefined, startDate, endDate)
     expect(result).toBe(70)
   })
 })

--- a/app/features/territories/server/territory-coverage-total.server.ts
+++ b/app/features/territories/server/territory-coverage-total.server.ts
@@ -1,9 +1,10 @@
 import type { Prisma } from '~/database/generated/client'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverageTotal(
+  db: ScopedDb,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,

--- a/app/features/territories/server/territory-coverage.server.test.ts
+++ b/app/features/territories/server/territory-coverage.server.test.ts
@@ -22,15 +22,15 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10)
     vi.mocked(db.attribution.count).mockResolvedValue(3)
 
-    const result = await computeTerritoryCoverage()
+    const result = await computeTerritoryCoverage(db)
     expect(result).toBe(30)
   })
 
-  it('retourne 0 quand il n\'y a aucun territoire', async () => {
+  it("retourne 0 quand il n'y a aucun territoire", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
     vi.mocked(db.attribution.count).mockResolvedValue(0)
 
-    const result = await computeTerritoryCoverage()
+    const result = await computeTerritoryCoverage(db)
     expect(result).toBe(0)
   })
 
@@ -38,7 +38,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
     vi.mocked(db.attribution.count).mockResolvedValue(5)
 
-    const result = await computeTerritoryCoverage()
+    const result = await computeTerritoryCoverage(db)
     expect(result).toBe(100)
   })
 
@@ -46,7 +46,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
     vi.mocked(db.attribution.count).mockResolvedValue(10)
 
-    const result = await computeTerritoryCoverage()
+    const result = await computeTerritoryCoverage(db)
     expect(result).toBe(200)
   })
 
@@ -55,6 +55,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(5)
 
     const result = await computeTerritoryCoverage(
+      db as any,
       [TerritoryKind.Phone, TerritoryKind.Classical],
       [TerritoryAttributionKind.Phone],
     )
@@ -65,11 +66,11 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10)
     vi.mocked(db.attribution.count).mockResolvedValue(2)
 
-    await computeTerritoryCoverage()
+    await computeTerritoryCoverage(db)
 
     // On vérifie le résultat, pas l'appel au mock
     // Les valeurs par défaut sont testées implicitement via le résultat correct
-    expect(await computeTerritoryCoverage()).toBe(20)
+    expect(await computeTerritoryCoverage(db)).toBe(20)
   })
 
   it('accepte un filtre startDate', async () => {
@@ -77,7 +78,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(4)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverage(undefined, undefined, startDate)
+    const result = await computeTerritoryCoverage(db as any, undefined, undefined, startDate)
     expect(result).toBe(40)
   })
 
@@ -86,7 +87,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(6)
 
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(undefined, undefined, undefined, endDate)
+    const result = await computeTerritoryCoverage(db as any, undefined, undefined, undefined, endDate)
     expect(result).toBe(60)
   })
 
@@ -96,7 +97,7 @@ describe('computeTerritoryCoverage', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverage(db as any, undefined, undefined, startDate, endDate)
     expect(result).toBe(80)
   })
 })

--- a/app/features/territories/server/territory-coverage.server.ts
+++ b/app/features/territories/server/territory-coverage.server.ts
@@ -1,9 +1,10 @@
 import type { Prisma } from '~/database/generated/client'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverage(
+  db: ScopedDb,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,

--- a/app/features/territories/server/theocratic-year.server.test.ts
+++ b/app/features/territories/server/theocratic-year.server.test.ts
@@ -8,7 +8,7 @@ import {
 } from './theocratic-year.server'
 
 describe('getBeginingDateOfTheocraticYear', () => {
-  it('retourne le 1er septembre de l\'année donnée', () => {
+  it("retourne le 1er septembre de l'année donnée", () => {
     const result = getBeginingDateOfTheocraticYear(2025)
     // theocraticYear=2025 → new Date(2025, 10, 1) → novembre 2025 → month > 7 → new Date(2025, 8, 1)
     expect(result.getFullYear()).toBe(2025)
@@ -32,7 +32,7 @@ describe('getBeginingDateOfTheocraticYear', () => {
       vi.useRealTimers()
     })
 
-    it('retourne septembre de l\'année courante si on est après août', () => {
+    it("retourne septembre de l'année courante si on est après août", () => {
       // Octobre 2025
       vi.setSystemTime(new Date(2025, 9, 15))
       const result = getBeginingDateOfTheocraticYear()
@@ -41,7 +41,7 @@ describe('getBeginingDateOfTheocraticYear', () => {
       expect(result.getMonth()).toBe(8)
     })
 
-    it('retourne septembre de l\'année précédente si on est avant septembre', () => {
+    it("retourne septembre de l'année précédente si on est avant septembre", () => {
       // Mars 2025
       vi.setSystemTime(new Date(2025, 2, 15))
       const result = getBeginingDateOfTheocraticYear()
@@ -50,7 +50,7 @@ describe('getBeginingDateOfTheocraticYear', () => {
       expect(result.getMonth()).toBe(8)
     })
 
-    it('retourne septembre de l\'année précédente en août (month 7, pas > 7)', () => {
+    it("retourne septembre de l'année précédente en août (month 7, pas > 7)", () => {
       // Août 2025 → month=7, pas > 7 → année précédente
       vi.setSystemTime(new Date(2025, 7, 15))
       const result = getBeginingDateOfTheocraticYear()
@@ -59,7 +59,7 @@ describe('getBeginingDateOfTheocraticYear', () => {
       expect(result.getMonth()).toBe(8)
     })
 
-    it('retourne septembre de l\'année courante en septembre (month 8, > 7)', () => {
+    it("retourne septembre de l'année courante en septembre (month 8, > 7)", () => {
       // Septembre 2025 → month=8, > 7 → année courante
       vi.setSystemTime(new Date(2025, 8, 15))
       const result = getBeginingDateOfTheocraticYear()
@@ -71,7 +71,7 @@ describe('getBeginingDateOfTheocraticYear', () => {
 })
 
 describe('getEndDateOfTheocraticYear', () => {
-  it('retourne le 31 août de l\'année suivante pour l\'année donnée', () => {
+  it("retourne le 31 août de l'année suivante pour l'année donnée", () => {
     const result = getEndDateOfTheocraticYear(2025)
     // theocraticYear=2025 → new Date(2025, 10, 1) → novembre → month > 7 → new Date(2026, 7, 31)
     expect(result.getFullYear()).toBe(2026)
@@ -88,7 +88,7 @@ describe('getEndDateOfTheocraticYear', () => {
       vi.useRealTimers()
     })
 
-    it('retourne août de l\'année suivante si on est après août', () => {
+    it("retourne août de l'année suivante si on est après août", () => {
       // Octobre 2025
       vi.setSystemTime(new Date(2025, 9, 15))
       const result = getEndDateOfTheocraticYear()
@@ -98,7 +98,7 @@ describe('getEndDateOfTheocraticYear', () => {
       expect(result.getDate()).toBe(31)
     })
 
-    it('retourne août de l\'année courante si on est avant septembre', () => {
+    it("retourne août de l'année courante si on est avant septembre", () => {
       // Mars 2025
       vi.setSystemTime(new Date(2025, 2, 15))
       const result = getEndDateOfTheocraticYear()
@@ -119,12 +119,12 @@ describe('getCurrentTheocraticYear', () => {
     vi.useRealTimers()
   })
 
-  it('retourne l\'année courante après septembre', () => {
+  it("retourne l'année courante après septembre", () => {
     vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
     expect(getCurrentTheocraticYear()).toBe(2025)
   })
 
-  it('retourne l\'année précédente avant septembre', () => {
+  it("retourne l'année précédente avant septembre", () => {
     vi.setSystemTime(new Date(2025, 2, 15)) // mars 2025
     expect(getCurrentTheocraticYear()).toBe(2024)
   })
@@ -139,7 +139,7 @@ describe('getNextTheocraticYear', () => {
     vi.useRealTimers()
   })
 
-  it('retourne l\'année théocratique suivante', () => {
+  it("retourne l'année théocratique suivante", () => {
     vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
     expect(getNextTheocraticYear()).toBe(2026)
   })
@@ -154,7 +154,7 @@ describe('getPreviousTheocraticYear', () => {
     vi.useRealTimers()
   })
 
-  it('retourne l\'année théocratique précédente', () => {
+  it("retourne l'année théocratique précédente", () => {
     vi.setSystemTime(new Date(2025, 9, 15)) // octobre 2025
     expect(getPreviousTheocraticYear()).toBe(2024)
   })

--- a/app/features/territories/server/update-buildings-in-entrance.server.test.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.test.ts
@@ -28,12 +28,12 @@ beforeEach(() => {
 })
 
 describe('updateBuildingsInEntrance', () => {
-  it('ne fait rien si l\'entrée n\'existe pas', async () => {
+  it("ne fait rien si l'entrée n'existe pas", async () => {
     vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue(null as never)
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
-    result = await updateBuildingsInEntrance(999, [1, 2], 1)
+    result = await updateBuildingsInEntrance(db, 999, [1, 2], 1)
     expect(result).toBeUndefined()
     expect(result).not.toBe(sentinel)
   })
@@ -61,7 +61,7 @@ describe('updateBuildingsInEntrance', () => {
     }) as never)
 
     // buildingIds [1, 4] → ajouter 4, déconnecter 2 et 3
-    await updateBuildingsInEntrance(10, [1, 4], 1)
+    await updateBuildingsInEntrance(db, 10, [1, 4], 1)
 
     // La transaction a été exécutée
     expect(vi.mocked(db.$transaction).mock.calls).toHaveLength(1)
@@ -88,7 +88,7 @@ describe('updateBuildingsInEntrance', () => {
       await fn(tx)
     }) as never)
 
-    await updateBuildingsInEntrance(10, [1], 1)
+    await updateBuildingsInEntrance(db, 10, [1], 1)
 
     // deleteMany est toujours appelé pour nettoyer les entrées vides
     expect(vi.mocked(db.buildingEntrance.deleteMany).mock.calls).toHaveLength(1)
@@ -108,6 +108,6 @@ describe('updateBuildingsInEntrance', () => {
     vi.mocked(db.$transaction).mockRejectedValue(new Error('Transaction failed'))
 
     // Ne doit pas lancer d'erreur
-    await expect(updateBuildingsInEntrance(10, [1, 2], 1)).resolves.toBeUndefined()
+    await expect(updateBuildingsInEntrance(db, 10, [1, 2], 1)).resolves.toBeUndefined()
   })
 })

--- a/app/features/territories/server/update-buildings-in-entrance.server.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.ts
@@ -1,7 +1,12 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
-export async function updateBuildingsInEntrance(entranceId: number, buildingIds: number[], congregationId: number) {
+export async function updateBuildingsInEntrance(
+  db: ScopedDb,
+  entranceId: number,
+  buildingIds: number[],
+  congregationId: number,
+) {
   const entrance = await db.buildingEntrance.findUnique({
     where: { id: entranceId },
     include: { buildings: true },

--- a/app/features/territories/ui/MonthlyCoverageChart.tsx
+++ b/app/features/territories/ui/MonthlyCoverageChart.tsx
@@ -39,7 +39,7 @@ export default function MonthlyCoverageChart({ data }: { data: MonthlyCoverage[]
             borderRadius: '0.5rem',
           }}
           labelStyle={{ color: 'var(--color-card-foreground)' }}
-          formatter={(value) => [`${Number(value).toFixed(1)} %`, 'Couverture']}
+          formatter={value => [`${Number(value).toFixed(1)} %`, 'Couverture']}
         />
         <Line
           type="monotone"

--- a/app/features/territories/ui/TerritoriesNeverWorkedList.tsx
+++ b/app/features/territories/ui/TerritoriesNeverWorkedList.tsx
@@ -5,9 +5,7 @@ import { EmptyState } from '~/shared/ui/EmptyState'
 
 const MAX_DISPLAY = 20
 
-export default function TerritoriesNeverWorkedList({
-  territories,
-}: { territories: NeverWorkedTerritory[] }) {
+export default function TerritoriesNeverWorkedList({ territories }: { territories: NeverWorkedTerritory[] }) {
   if (territories.length === 0) {
     return (
       <EmptyState
@@ -32,11 +30,7 @@ export default function TerritoriesNeverWorkedList({
             {t.number}
           </Badge>
         ))}
-        {remaining > 0 && (
-          <Badge variant="secondary">
-            +{remaining} autres
-          </Badge>
-        )}
+        {remaining > 0 && <Badge variant="secondary">+{remaining} autres</Badge>}
       </div>
     </div>
   )

--- a/app/features/territories/ui/YearOverYearTable.tsx
+++ b/app/features/territories/ui/YearOverYearTable.tsx
@@ -29,12 +29,7 @@ function formatDelta(delta: number, unit: string): string {
   return `${sign}${delta.toFixed(1)}${unit}`
 }
 
-export default function YearOverYearTable({
-  current,
-  previous,
-  currentLabel,
-  previousLabel,
-}: YearOverYearTableProps) {
+export default function YearOverYearTable({ current, previous, currentLabel, previousLabel }: YearOverYearTableProps) {
   const rows: MetricRow[] = [
     {
       label: 'Couverture du territoire',
@@ -66,7 +61,7 @@ export default function YearOverYearTable({
       invertedBetter: true,
     },
     {
-      label: 'Nombre d\'attributions',
+      label: "Nombre d'attributions",
       currentValue: String(current.attributionCount),
       previousValue: String(previous.attributionCount),
       delta: current.attributionCount - previous.attributionCount,

--- a/app/shared/libs/auth.server.test.ts
+++ b/app/shared/libs/auth.server.test.ts
@@ -12,12 +12,13 @@ vi.mock('~/features/authorization/server/verify-role.server', () => ({
 
 vi.mock('~/shared/libs/db.server', () => ({
   restoreCongregationContext: vi.fn(),
+  createScopedDb: vi.fn(() => 'mocked-scoped-db'),
 }))
 
 const { authenticateAndAuthorize } = await import('./auth.server')
 const { verifySession } = await import('~/features/authentication/server/session.server')
 const { verifyRole } = await import('~/features/authorization/server/verify-role.server')
-const { restoreCongregationContext } = await import('~/shared/libs/db.server')
+const { restoreCongregationContext, createScopedDb } = await import('~/shared/libs/db.server')
 
 function makeRequest() {
   return new Request('http://localhost/')
@@ -41,6 +42,13 @@ describe('authenticateAndAuthorize', () => {
     expect(result.currentUser).toBe(fakeSessionResult.currentUser)
     expect(result.congregation).toBe(fakeSessionResult.congregation)
     expect(result.session).toBe(fakeSessionResult.session)
+  })
+
+  it('retourne un db scopé via createScopedDb', async () => {
+    const result = await authenticateAndAuthorize(makeRequest())
+
+    expect(createScopedDb).toHaveBeenCalledWith(5)
+    expect(result.db).toBe('mocked-scoped-db')
   })
 
   it('résout les permissions via verifyRole', async () => {

--- a/app/shared/libs/auth.server.ts
+++ b/app/shared/libs/auth.server.ts
@@ -2,22 +2,24 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import type { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 
-import { restoreCongregationContext } from './db.server'
+import { createScopedDb, restoreCongregationContext } from './db.server'
 
 /**
- * Authenticates the user, checks roles, and restores the congregation context.
+ * Authenticates the user, checks roles, and returns a tenant-scoped db client.
  *
- * Combines verifySession + verifyRole + restoreCongregationContext into a single call.
+ * Combines verifySession + verifyRole into a single call. Returns a scoped `db`
+ * client that reads congregationId from a closure (not AsyncLocalStorage), making
+ * it immune to the Prisma 7 pg adapter breaking ALS propagation.
+ *
  * Use this in all authenticated route loaders and actions.
  */
 export async function authenticateAndAuthorize(request: Request, roles: Role[] = []) {
   const { currentUser, congregation, session } = await verifySession(request)
 
-  const resolved = await Promise.all(roles.map(async (role) => [role, await verifyRole(request, role)] as const))
+  const resolved = await Promise.all(roles.map(async role => [role, await verifyRole(request, role)] as const))
   const permissions = new Set(resolved.filter(([, granted]) => granted).map(([role]) => role))
 
-  // Restore ALS context after all auth/role Prisma queries.
-  // The Prisma 7 pg adapter breaks AsyncLocalStorage propagation after async operations.
+  // Also restore ALS for any code that still reads from it (e.g. legacy db import)
   restoreCongregationContext(currentUser.congregationId)
 
   return {
@@ -25,5 +27,6 @@ export async function authenticateAndAuthorize(request: Request, roles: Role[] =
     congregation,
     session,
     can: (role: Role) => permissions.has(role),
+    db: createScopedDb(currentUser.congregationId),
   }
 }

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -48,7 +48,7 @@ const baseCongregation = {
 }
 
 describe('resolveCongregation', () => {
-  it('lance une erreur si la congrégation n\'existe pas', async () => {
+  it("lance une erreur si la congrégation n'existe pas", async () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue(null as never)
 
     await expect(resolveCongregation(999)).rejects.toThrow('Congregation 999 not found')
@@ -71,14 +71,14 @@ describe('resolveCongregation', () => {
     expect(result.displayName).toBe('Nom affiché')
   })
 
-  it('utilise l\'email par défaut quand emailFromAddress est null', async () => {
+  it("utilise l'email par défaut quand emailFromAddress est null", async () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
 
     const result = await resolveCongregation(1)
     expect(result.emailFrom).toBe('Unitae <noreply@unitae.app>')
   })
 
-  it('construit l\'emailFrom à partir de emailFromAddress et emailFromName', async () => {
+  it("construit l'emailFrom à partir de emailFromAddress et emailFromName", async () => {
     vi.mocked(db.congregation.findUnique).mockResolvedValue({
       ...baseCongregation,
       emailFromName: 'Ma Congré',
@@ -151,7 +151,7 @@ describe('resolveCongregation', () => {
 })
 
 describe('getCongregationFromContext', () => {
-  it('retourne null quand le contexte n\'est pas défini', () => {
+  it("retourne null quand le contexte n'est pas défini", () => {
     vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
 
     expect(getCongregationFromContext()).toBeNull()
@@ -177,7 +177,7 @@ describe('getCongregationFromContext', () => {
 })
 
 describe('requireCongregation', () => {
-  it('lance une erreur quand le contexte n\'est pas défini', () => {
+  it("lance une erreur quand le contexte n'est pas défini", () => {
     vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
 
     expect(() => requireCongregation()).toThrow('Congregation context is required but not set')
@@ -235,7 +235,7 @@ describe('resolveCongregationFromRequest', () => {
     )
   })
 
-  it('résout par domaine personnalisé quand il n\'y a pas de slug', async () => {
+  it("résout par domaine personnalisé quand il n'y a pas de slug", async () => {
     process.env.MULTI_TENANT = 'true'
     process.env.APP_BASE_URL = 'unitae.app'
     vi.mocked(db.congregation.findFirst).mockResolvedValue({ id: 2, slug: 'paris' } as never)

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -78,9 +78,7 @@ export function getPlatformName(): string {
  * - Returns `null` in single-tenant mode or if no slug is extracted from the URL (root domain).
  * - Redirects to `/congregation-not-found` if a slug is present but doesn't match any congregation.
  */
-export async function resolveCongregationFromRequest(
-  request: Request,
-): Promise<{ id: number; slug: string } | null> {
+export async function resolveCongregationFromRequest(request: Request): Promise<{ id: number; slug: string } | null> {
   if (process.env.MULTI_TENANT !== 'true') return null
 
   const hostname = new URL(request.url).hostname

--- a/app/shared/libs/db.server.ts
+++ b/app/shared/libs/db.server.ts
@@ -14,24 +14,17 @@ type CongregationContext = {
 }
 export const congregationContext = new AsyncLocalStorage<CongregationContext>()
 
-// Fallback congregation ID when ALS context is lost. Used by the db extension
-// as a safety net when concurrent loaders (run in parallel by React Router)
-// break each other's ALS context via the Prisma 7 pg adapter.
-let fallbackCongregationId: number | null = null
-
 /**
  * Restores the congregation context in AsyncLocalStorage.
  *
  * The Prisma 7 pg adapter breaks AsyncLocalStorage propagation after async queries.
- * Also stores the congregation ID in a module-level fallback for cases where
- * concurrent loaders break each other's ALS context.
+ * Call this after verifySession/verifyRole to ensure subsequent db queries are scoped.
  */
 export function restoreCongregationContext(congregationId: number) {
-  fallbackCongregationId = congregationId
   congregationContext.enterWith({ congregationId })
 }
 
-const SCOPED_MODELS = new Set([
+const SCOPED_MODELS = new Set<string>([
   'User',
   'Territory',
   'Building',
@@ -66,16 +59,7 @@ const db = unscopedDb.$extends({
     async $allOperations({ model, operation, args, query }) {
       if (!model || !SCOPED_MODELS.has(model)) return query(args)
 
-      let ctx = congregationContext.getStore()
-
-      // If ALS context is lost (Prisma 7 pg adapter issue), recover from the fallback.
-      // This handles concurrent loaders run in parallel by React Router where one loader's
-      // Prisma queries break another loader's ALS context.
-      if (!ctx && fallbackCongregationId) {
-        ctx = { congregationId: fallbackCongregationId }
-        congregationContext.enterWith(ctx)
-      }
-
+      const ctx = congregationContext.getStore()
       if (!ctx) {
         throw new Error(
           `Congregation context is required for ${model}.${operation} but was not set. ` +
@@ -115,4 +99,41 @@ const db = unscopedDb.$extends({
   },
 })
 
-export { db, unscopedDb }
+/**
+ * Creates a tenant-scoped Prisma client that reads congregationId from a closure
+ * instead of AsyncLocalStorage. This is immune to the Prisma 7 pg adapter breaking
+ * ALS propagation after async queries.
+ */
+function scopeQueries(congregationId: number) {
+  return unscopedDb.$extends({
+    query: {
+      $allOperations({ model, operation, args, query }) {
+        if (!model || !SCOPED_MODELS.has(model)) return query(args)
+
+        if (READ_OPERATIONS.has(operation)) {
+          args.where = { ...args.where, congregationId }
+        }
+
+        if (WRITE_OPERATIONS.has(operation)) {
+          if (Array.isArray(args.data)) {
+            args.data = args.data.map((d: Record<string, unknown>) => ({ ...d, congregationId }))
+          } else if (args.data) {
+            args.data = { ...args.data, congregationId }
+          }
+        }
+
+        if (UPDATE_OPERATIONS.has(operation)) {
+          args.where = { ...args.where, congregationId }
+          if (operation === 'upsert' && args.create) {
+            args.create = { ...args.create, congregationId }
+          }
+        }
+
+        return query(args)
+      },
+    },
+  })
+}
+
+export type ScopedDb = ReturnType<typeof scopeQueries>
+export { db, scopeQueries as createScopedDb, unscopedDb }

--- a/app/shared/libs/file-storage.server.test.ts
+++ b/app/shared/libs/file-storage.server.test.ts
@@ -89,7 +89,7 @@ describe('local filesystem driver', () => {
       expect(result).toBeNull()
     })
 
-    it('ne lance pas d\'erreur pour un fichier inexistant', async () => {
+    it("ne lance pas d'erreur pour un fichier inexistant", async () => {
       const { deleteFileFromStorage } = await getModule()
 
       await expect(deleteFileFromStorage('inexistant/fichier.pdf')).resolves.toBeUndefined()

--- a/app/shared/libs/host-settings.server.test.ts
+++ b/app/shared/libs/host-settings.server.test.ts
@@ -16,7 +16,7 @@ describe('getHostSettings', () => {
     }
   })
 
-  it('retourne un objet vide quand HOST_SETTINGS n\'est pas défini', async () => {
+  it("retourne un objet vide quand HOST_SETTINGS n'est pas défini", async () => {
     delete process.env.HOST_SETTINGS
     const { getHostSettings } = await import('./host-settings.server')
 

--- a/app/shared/libs/limits.server.test.ts
+++ b/app/shared/libs/limits.server.test.ts
@@ -9,7 +9,9 @@ vi.mock('~/shared/libs/db.server', () => ({
   },
 }))
 
-function makeLimits(overrides: Partial<ConstructorParameters<typeof LimitService>[0]> = {}) {
+const { db } = await import('~/shared/libs/db.server')
+
+function makeLimits(overrides: Partial<ConstructorParameters<typeof LimitService>[1]> = {}) {
   return {
     maxPublishers: null,
     maxTerritories: null,
@@ -23,22 +25,22 @@ function makeLimits(overrides: Partial<ConstructorParameters<typeof LimitService
 describe('LimitService', () => {
   describe('isLimited', () => {
     it('retourne false quand la limite est null (illimité)', () => {
-      const service = new LimitService(makeLimits({ maxPublishers: null }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: null }))
       expect(service.isLimited('publishers')).toBe(false)
     })
 
     it('retourne true quand la limite est définie', () => {
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       expect(service.isLimited('publishers')).toBe(true)
     })
 
     it('retourne true même quand la limite est 0', () => {
-      const service = new LimitService(makeLimits({ maxTerritories: 0 }))
+      const service = new LimitService(db as any, makeLimits({ maxTerritories: 0 }))
       expect(service.isLimited('territories')).toBe(true)
     })
 
     it('vérifie chaque type de limite indépendamment', () => {
-      const service = new LimitService(makeLimits({ maxPublishers: 10, maxTerritories: null }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10, maxTerritories: null }))
       expect(service.isLimited('publishers')).toBe(true)
       expect(service.isLimited('territories')).toBe(false)
     })
@@ -46,46 +48,46 @@ describe('LimitService', () => {
 
   describe('isStorageLimited', () => {
     it('retourne false quand maxStorageBytes est null', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: null }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: null }))
       expect(service.isStorageLimited()).toBe(false)
     })
 
     it('retourne true quand maxStorageBytes est défini', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.isStorageLimited()).toBe(true)
     })
   })
 
   describe('checkStorageLimit', () => {
-    it('retourne false quand le stockage n\'est pas limité', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: null }))
+    it("retourne false quand le stockage n'est pas limité", () => {
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: null }))
       expect(service.checkStorageLimit(500n, 100n)).toBe(false)
     })
 
     it('retourne false quand le total est sous la limite', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 100n)).toBe(false)
     })
 
     it('retourne false quand le total est exactement à la limite', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 500n)).toBe(false)
     })
 
     it('retourne true quand le total dépasse la limite', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 501n)).toBe(true)
     })
   })
 
   describe('errorIfStorageOverLimit', () => {
-    it('ne lance pas d\'erreur quand sous la limite', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+    it("ne lance pas d'erreur quand sous la limite", () => {
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       expect(() => service.errorIfStorageOverLimit(100n, 100n)).not.toThrow()
     })
 
     it('lance LimitError quand la limite est dépassée', () => {
-      const service = new LimitService(makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
       try {
         service.errorIfStorageOverLimit(900n, 200n)
         expect.unreachable('devrait lancer une erreur')
@@ -101,53 +103,48 @@ describe('LimitService', () => {
       vi.resetAllMocks()
     })
 
-    it('retourne false quand la ressource n\'est pas limitée', async () => {
-      const service = new LimitService(makeLimits({ maxPublishers: null }))
+    it("retourne false quand la ressource n'est pas limitée", async () => {
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: null }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(false)
     })
 
     it('retourne false quand le count est sous la limite', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.user.count).mockResolvedValue(5)
 
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(false)
     })
 
     it('retourne true quand le count atteint la limite', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.user.count).mockResolvedValue(10)
 
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(true)
     })
 
     it('retourne true quand le count dépasse la limite', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.user.count).mockResolvedValue(15)
 
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(true)
     })
 
     it('vérifie les territoires via db.territory.count', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.territory.count).mockResolvedValue(3)
 
-      const service = new LimitService(makeLimits({ maxTerritories: 5 }))
+      const service = new LimitService(db as any, makeLimits({ maxTerritories: 5 }))
       const result = await service.checkWouldGoOverLimit('territories')
       expect(result).toBe(false)
     })
 
     it('vérifie les documents via db.boardDocument.count', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.boardDocument.count).mockResolvedValue(20)
 
-      const service = new LimitService(makeLimits({ maxBoardDocuments: 20 }))
+      const service = new LimitService(db as any, makeLimits({ maxBoardDocuments: 20 }))
       const result = await service.checkWouldGoOverLimit('boardDocuments')
       expect(result).toBe(true)
     })
@@ -158,19 +155,17 @@ describe('LimitService', () => {
       vi.resetAllMocks()
     })
 
-    it('ne lance pas d\'erreur quand sous la limite', async () => {
-      const { db } = await import('~/shared/libs/db.server')
+    it("ne lance pas d'erreur quand sous la limite", async () => {
       vi.mocked(db.user.count).mockResolvedValue(5)
 
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       await expect(service.errorIfWouldGoOverLimit('publishers')).resolves.toBeUndefined()
     })
 
     it('lance LimitError quand la limite est atteinte', async () => {
-      const { db } = await import('~/shared/libs/db.server')
       vi.mocked(db.user.count).mockResolvedValue(10)
 
-      const service = new LimitService(makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
       try {
         await service.errorIfWouldGoOverLimit('publishers')
         expect.unreachable('devrait lancer une erreur')

--- a/app/shared/libs/limits.server.ts
+++ b/app/shared/libs/limits.server.ts
@@ -1,4 +1,4 @@
-import { db } from '~/shared/libs/db.server'
+import type { ScopedDb } from '~/shared/libs/db.server'
 
 const LIMIT_COLUMN_MAP = {
   publishers: 'maxPublishers',
@@ -27,7 +27,10 @@ export class LimitError extends Error {
 }
 
 export class LimitService {
-  constructor(private limits: CongregationLimits) {}
+  constructor(
+    private db: ScopedDb,
+    private limits: CongregationLimits,
+  ) {}
 
   isLimited(name: LimitName): boolean {
     const column = LIMIT_COLUMN_MAP[name]
@@ -69,13 +72,13 @@ export class LimitService {
   private countCurrent(name: LimitName): Promise<number> {
     switch (name) {
       case 'publishers':
-        return db.user.count({ where: { isPublisher: true } })
+        return this.db.user.count({ where: { isPublisher: true } })
       case 'territories':
-        return db.territory.count()
+        return this.db.territory.count()
       case 'users':
-        return db.user.count()
+        return this.db.user.count()
       case 'boardDocuments':
-        return db.boardDocument.count()
+        return this.db.boardDocument.count()
     }
   }
 }

--- a/app/shared/libs/pagination.server.test.ts
+++ b/app/shared/libs/pagination.server.test.ts
@@ -15,7 +15,7 @@ describe('paginationFromUrl', () => {
     expect(result.next).toBe(2)
   })
 
-  it('utilise les paramètres page et pageSize de l\'URL', () => {
+  it("utilise les paramètres page et pageSize de l'URL", () => {
     const url = new URL('http://localhost/?page=3&pageSize=10')
     const result = paginationFromUrl(url, 50)
 
@@ -78,7 +78,7 @@ describe('paginationFromUrl', () => {
     expect(result.pages).toBe(4)
   })
 
-  it('calcule l\'offset correctement', () => {
+  it("calcule l'offset correctement", () => {
     const url = new URL('http://localhost/?page=5&pageSize=20')
     const result = paginationFromUrl(url, 200)
 

--- a/app/shared/libs/point-in-polygon.server.test.ts
+++ b/app/shared/libs/point-in-polygon.server.test.ts
@@ -9,11 +9,11 @@ describe('pointInPolygon', () => {
     [10, 0],
   ]
 
-  it('retourne true pour un point à l\'intérieur d\'un carré', () => {
+  it("retourne true pour un point à l'intérieur d'un carré", () => {
     expect(pointInPolygon([5, 5], square)).toBe(true)
   })
 
-  it('retourne false pour un point à l\'extérieur d\'un carré', () => {
+  it("retourne false pour un point à l'extérieur d'un carré", () => {
     expect(pointInPolygon([15, 5], square)).toBe(false)
   })
 

--- a/dependabot.yaml
+++ b/dependabot.yaml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 5
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 8

--- a/docs/architecture-schema.md
+++ b/docs/architecture-schema.md
@@ -4,23 +4,23 @@
 
 ```
                          ┌──────────────────┐
-                         │     Traefik       │
-                         │   your.domain     │
+                         │  Reverse Proxy   │
+                         │   your.domain    │
                          └────────┬─────────┘
                                   │
                     ┌─────────────┼─────────────┐
-                    │             │              │
-              ┌─────▼─────┐ ┌────▼─────┐ ┌─────▼─────┐
+                    │             │             │
+              ┌─────▼──────┐ ┌────▼─────┐ ┌─────▼─────┐
               │  Web Pod   │ │ Web Pod  │ │ Web Pod   │
               │ (port 8080)│ │(port 8080│ │(port 8080)│
               └─────┬──────┘ └────┬─────┘ └─────┬─────┘
-                    │             │              │
-         ┌─────────┴─────────────┴──────────────┘
+                    │             │             │
+         ┌──────────┴─────────────┴─────────────┘
          │
-    ┌────▼────┐    ┌───────┐    ┌──────────┐    ┌──────────────┐
-    │PostgreSQL│    │ Redis │    │  Worker   │    │ File Storage │
-    │  (PVC)  │    │ (PVC) │    │ (BullMQ) │    │ (S3 or local)│
-    └─────────┘    └───────┘    └──────────┘    └──────────────┘
+    ┌────▼─────┐    ┌───────┐    ┌──────────┐    ┌──────────────┐
+    │PostgreSQL│    │ Redis │    │  Worker  │    │ File Storage │
+    │   (PVC)  │    │ (PVC) │    │ (BullMQ) │    │ (S3 or local)│
+    └──────────┘    └───────┘    └──────────┘    └──────────────┘
 ```
 
 ## Multi-Tenancy Model
@@ -29,67 +29,70 @@
 ┌─────────────────────────────────────────────────────────┐
 │                      Platform                           │
 │                                                         │
-│  ┌─────────────────┐  ┌─────────────────┐              │
-│  │  Congregation A  │  │  Congregation B  │  ...        │
-│  │  (slug: lyon)    │  │  (slug: paris)   │              │
-│  │                  │  │                  │              │
-│  │  Users           │  │  Users           │              │
-│  │  Territories     │  │  Territories     │              │
-│  │  Buildings       │  │  Buildings       │              │
-│  │  Attributions    │  │  Attributions    │              │
-│  │  Activities      │  │  Activities      │              │
-│  │  Events          │  │  Events          │              │
-│  │  Settings        │  │  Settings        │              │
-│  │  Board Docs      │  │  Board Docs      │              │
-│  └─────────────────┘  └─────────────────┘              │
+│  ┌─────────────────┐  ┌──────────────────┐              │
+│  │ Congregation A  │  │  Congregation B  │   ...        │
+│  │ (slug: lyon)    │  │  (slug: paris)   │              │
+│  │                 │  │                  │              │
+│  │  Users          │  │  Users           │              │
+│  │  Territories    │  │  Territories     │              │
+│  │  Buildings      │  │  Buildings       │              │
+│  │  Attributions   │  │  Attributions    │              │
+│  │  Activities     │  │  Activities      │              │
+│  │  Events         │  │  Events          │              │
+│  │  Settings       │  │  Settings        │              │
+│  │  Board Docs     │  │  Board Docs      │              │
+│  └─────────────────┘  └──────────────────┘              │
 │                                                         │
-│  Global: UserRole (14 role definitions)                  │
+│  Global: UserRole (14 role definitions)                 │
 │  Global: PasswordResetToken                             │
-│  Platform: User.platformAdmin for /platform-admin/      │
 └─────────────────────────────────────────────────────────┘
 ```
 
 ## Request Flow
 
-1. **Traefik** routes incoming requests to web pods
+1. **Reverse Proxy** (Traefik/Nginx) routes incoming requests to web pods
 2. **React Router** matches route, runs loader/action
-3. **`verifySession()`** authenticates user, resolves congregation, sets `AsyncLocalStorage` context
-4. **Prisma extension** auto-injects `congregationId` into all scoped queries
-5. **Service layer** (`features/*/server/`) handles business logic
+3. **`authenticateAndAuthorize(request, roles)`** authenticates user, checks roles, and returns a **scoped `db` client**
+4. **Scoped `db`** auto-injects `congregationId` into all queries (via closure, not AsyncLocalStorage)
+5. **Service layer** (`features/*/server/`) receives `db` as first parameter and handles business logic
 6. **Route component** renders with loader data
 
-> **Important**: Route actions must call `verifySession(request)` and use the returned `congregation` object directly (e.g., `congregation.id`) instead of reading from `congregationContext.getStore()`. The Prisma 7 pg adapter breaks AsyncLocalStorage propagation across async boundaries — context set by `enterWith()` can be lost after awaited Prisma queries.
+```
+Request → authenticateAndAuthorize(request, [Role.X, Role.Y])
+        → verifySession(request)     // authenticates user
+        → verifyRole(request, role)  // checks permissions (via Promise.all)
+        → createScopedDb(congregationId)  // scoped db from closure
+        → return { currentUser, congregation, session, can, db }
+```
+
+> **Why not AsyncLocalStorage?** The Prisma 7 pg adapter breaks ALS propagation after async queries. Using a closure-based scoped `db` client eliminates this issue entirely.
 
 ## Authentication & Role Flow
 
 ```
-Login → validateCredentials (unscopedDb)
-     → set session cookie (userId)
-     → redirect to /
+Login → validateCredentials(email, password)
+      → set session cookie (userId)
+      → redirect to /
 
-Protected Route → verifySession(request)
-              → fetch user (unscopedDb)
-              → resolveCongregation(user.congregationId)
-              → congregationContext.enterWith({ congregationId, congregation })
-              → return { currentUser, congregation, session }
+Protected Route → authenticateAndAuthorize(request, [roles])
+                → verifySession: fetch user (unscopedDb)
+                → verifyRole: check CongregationUserRole (unscopedDb, via Promise.all)
+                → createScopedDb(congregationId)  // closure-based, no ALS
+                → return { currentUser, congregation, session, can, db }
 
-Role Check → verifyRole(request, roleKey)
-          → query CongregationUserRole (unscopedDb)
-          → check: admin for this congregation? OR has specific role?
-
-Registration → /register (open, no auth)
-            → create Congregation + User + CongregationUserRole(admin) + default EventKind
-            → set session, redirect to /
+Role Check → can(Role.TerritoriesViewer) → boolean
+           (resolved during authenticateAndAuthorize, no extra DB query)
 ```
 
 ## Data Isolation
 
-- **`db`** (scoped): Auto-injects `congregationId` — use for all authenticated routes
-- **`unscopedDb`** (global): No injection — use for login, setup, health, password reset, platform admin
+- **`db` from `authenticateAndAuthorize`** (scoped): Injects `congregationId` via closure — use in all authenticated routes and pass to service functions
+- **`unscopedDb`** (global): No injection — use for login, setup, health, password reset
+- **`createScopedDb(congregationId)`**: Creates a scoped client for non-route contexts (e.g., background workers)
 - **Scoped models** (12): User, Territory, Building, BuildingEntrance, Attribution, PublisherGroup, PublisherActivity, BoardSection, BoardDocument, Event, EventKind, Setting
 - **Global models**: UserRole, Congregation, CongregationUserRole, PasswordResetToken
 
-> **Important**: Never use `congregationId: 0 as number` as a placeholder. Always pass the real `congregation.id` from `verifySession()`. The `0` placeholder relied on the Prisma extension to replace it at runtime, but context loss causes FK violations.
+> **Important**: Service functions must receive `db: ScopedDb` as their first parameter. Never import the global `db` in service functions — it relies on AsyncLocalStorage which is unreliable with the Prisma 7 pg adapter.
 
 ## File Storage
 
@@ -110,7 +113,7 @@ Key structure (same for both drivers):
 │       └── {uuid}.pdf.meta    ← content-type sidecar (local driver only)
 ```
 
-Self-hosted users need no S3 setup — document uploads work out of the box with local storage.
+No S3 setup needed — document uploads work out of the box with local storage.
 
 ## Google Maps Integration
 
@@ -121,7 +124,7 @@ Territory features use Google Maps for interactive maps (building entrance locat
 | `GOOGLE_MAPS_API_KEY` | No | Google Maps API key — enables map rendering on territory pages and static maps in PDF exports |
 | `GOOGLE_MAPS_MAP_ID` | No | Google Maps Map ID — enables custom styled maps (requires `GOOGLE_MAPS_API_KEY`) |
 
-When `GOOGLE_MAPS_API_KEY` is not set, map features are silently disabled: interactive maps are hidden and PDF territory cards skip the map page. Self-hosted users who don't need maps can leave these unset.
+When `GOOGLE_MAPS_API_KEY` is not set, map features are silently disabled: interactive maps are hidden and PDF territory cards skip the map page.
 
 The API key must have the following Google APIs enabled:
 - **Maps JavaScript API** — for interactive maps on territory and split-tool pages
@@ -133,11 +136,11 @@ The API key must have the following Google APIs enabled:
 User triggers sync → syncQueue.add({ userEmail, userName, congregationId })
                    → Redis queue
 
-Worker picks up job → resolveCongregation(congregationId)
-                   → congregationContext.enterWith({ congregationId, congregation })
-                   → importOpenData(congregationId, progressCallback)
-                   → sendMailAfterDataSync(email, name, congregation)
-                   → job complete
+Worker picks up job → createScopedDb(congregationId)
+                    → resolveCongregation(congregationId)
+                    → importOpenData(db, congregationId, progressCallback)
+                    → sendMailAfterDataSync(email, name, congregation)
+                    → job complete
 ```
 
 ## Testing
@@ -159,7 +162,5 @@ Testing conventions:
 
 - **Session**: Cookie-based, `SESSION_SECRET` required, rate-limited login (5/15min)
 - **Passwords**: scrypt hashed, reset via time-limited tokens (24h)
-- **Roles**: Congregation-scoped via CongregationUserRole — admin in A ≠ admin in B
-- **Platform admin**: Separate `platformAdmin` boolean on User
-- **K8s**: PSS restricted, seccomp, NetworkPolicies, non-root pods
+- **Roles**: Congregation-scoped via CongregationUserRole
 - **Files**: Congregation-scoped storage keys, UUID filenames

--- a/docs/background-processing-architecture.md
+++ b/docs/background-processing-architecture.md
@@ -7,21 +7,21 @@ Unitae uses a Redis-based background job processing system built on **BullMQ** f
 ## Architecture
 
 ```
-Web Pod                          Worker Pod
-┌────────────────┐               ┌─────────────────────┐
-│  Route Action   │               │  sync-worker.server  │
-│                 │               │                     │
-│  syncQueue.add({│──── Redis ───▶│  handleSyncWork()   │
-│    userEmail,   │               │    ↓                │
-│    userName,    │               │  congregationContext │
-│    congregationId│              │    .enterWith()     │
-│  })            │               │    ↓                │
-└────────────────┘               │  importOpenData()    │
-                                 │    ↓                │
-                                 │  sendMailAfterSync() │
-                                 │                     │
-                                 │  Health: :9090/health│
-                                 └─────────────────────┘
+Web Pod                             Worker Pod
+┌───────────────────┐               ┌───────────────────────┐
+│  Route Action     │               │  sync-worker.server   │
+│                   │               │                       │
+│  syncQueue.add({  │──── Redis ───▶│  handleSyncWork()     │
+│    userEmail,     │               │    ↓                  │
+│    userName,      │               │  congregationContext  │
+│    congregationId │               │    .enterWith()       │
+│  })               │               │    ↓                  │
+└───────────────────┘               │  importOpenData()     │
+                                    │    ↓                  │
+                                    │  sendMailAfterSync()  │
+                                    │                       │
+                                    │  Health: :9090/health │
+                                    └───────────────────────┘
 ```
 
 ## Components
@@ -49,33 +49,32 @@ interface SyncJobData {
 ### Worker
 - **Location**: `workers/sync-worker.server.ts`
 - Concurrency: 1 (sync operations)
-- HTTP health server on port 9090 (for K8s probes)
+- HTTP health server on port 9090 (for container probes)
 - Graceful SIGTERM/SIGINT shutdown (closes health server + worker)
 - Tracks `isReady` and `closing` state for health checks
 
 ### Job Handler
 - **Location**: `app/features/territories/server/handle-sync-work.server.ts`
-- Sets `congregationContext.enterWith()` before processing — all scoped DB queries are tenant-isolated
+- Creates a scoped `db` client via `createScopedDb(congregationId)` — tenant-isolated queries via closure
 - Resolves congregation info for branded email notifications
 - Progress tracking (0-100%)
 
 ## Tenant Isolation in Workers
 
-Workers don't have HTTP request context, so they set congregation context manually from job data:
+Workers don't have HTTP request context, so they create a scoped `db` client from job data:
 
 ```typescript
 export async function handleSyncWork(job: Job<SyncJobData>) {
   const { congregationId } = job.data
+  const db = createScopedDb(congregationId)
   const congregation = await resolveCongregation(congregationId)
-  congregationContext.enterWith({ congregationId, congregation })
 
-  // Pass congregationId explicitly to avoid AsyncLocalStorage context loss
-  await importOpenData(congregationId, progressCallback)
+  await importOpenData(db, congregationId, progressCallback)
   await sendMailAfterDataSync(email, name, congregation)
 }
 ```
 
-> **Note**: Service functions that create records should accept `congregationId` as an explicit parameter rather than relying on AsyncLocalStorage context, which can be lost across async boundaries with the Prisma 7 pg adapter.
+> **Note**: Workers use `createScopedDb(congregationId)` directly (same factory used by `authenticateAndAuthorize` in routes). The scoped client reads `congregationId` from a closure, not AsyncLocalStorage, so it's immune to the Prisma 7 pg adapter issue.
 
 ## Development
 
@@ -90,22 +89,20 @@ pnpm start:worker
 pnpm start:dev
 ```
 
-## K8s Deployment
+## Deployment
 
-- Worker runs as separate Deployment (`k8s/base/worker.yaml`)
-- Same Docker image, different command: `pnpm start:worker`
-- Health probes on port 9090
-- 60s termination grace period for in-progress jobs
-- Scales independently from web pods
+- Worker runs as a separate process from the web server
+- Same codebase, different command: `pnpm start:worker`
+- Health endpoint on port 9090
+- Scales independently from web processes
 
 ## Adding New Job Types
 
 1. **Queue**: `app/features/{feature}/server/{name}-queue.server.ts`
 2. **Handler**: `app/features/{feature}/server/handle-{name}-work.server.ts`
-   - Set `congregationContext.enterWith()` from job data
-   - Pass `congregationId` explicitly to service functions that create records
+   - Create scoped client: `const db = createScopedDb(congregationId)`
+   - Pass `db` as first argument to all service functions
 3. **Worker**: `workers/{name}-worker.server.ts`
    - Include HTTP health server
    - Handle SIGTERM gracefully
 4. **Package script**: `"start:{name}-worker": "pnpm tsx ./workers/{name}-worker.server.ts"`
-5. **K8s**: Add Deployment to `k8s/base/`

--- a/package.json
+++ b/package.json
@@ -1,85 +1,97 @@
 {
-    "name": "unitae",
-    "private": true,
-    "sideEffects": false,
-    "type": "module",
-    "scripts": {
-        "build": "react-router build",
-        "build:format": "biome check --write",
-        "build:db": "prisma generate",
-        "start": "react-router-serve ./build/server/index.js",
-        "db:migrate": "pnpm prisma migrate deploy",
-        "db:seed": "pnpm prisma db seed",
-        "start:dev": "react-router dev",
-        "start:emails": "email dev",
-        "start:worker": "pnpm tsx ./workers/sync-worker.server.ts",
-        "test:lint": "biome lint",
-        "test:typecheck": "react-router typegen && tsc",
-        "test:unit": "vitest run",
-        "test:unit:watch": "vitest",
-        "test:unit:coverage": "vitest run --coverage"
+  "name": "unitae",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "build": "react-router build",
+    "build:format": "biome check --write",
+    "build:db": "prisma generate",
+    "start": "react-router-serve ./build/server/index.js",
+    "db:migrate": "pnpm prisma migrate deploy",
+    "db:seed": "pnpm prisma db seed",
+    "start:dev": "react-router dev",
+    "start:emails": "email dev",
+    "start:worker": "pnpm tsx ./workers/sync-worker.server.ts",
+    "test:lint": "biome lint",
+    "test:typecheck": "react-router typegen && tsc",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test:unit:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.1024.0",
+    "@mjackson/form-data-parser": "^0.9.1",
+    "@prisma/adapter-pg": "^7.6.0",
+    "@prisma/client": "7.6.0",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@react-email/components": "^1.0.11",
+    "@react-pdf/renderer": "^4.3.3",
+    "@react-router/node": "^7.14.0",
+    "@react-router/serve": "^7.14.0",
+    "@vis.gl/react-google-maps": "^1.8.2",
+    "bullmq": "^5.73.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "csv": "^6.5.1",
+    "dotenv": "^17.4.0",
+    "exceljs": "^4.4.0",
+    "ioredis": "^5.10.1",
+    "isbot": "^5.1.37",
+    "jszip": "^3.10.1",
+    "lucide-react": "^1.7.0",
+    "next-themes": "^0.4.6",
+    "radix-ui": "^1.4.3",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.14.0",
+    "recharts": "^3.8.1",
+    "resend": "^6.10.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.5.0",
+    "tsx": "^4.21.0",
+    "winston": "^3.19.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.10",
+    "@react-router/dev": "^7.14.0",
+    "@tailwindcss/vite": "^4.2.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^4.1.3",
+    "prisma": "^7.6.0",
+    "react-email": "5.2.10",
+    "shadcn": "^4.2.0",
+    "tailwindcss": "^4.2.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.2",
+    "vite": "^8.0.5",
+    "vitest": "^4.1.3"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "^0.25.8"
     },
-    "dependencies": {
-        "@aws-sdk/client-s3": "^3.1024.0",
-        "@mjackson/form-data-parser": "^0.9.1",
-        "@prisma/adapter-pg": "^7.6.0",
-        "@prisma/client": "7.6.0",
-        "@radix-ui/react-slot": "^1.2.4",
-        "@react-email/components": "^1.0.11",
-        "@react-pdf/renderer": "^4.3.3",
-        "@react-router/node": "^7.14.0",
-        "@react-router/serve": "^7.14.0",
-        "@vis.gl/react-google-maps": "^1.8.2",
-        "bullmq": "^5.73.0",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
-        "csv": "^6.5.1",
-        "dotenv": "^17.4.0",
-        "exceljs": "^4.4.0",
-        "ioredis": "^5.10.1",
-        "isbot": "^5.1.37",
-        "jszip": "^3.10.1",
-        "lucide-react": "^1.7.0",
-        "next-themes": "^0.4.6",
-        "radix-ui": "^1.4.3",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "react-router": "^7.14.0",
-        "recharts": "^3.8.1",
-        "resend": "^6.10.0",
-        "sonner": "^2.0.7",
-        "tailwind-merge": "^3.5.0",
-        "tsx": "^4.21.0",
-        "winston": "^3.19.0"
+    "onlyBuiltDependencies": [
+      "@prisma/engines",
+      "better-sqlite3",
+      "prisma"
+    ]
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24.11.0",
+      "onFail": "error"
     },
-    "devDependencies": {
-        "@biomejs/biome": "2.4.10",
-        "@react-router/dev": "^7.14.0",
-        "@tailwindcss/vite": "^4.2.2",
-        "@types/react": "^19.2.14",
-        "@types/react-dom": "^19.2.3",
-        "@vitest/coverage-v8": "^4.1.3",
-        "prisma": "^7.6.0",
-        "react-email": "5.2.10",
-        "shadcn": "^4.2.0",
-        "tailwindcss": "^4.2.2",
-        "ts-node": "^10.9.2",
-        "typescript": "^6.0.2",
-        "vite": "^8.0.5",
-        "vitest": "^4.1.3"
-    },
-    "engines": {
-        "node": ">=22.0.0"
-    },
-    "pnpm": {
-        "overrides": {
-            "esbuild": "^0.25.8"
-        },
-        "onlyBuiltDependencies": [
-            "@prisma/engines",
-            "better-sqlite3",
-            "prisma"
-        ]
-    },
-    "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.26.1",
+      "onFail": "warn"
+    }
+  },
+  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
 }


### PR DESCRIPTION
## Summary

- **Root cause fix**: the Prisma 7 pg adapter breaks `AsyncLocalStorage` after async queries, making ALS-based tenant scoping unreliable. A previous module-level fallback caused cross-tenant data leaks in production due to race conditions between concurrent requests.
- **New approach**: `createScopedDb(congregationId)` creates a Prisma `$extends` client that captures `congregationId` in a **JavaScript closure** — completely immune to ALS propagation issues.
- **`authenticateAndAuthorize()`** now returns a scoped `db` client alongside `currentUser`, `congregation`, `session`, and `can()`.
- **All service functions** (30+ files) receive `db: ScopedDb` as their first parameter instead of importing the global `db`.
- **`LimitService`** constructor takes `db` as first parameter.
- **Background worker** uses `createScopedDb()` directly for tenant isolation.
- **Docs updated** to reflect the new architecture (OSS-focused, no SaaS-specific content).

Supersedes #13 and #12 which used ALS-based workarounds.

## Test plan

- [ ] Log into a congregation → see only that congregation's data
- [ ] Create/edit/delete records → changes apply to the correct congregation
- [ ] Navigate all pages — no "Congregation context is required" errors
- [ ] `pnpm test:unit` — 322 tests pass
- [ ] `pnpm test:typecheck` — clean
- [ ] `pnpm test:lint` — clean