### PR TITLE
feat: add attribution lists to publisher and territory views

### DIFF
--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -2,6 +2,9 @@ import { Archive, Download, IdCard, Pencil } from 'lucide-react'
 import { Form, Link, redirect } from 'react-router'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { Role } from '~/features/authorization/model/roles.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { findActiveAttributionsForPublisher } from '~/features/territories/server/attributions'
+import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
 import { PublisherActivityDownloadLink } from '~/features/publishers/ui/PublisherActivityDownloadLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
@@ -10,6 +13,7 @@ import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import { Separator } from '~/shared/ui/separator'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/shared/ui/table'
 
 import type { Route } from './+types/publisher'
 
@@ -22,10 +26,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     Role.PublisherViewer,
     Role.PublisherManager,
     Role.ActivityManager,
+    Role.TerritoriesViewer,
   ])
   const canViewPublisher = can(Role.PublisherViewer)
   const canManagePublisher = can(Role.PublisherManager)
   const canManageActivity = can(Role.ActivityManager)
+  const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewPublisher) {
     logger.warn(`Tried to load publisher file. User ID: ${currentUser.id}. Does NOT have rights to view publishers.`)
@@ -76,14 +82,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/congregation/publishers')
   }
 
+  const attributions = await findActiveAttributionsForPublisher(db, publisher.id)
+
   const messages = { success: session.get('success'), error: session.get('error') }
 
   return {
     publisher: sanitizeUser(publisher),
+    attributions,
     messages,
     roles: {
       canViewPublisher,
       canManagePublisher,
+      canViewTerritories,
       canManageActivity:
         canManageActivity ||
         publisher.publisherGroup?.responsible.id === currentUser.id ||
@@ -93,7 +103,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export default function PublisherPage({ loaderData }: Route.ComponentProps) {
-  const { publisher, roles } = loaderData
+  const { publisher, attributions, roles } = loaderData
 
   return (
     <div className="flex flex-col gap-6">
@@ -221,6 +231,61 @@ export default function PublisherPage({ loaderData }: Route.ComponentProps) {
           <p className="text-muted-foreground text-xs italic">
             Si certaines de ces informations ne sont pas bonnes, merci de contacter le secrétaire.
           </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Attributions en cours</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {attributions.length > 0 ? (
+            <div className="overflow-hidden rounded-xl border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Nº</TableHead>
+                    <TableHead className="max-sm:hidden">Type</TableHead>
+                    <TableHead className="text-center">Sortie le</TableHead>
+                    <TableHead className="text-center">Statut</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {attributions.map(attribution => (
+                    <TableRow key={attribution.id}>
+                      <TableCell>
+                        {roles.canViewTerritories ? (
+                          <Link
+                            to={`/territories/territory/${attribution.territoryId}/view`}
+                            className="hover:text-primary"
+                          >
+                            {attribution.territory.number}
+                          </Link>
+                        ) : (
+                          attribution.territory.number
+                        )}
+                      </TableCell>
+                      <TableCell className="max-sm:hidden">
+                        {attribution.territory.type === TerritoryKind.Classical && 'Porte à porte'}
+                        {attribution.territory.type === TerritoryKind.Commerces && 'Commerces'}
+                        {attribution.territory.type === TerritoryKind.Phone && 'Téléphones'}
+                        {attribution.territory.type === TerritoryKind.Hotel && 'Hôtels'}
+                        {attribution.territory.type === TerritoryKind.Univ && 'Universités'}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {attribution.startDate.toLocaleDateString('fr-FR')}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <AttributionStatus attribution={attribution} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm italic">Aucune attribution en cours</p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -195,7 +195,7 @@ export default function AttributionListPage({ loaderData }: Route.ComponentProps
                     </TableCell>
                     <TableCell className="text-center">
                       <Link
-                        to={`/territories/territory/${attribution.territoryId}/edit`}
+                        to={`/territories/territory/${attribution.territoryId}/view`}
                         className="hover:text-primary"
                       >
                         {attribution.territory.number}

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -130,7 +130,7 @@ export default function TerritorySelectorPage({ loaderData }: Route.ComponentPro
                 <TableCell>
                   <div className="flex justify-end gap-2">
                     <Button variant="ghost" size="icon" asChild>
-                      <Link to={`/territories/territory/${territory.id}/edit`} title="Voir le détail du territoire">
+                      <Link to={`/territories/territory/${territory.id}/view`} title="Voir le détail du territoire">
                         <ExternalLink className="size-4" />
                       </Link>
                     </Button>

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { computeTerritoryQuantity } from '~/features/territories/server/compute-territory-quantity'
 import {
   aggregateEntrance,
   getAvailableEntrances,
@@ -113,28 +114,7 @@ export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) 
   const [territoryEntrances, setTerritoryEntrances] = useState(savedTerritoryEntrances)
 
   const attribution = [...territory.attributions].shift()
-
-  let quantity = territoryEntrances.length
-  if (territory.type === TerritoryKind.Phone) {
-    quantity = territoryEntrances.reduce((acc, entrance) => {
-      return (
-        acc +
-        entrance.buildings.reduce((acc, building) => {
-          return acc + (building.phones ?? 0)
-        }, 0)
-      )
-    }, 0)
-  }
-  if (territory.type === TerritoryKind.Classical || territory.type === TerritoryKind.Univ) {
-    quantity = territoryEntrances.reduce((acc, entrance) => {
-      return (
-        acc +
-        entrance.buildings.reduce((acc, building) => {
-          return acc + (building.homes ?? building.phones ?? 0)
-        }, 0)
-      )
-    }, 0)
-  }
+  const quantity = computeTerritoryQuantity(territory.type, territoryEntrances)
 
   return (
     <div className="flex flex-col gap-6">

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -150,7 +150,11 @@ export default function TerritoryListPage({ loaderData }: Route.ComponentProps) 
 
                 return (
                   <TableRow key={territory.id}>
-                    <TableCell>{territory.number}</TableCell>
+                    <TableCell>
+                      <Link to={`./territory/${territory.id}/view`} className="hover:text-primary">
+                        {territory.number}
+                      </Link>
+                    </TableCell>
                     <TableCell className="text-center">
                       {territory.type === TerritoryKind.Classical && 'Porte à porte'}
                       {territory.type === TerritoryKind.Commerces && 'Commerces'}

--- a/app/features/territories/routes/territory/view.tsx
+++ b/app/features/territories/routes/territory/view.tsx
@@ -1,0 +1,354 @@
+import { CalendarCheck, Download, ExternalLink, Pencil, X } from 'lucide-react'
+import { Link, redirect } from 'react-router'
+import type { Attribution, User } from '~/database/generated/client'
+import { Role } from '~/features/authorization/model/roles.type'
+import { getBoolSetting } from '~/features/settings/server/settings'
+import type { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { findTerritoryWithHistory } from '~/features/territories/server/attributions'
+import { aggregateEntrance } from '~/features/territories/server/buildings'
+import { computeTerritoryQuantity } from '~/features/territories/server/compute-territory-quantity'
+import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
+import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
+import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
+import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { getOptionalEnv } from '~/shared/libs/env.server'
+import { requireParamId } from '~/shared/libs/params.server'
+import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
+import { Button } from '~/shared/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
+import { EmptyState } from '~/shared/ui/EmptyState'
+import { PageHeader } from '~/shared/ui/PageHeader'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/shared/ui/table'
+
+import type { Route } from './+types/view'
+
+export const meta: Route.MetaFunction = ({ data }) => {
+  return [{ title: `Territoire ${data.territory.number} - Unitae` }]
+}
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const { can, db } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesViewer,
+    Role.TerritoriesManager,
+    Role.PublisherViewer,
+  ])
+  const canViewTerritories = can(Role.TerritoriesViewer)
+  const canManageTerritories = can(Role.TerritoriesManager)
+  const canViewPublisher = can(Role.PublisherViewer)
+
+  if (!canViewTerritories) {
+    throw redirect('/')
+  }
+
+  const territory = await findTerritoryWithHistory(db, requireParamId(params.territoryId, '/territories'))
+
+  if (territory == null) {
+    throw redirect('/territories', { status: 404 })
+  }
+
+  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
+  const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
+  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+
+  return {
+    territory,
+    territoryEntrances: territory.entrances.map(aggregateEntrance),
+    googleMaps: { mapId, apiKey },
+    phoneTypeActive,
+    canManageTerritories,
+    canViewPublisher,
+  }
+}
+
+const territoryTypeLabels: Record<string, string> = {
+  [TerritoryKind.Classical]: 'Porte à Porte',
+  [TerritoryKind.Commerces]: 'Commerces',
+  [TerritoryKind.Hotel]: 'Hôtels',
+  [TerritoryKind.Phone]: 'Téléphone',
+  [TerritoryKind.Univ]: 'Université',
+}
+
+function CurrentAttributionSection({
+  attribution,
+  territoryId,
+  canManageTerritories,
+  canViewPublisher,
+}: {
+  attribution: (Attribution & { publisher: User }) | undefined
+  territoryId: number
+  canManageTerritories: boolean
+  canViewPublisher: boolean
+}) {
+  if (attribution == null) {
+    return (
+      <>
+        <div className="flex items-center justify-center gap-3 rounded-md border p-3">
+          <span className="text-muted-foreground italic">Aucune attribution en cours pour ce territoire</span>
+        </div>
+        {canManageTerritories && (
+          <Button variant="secondary" asChild>
+            <Link to={`/territories/attributions/new?territory=${territoryId}`}>Attribuer ce territoire</Link>
+          </Button>
+        )}
+      </>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border p-3">
+      <div className="flex flex-col">
+        <span className="font-medium">
+          {canViewPublisher ? (
+            <Link to={`/congregation/publishers/${attribution.publisherId}/view`} className="hover:text-primary">
+              {attribution.publisher.firstname} {attribution.publisher.lastname?.toLocaleUpperCase()}
+            </Link>
+          ) : (
+            <>
+              {attribution.publisher.firstname} {attribution.publisher.lastname?.toLocaleUpperCase()}
+            </>
+          )}
+        </span>
+        <span className="text-muted-foreground text-sm">
+          {attribution.startDate.toLocaleDateString('fr-FR')} - {attribution.lateDate.toLocaleDateString('fr-FR')}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <AttributionStatus attribution={attribution} />
+        {canManageTerritories && (
+          <>
+            <Button variant="ghost" size="icon" asChild>
+              <Link to={`/territories/attributions/${attribution.id}/edit`} title="Voir l'attribution en détail">
+                <ExternalLink className="size-4 text-primary" />
+              </Link>
+            </Button>
+            {attribution.endDate == null && (
+              <Button variant="ghost" size="icon" asChild className="text-destructive hover:text-destructive">
+                <Link to={`/territories/attributions/${attribution.id}/delete`} title="Annuler l'attribution">
+                  <X className="size-4" />
+                </Link>
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AttributionHistoryTable({
+  attributions,
+  canViewPublisher,
+}: {
+  attributions: (Attribution & { publisher: User })[]
+  canViewPublisher: boolean
+}) {
+  if (attributions.length < 1) {
+    return (
+      <EmptyState
+        icon={CalendarCheck}
+        title="Aucun historique d'attribution"
+        description="Ce territoire n'a pas encore été attribué par le passé."
+      />
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Proclamateur</TableHead>
+            <TableHead className="text-center">Sortie le</TableHead>
+            <TableHead className="text-center">Rendu le</TableHead>
+            <TableHead className="text-center max-sm:hidden">Durée</TableHead>
+            <TableHead className="text-center max-sm:hidden">Type</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {attributions.map(attribution => {
+            const durationDays = attribution.endDate
+              ? Math.round(
+                  (attribution.endDate.getTime() - attribution.startDate.getTime()) / (1000 * 60 * 60 * 24),
+                )
+              : null
+
+            return (
+              <TableRow key={attribution.id}>
+                <TableCell>
+                  {canViewPublisher ? (
+                    <Link
+                      to={`/congregation/publishers/${attribution.publisherId}/view`}
+                      className="hover:text-primary"
+                    >
+                      {attribution.publisher.lastname?.toLocaleUpperCase()} {attribution.publisher.firstname}
+                    </Link>
+                  ) : (
+                    <>
+                      {attribution.publisher.lastname?.toLocaleUpperCase()} {attribution.publisher.firstname}
+                    </>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">{attribution.startDate.toLocaleDateString('fr-FR')}</TableCell>
+                <TableCell className="text-center">{attribution.endDate?.toLocaleDateString('fr-FR')}</TableCell>
+                <TableCell className="text-center max-sm:hidden">
+                  {durationDays != null ? `${durationDays} jours` : '-'}
+                </TableCell>
+                <TableCell className="text-center max-sm:hidden">
+                  {attribution.type === 'default' && 'Porte à porte'}
+                  {attribution.type === 'campaign' && 'Campagne'}
+                  {attribution.type === 'phones' && 'Téléphones'}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export default function ViewTerritoryPage({ loaderData }: Route.ComponentProps) {
+  const {
+    territory,
+    territoryEntrances,
+    googleMaps: { mapId, apiKey },
+    phoneTypeActive,
+    canManageTerritories,
+    canViewPublisher,
+  } = loaderData
+
+  const currentAttribution = territory.attributions.find(a => a.endDate == null)
+  const pastAttributions = territory.attributions.filter(a => a.endDate != null)
+  const quantity = computeTerritoryQuantity(territory.type, territoryEntrances)
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title={`Territoire ${territory.number}`}
+        subtitle="Fiche du territoire"
+        actions={
+          <>
+            <TerritoryDownloadLink
+              territory={territory}
+              entrances={territory.entrances}
+              googleMapId={mapId}
+              googleMapKey={apiKey}
+              owner={
+                currentAttribution
+                  ? `${currentAttribution.publisher.firstname} ${currentAttribution.publisher.lastname?.toUpperCase().at(0)}.`
+                  : undefined
+              }
+              restitutionDate={currentAttribution?.lateDate}
+              showPhone={!phoneTypeActive}
+              attributionType={currentAttribution?.type as TerritoryAttributionKind}
+            >
+              <Button variant="outline" size="icon" title="Télécharger le territoire en PDF">
+                <Download className="size-4" />
+              </Button>
+            </TerritoryDownloadLink>
+
+            {canManageTerritories && (
+              <Button asChild variant="outline" size="icon" title="Modifier le territoire">
+                <Link to="../edit" relative="path">
+                  <Pencil className="size-4" />
+                </Link>
+              </Button>
+            )}
+          </>
+        }
+      />
+
+      <div className="flex gap-10 max-sm:flex-col">
+        <div className="flex flex-1 flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Informations du territoire</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-3">
+                <p className="text-muted-foreground text-sm">
+                  Numéro : <span className="font-medium text-foreground">{territory.number}</span>
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  Type de territoire :{' '}
+                  <span className="font-medium text-foreground">{territoryTypeLabels[territory.type]}</span>
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {territory.type === TerritoryKind.Phone ? 'Nombre de téléphones' : 'Nombre de foyers'} :{' '}
+                  <span className="font-medium text-foreground">{quantity}</span>
+                </p>
+                {territory.notes.length > 0 && (
+                  <p className="text-muted-foreground text-sm">
+                    Notes : <span className="font-medium text-foreground">{territory.notes}</span>
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {territory.type === TerritoryKind.Commerces && territoryEntrances.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Commerces</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-2">
+                  {territoryEntrances.map(entrance => (
+                    <div key={entrance.id} className="flex items-center justify-between gap-3 rounded-md border p-3">
+                      <div className="flex flex-col">
+                        <span className="font-medium">
+                          {entrance.number} {entrance.street}, {entrance.zip}
+                        </span>
+                        <span className="text-muted-foreground text-sm">
+                          {entrance.buildings[0]?.shopKind || '-'}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {territory.type !== TerritoryKind.Commerces && territoryEntrances.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Allées</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-2">
+                  {territoryEntrances.map(entrance => (
+                    <div key={entrance.id} className="flex items-center justify-between gap-3 rounded-md border p-3">
+                      <div className="flex flex-col">
+                        <span className="font-medium">
+                          {entrance.number} {entrance.street}, {entrance.zip}
+                        </span>
+                        <span className="text-muted-foreground text-sm">
+                          {entrance.homes || entrance.phones} foyers
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <h2 className="font-semibold text-lg">Attribution en cours</h2>
+          <CurrentAttributionSection
+            attribution={currentAttribution}
+            territoryId={territory.id}
+            canManageTerritories={canManageTerritories}
+            canViewPublisher={canViewPublisher}
+          />
+
+          <h2 className="font-semibold text-lg">Historique des attributions</h2>
+          <AttributionHistoryTable attributions={pastAttributions} canViewPublisher={canViewPublisher} />
+        </div>
+
+        <BuildingEntranceMap apiKey={apiKey} entrances={territory.entrances} />
+      </div>
+    </div>
+  )
+}

--- a/app/features/territories/server/attributions.server.test.ts
+++ b/app/features/territories/server/attributions.server.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/libs/db.server', () => ({
+  db: {
+    attribution: { count: vi.fn(), findMany: vi.fn() },
+    territory: { findUnique: vi.fn() },
+  },
+}))
+
+vi.mock('~/shared/libs/pagination.server', () => ({
+  paginationFromUrl: vi.fn(() => ({ offset: 0, size: 25, page: 1, pages: 1, total: 0 })),
+}))
+
+const { findActiveAttributionsForPublisher, findTerritoryWithHistory } = await import('./attributions')
+const { db } = await import('~/shared/libs/db.server')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('findActiveAttributionsForPublisher', () => {
+  it('retourne les attributions actives avec le territoire inclus', async () => {
+    const fakeAttributions = [
+      { id: 1, publisherId: 42, endDate: null, territory: { id: 10, number: 'T-1' } },
+      { id: 2, publisherId: 42, endDate: null, territory: { id: 20, number: 'T-2' } },
+    ]
+    vi.mocked(db.attribution.findMany).mockResolvedValue(fakeAttributions as never)
+
+    const result = await findActiveAttributionsForPublisher(db, 42)
+
+    expect(result).toEqual(fakeAttributions)
+    expect(db.attribution.findMany).toHaveBeenCalledWith({
+      where: { publisherId: 42, endDate: null },
+      include: { territory: true },
+      orderBy: [{ startDate: 'asc' }],
+    })
+  })
+
+  it("retourne un tableau vide quand le proclamateur n'a pas d'attribution", async () => {
+    vi.mocked(db.attribution.findMany).mockResolvedValue([])
+
+    const result = await findActiveAttributionsForPublisher(db, 99)
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('findTerritoryWithHistory', () => {
+  it('retourne le territoire avec ses allées et toutes les attributions', async () => {
+    const fakeTerritory = {
+      id: 10,
+      number: 'T-1',
+      entrances: [{ id: 1, buildings: [{ id: 1, active: true }] }],
+      attributions: [
+        { id: 1, endDate: null, publisher: { id: 42, firstname: 'Jean' } },
+        { id: 2, endDate: new Date('2025-01-15'), publisher: { id: 43, firstname: 'Paul' } },
+      ],
+    }
+    vi.mocked(db.territory.findUnique).mockResolvedValue(fakeTerritory as never)
+
+    const result = await findTerritoryWithHistory(db, 10)
+
+    expect(result).toEqual(fakeTerritory)
+    expect(db.territory.findUnique).toHaveBeenCalledWith({
+      where: { id: 10 },
+      include: {
+        entrances: { include: { buildings: { where: { active: true } } } },
+        attributions: {
+          include: { publisher: true },
+          orderBy: [{ startDate: 'desc' }],
+        },
+      },
+    })
+  })
+
+  it("retourne null quand le territoire n'existe pas", async () => {
+    vi.mocked(db.territory.findUnique).mockResolvedValue(null)
+
+    const result = await findTerritoryWithHistory(db, 999)
+
+    expect(result).toBeNull()
+  })
+})

--- a/app/features/territories/server/attributions.ts
+++ b/app/features/territories/server/attributions.ts
@@ -16,3 +16,24 @@ export async function findActiveAttributionsPaginated(db: ScopedDb, selectors: P
 
   return { attributions, pagination }
 }
+
+export function findActiveAttributionsForPublisher(db: ScopedDb, publisherId: number) {
+  return db.attribution.findMany({
+    where: { publisherId, endDate: null },
+    include: { territory: true },
+    orderBy: [{ startDate: 'asc' }],
+  })
+}
+
+export function findTerritoryWithHistory(db: ScopedDb, territoryId: number) {
+  return db.territory.findUnique({
+    where: { id: territoryId },
+    include: {
+      entrances: { include: { buildings: { where: { active: true } } } },
+      attributions: {
+        include: { publisher: true },
+        orderBy: [{ startDate: 'desc' }],
+      },
+    },
+  })
+}

--- a/app/features/territories/server/compute-territory-quantity.test.ts
+++ b/app/features/territories/server/compute-territory-quantity.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { AggregatedEntrance } from '~/shared/types/entrance'
+import { computeTerritoryQuantity } from './compute-territory-quantity'
+
+function makeEntrance(overrides: { homes?: number; phones?: number } = {}): AggregatedEntrance {
+  return {
+    id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    access: null,
+    // biome-ignore lint/style/useNamingConvention: Prisma property
+    isPMR: null,
+    isOpenEarly: null,
+    isMailboxOpen: null,
+    congregationId: 1,
+    street: 'Rue de la Paix',
+    zip: '75001',
+    number: '1',
+    homes: overrides.homes ?? 0,
+    phones: overrides.phones ?? 0,
+    liberals: 0,
+    importantNotes: [],
+    buildings: [
+      {
+        id: 1,
+        number: '1',
+        street: 'Rue de la Paix',
+        zip: '75001',
+        latitude: null,
+        longitude: null,
+        active: true,
+        inTerritory: true,
+        inOpenData: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        homes: overrides.homes ?? null,
+        phones: overrides.phones ?? null,
+        liberals: null,
+        hasShops: null,
+        shopKind: '',
+        hasCampus: null,
+        hasHotel: null,
+        hasLandromat: null,
+        prospectionDate: null,
+        entranceId: 1,
+        notes: '',
+        importantNotes: '',
+        congregationId: 1,
+      },
+    ],
+  }
+}
+
+describe('computeTerritoryQuantity', () => {
+  it('retourne la somme des foyers pour un territoire classique', () => {
+    const entrances = [makeEntrance({ homes: 10 }), makeEntrance({ homes: 20 })]
+    expect(computeTerritoryQuantity(TerritoryKind.Classical, entrances)).toBe(30)
+  })
+
+  it('retourne la somme des foyers pour un territoire universitaire', () => {
+    const entrances = [makeEntrance({ homes: 5 }), makeEntrance({ homes: 15 })]
+    expect(computeTerritoryQuantity(TerritoryKind.Univ, entrances)).toBe(20)
+  })
+
+  it('utilise les téléphones en fallback quand les foyers sont absents pour un territoire classique', () => {
+    const entrance = makeEntrance({ phones: 8 })
+    entrance.buildings[0].homes = null
+    expect(computeTerritoryQuantity(TerritoryKind.Classical, [entrance])).toBe(8)
+  })
+
+  it('retourne la somme des téléphones pour un territoire téléphone', () => {
+    const entrances = [makeEntrance({ phones: 12 }), makeEntrance({ phones: 8 })]
+    expect(computeTerritoryQuantity(TerritoryKind.Phone, entrances)).toBe(20)
+  })
+
+  it("retourne le nombre d'allées pour un territoire commerces", () => {
+    const entrances = [makeEntrance(), makeEntrance(), makeEntrance()]
+    expect(computeTerritoryQuantity(TerritoryKind.Commerces, entrances)).toBe(3)
+  })
+
+  it("retourne le nombre d'allées pour un territoire hôtels", () => {
+    const entrances = [makeEntrance(), makeEntrance()]
+    expect(computeTerritoryQuantity(TerritoryKind.Hotel, entrances)).toBe(2)
+  })
+
+  it('retourne 0 quand il n\'y a pas d\'allées', () => {
+    expect(computeTerritoryQuantity(TerritoryKind.Classical, [])).toBe(0)
+    expect(computeTerritoryQuantity(TerritoryKind.Phone, [])).toBe(0)
+    expect(computeTerritoryQuantity(TerritoryKind.Commerces, [])).toBe(0)
+  })
+})

--- a/app/features/territories/server/compute-territory-quantity.ts
+++ b/app/features/territories/server/compute-territory-quantity.ts
@@ -1,0 +1,22 @@
+import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import type { AggregatedEntrance } from '~/shared/types/entrance'
+
+// Calcule le nombre de foyers/téléphones d'un territoire selon son type
+export function computeTerritoryQuantity(type: string, entrances: AggregatedEntrance[]): number {
+  if (type === TerritoryKind.Phone) {
+    return entrances.reduce(
+      (acc, entrance) => acc + entrance.buildings.reduce((acc, building) => acc + (building.phones ?? 0), 0),
+      0,
+    )
+  }
+
+  if (type === TerritoryKind.Classical || type === TerritoryKind.Univ) {
+    return entrances.reduce(
+      (acc, entrance) =>
+        acc + entrance.buildings.reduce((acc, building) => acc + (building.homes ?? building.phones ?? 0), 0),
+      0,
+    )
+  }
+
+  return entrances.length
+}

--- a/app/features/territories/territory-stats.routes.ts
+++ b/app/features/territories/territory-stats.routes.ts
@@ -5,6 +5,7 @@ export const territoryStatsRoutes = [
   ...prefix('territory', [
     route('new', 'features/territories/routes/territory/new.tsx'),
     ...prefix(':territoryId', [
+      route('view', 'features/territories/routes/territory/view.tsx'),
       route('edit', 'features/territories/routes/territory/edit.tsx'),
       route('delete', 'features/territories/routes/territory/delete.tsx'),
     ]),

--- a/app/features/territories/ui/TerritoryCardLink.tsx
+++ b/app/features/territories/ui/TerritoryCardLink.tsx
@@ -20,7 +20,7 @@ export function TerritoryCardLink({ territory, entrances }: { territory: Territo
             {entrances.reduce((aggr, curr) => aggr + (curr.homes ?? curr.phones ?? 0), 0)} portes
           </span>
         </div>
-        <Link to={`/territories/territory/${territory.id}/edit`} className="text-primary hover:text-primary/80">
+        <Link to={`/territories/territory/${territory.id}/view`} className="text-primary hover:text-primary/80">
           <ExternalLink className="size-5" />
         </Link>
       </CardContent>

--- a/docs/product/publishers.md
+++ b/docs/product/publishers.md
@@ -29,6 +29,15 @@ The *Profil du proclamateur* field offers:
 - **Pionnier spécial** — Special pioneer
 - **Missionnaire** — Missionary
 
+### Territory Attributions
+
+The publisher profile displays the list of territories currently attributed to the publisher. For each active attribution, the view shows:
+
+- **Nº** — The territory number (links to the territory view if the user has the `TerritoriesViewer` role)
+- **Type** — The territory type (Porte à Porte, Commerces, etc.)
+- **Date de sortie** — When the attribution started
+- **Statut** — Whether the attribution is on time or overdue
+
 ## Publisher Groups
 
 Publishers are organized into **groups** (field service groups). Each group has:

--- a/docs/product/territories.md
+++ b/docs/product/territories.md
@@ -14,6 +14,18 @@ Unitae supports several territory types to match different kinds of field minist
 
 Each territory has a number, a type, and optional notes.
 
+## Territory View
+
+Each territory has a read-only detail page showing:
+
+- **Territory info** — Number, type, household/phone count, and notes
+- **Type-specific details** — Commerce territories list each entrance with its shop type; other types show entrances with household counts
+- **Current attribution** — The publisher currently working the territory, with start date, expected return date, and status
+- **Attribution history** — A table of all past attributions with publisher name, start/end dates, duration, and type
+- **Map** — Building locations displayed on a map (when Google Maps is configured)
+
+The territory view is accessible to users with the `TerritoriesViewer` role. Editing and attribution management actions are only shown to `TerritoriesManager` users.
+
 ## Attributions
 
 An **attribution** is when a territory is assigned to a publisher for a period of time.


### PR DESCRIPTION
## Summary

- Add a new read-only territory view page (`/territories/territory/:id/view`) showing territory info, current attribution, full attribution history table, and map
- Display current territory attributions on the publisher profile page (`/congregation/publishers/:id/view`)
- Extract service functions (`findActiveAttributionsForPublisher`, `findTerritoryWithHistory`, `computeTerritoryQuantity`) with unit tests
- Update existing territory links across the app to point to `/view` instead of `/edit`
- Link territory numbers in the territory list to the new view page
- Update product documentation for publishers and territories

## Test plan

- [ ] Navigate to `/congregation/publishers/:id/view` — verify the "Attributions en cours" card displays active territories
- [ ] Navigate to `/territories/territory/:id/view` — verify territory info (type-specific), current attribution, history table, and map
- [ ] Click territory numbers in the attribution list and territory list — verify they navigate to `/view`
- [ ] Test with a `TerritoriesViewer`-only user — should access view page but not see edit/delete actions
- [ ] Test with a user without `TerritoriesViewer` — territory numbers on publisher view should not be links
- [ ] Run `pnpm test:unit` — all 333 tests pass
- [ ] Run `pnpm test:typecheck` — no type errors
- [ ] Run `pnpm test:lint` — no new warnings