### PR TITLE
fix: replace Prisma extension scoping with RLS and compound unique indexes

### DIFF
--- a/app/database/migrations/20260411000000_add_compound_unique_indexes_and_rls/migration.sql
+++ b/app/database/migrations/20260411000000_add_compound_unique_indexes_and_rls/migration.sql
@@ -1,0 +1,136 @@
+-- Compound unique indexes: enable findUnique({ where: { id_congregationId: { id, congregationId } } })
+CREATE UNIQUE INDEX "Attribution_id_congregationId_key" ON "Attribution"("id", "congregationId");
+CREATE UNIQUE INDEX "BoardDocument_id_congregationId_key" ON "BoardDocument"("id", "congregationId");
+CREATE UNIQUE INDEX "BoardSection_id_congregationId_key" ON "BoardSection"("id", "congregationId");
+CREATE UNIQUE INDEX "Building_id_congregationId_key" ON "Building"("id", "congregationId");
+CREATE UNIQUE INDEX "BuildingEntrance_id_congregationId_key" ON "BuildingEntrance"("id", "congregationId");
+CREATE UNIQUE INDEX "CongregationUserRole_id_congregationId_key" ON "CongregationUserRole"("id", "congregationId");
+CREATE UNIQUE INDEX "Event_id_congregationId_key" ON "Event"("id", "congregationId");
+CREATE UNIQUE INDEX "EventKind_id_congregationId_key" ON "EventKind"("id", "congregationId");
+CREATE UNIQUE INDEX "PublisherActivity_id_congregationId_key" ON "PublisherActivity"("id", "congregationId");
+CREATE UNIQUE INDEX "PublisherGroup_id_congregationId_key" ON "PublisherGroup"("id", "congregationId");
+CREATE UNIQUE INDEX "Setting_id_congregationId_key" ON "Setting"("id", "congregationId");
+CREATE UNIQUE INDEX "Territory_id_congregationId_key" ON "Territory"("id", "congregationId");
+CREATE UNIQUE INDEX "User_id_congregationId_key" ON "User"("id", "congregationId");
+
+-- Row-Level Security: DB-level tenant isolation safety net
+-- Policy: when app.congregation_id is NOT set, all rows are visible (unscoped mode).
+-- When set, only rows matching that congregation are visible.
+-- FORCE ensures RLS applies even to the table owner role.
+
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "User" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "CongregationUserRole" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "CongregationUserRole" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "CongregationUserRole" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "BoardSection" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BoardSection" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "BoardSection" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "BoardDocument" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BoardDocument" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "BoardDocument" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "Territory" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Territory" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Territory" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "Attribution" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Attribution" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Attribution" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "BuildingEntrance" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BuildingEntrance" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "BuildingEntrance" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "Building" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Building" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Building" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "Setting" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Setting" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Setting" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "PublisherGroup" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PublisherGroup" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "PublisherGroup" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "PublisherActivity" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "PublisherActivity" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "PublisherActivity" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "Event" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Event" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "Event" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+
+ALTER TABLE "EventKind" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "EventKind" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "EventKind" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -88,6 +88,8 @@ model User {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model UserRole {
@@ -107,6 +109,7 @@ model CongregationUserRole {
   congregationId Int
 
   @@unique([userId, roleId, congregationId])
+  @@unique([id, congregationId])
 }
 
 model BoardSection {
@@ -117,6 +120,8 @@ model BoardSection {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model BoardDocument {
@@ -135,6 +140,8 @@ model BoardDocument {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model Territory {
@@ -149,6 +156,8 @@ model Territory {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model Attribution {
@@ -168,6 +177,8 @@ model Attribution {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model BuildingEntrance {
@@ -185,6 +196,8 @@ model BuildingEntrance {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model Building {
@@ -219,6 +232,7 @@ model Building {
   congregationId Int
 
   @@unique([number, street, zip, congregationId], name: "address")
+  @@unique([id, congregationId])
 }
 
 model Setting {
@@ -230,6 +244,7 @@ model Setting {
   congregationId Int
 
   @@unique([key, congregationId])
+  @@unique([id, congregationId])
 }
 
 model PublisherGroup {
@@ -244,6 +259,8 @@ model PublisherGroup {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model PublisherActivity {
@@ -263,6 +280,7 @@ model PublisherActivity {
   congregationId Int
 
   @@index([publisherId, month, year], name: "activityId")
+  @@unique([id, congregationId])
 }
 
 model Event {
@@ -281,6 +299,8 @@ model Event {
 
   congregation   Congregation @relation(fields: [congregationId], references: [id])
   congregationId Int
+
+  @@unique([id, congregationId])
 }
 
 model EventKind {
@@ -299,6 +319,7 @@ model EventKind {
   congregationId Int
 
   @@unique([key, congregationId])
+  @@unique([id, congregationId])
 }
 
 model PasswordResetToken {

--- a/app/features/authentication/server/session.server.ts
+++ b/app/features/authentication/server/session.server.ts
@@ -1,7 +1,7 @@
 import { createCookieSessionStorage, redirect } from 'react-router'
 
 import { resolveCongregation, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
-import { congregationContext, unscopedDb } from '~/shared/libs/db.server'
+import { unscopedDb } from '~/shared/libs/db.server'
 
 import { sanitizeUser } from './sanitize-user.server'
 
@@ -72,7 +72,6 @@ export async function verifySession(request: Request) {
     })
   }
 
-  // Set congregation context for all subsequent tenant-scoped queries in this request
   const congregation = await resolveCongregation(user.congregationId)
 
   if (congregation.suspendedAt) {
@@ -87,8 +86,6 @@ export async function verifySession(request: Request) {
   if (congregation.trialEndsAt && congregation.trialEndsAt < new Date()) {
     throw redirect('/trial-expired')
   }
-
-  congregationContext.enterWith({ congregationId: user.congregationId, congregation })
 
   return {
     currentUser: sanitizeUser(user),

--- a/app/features/authorization/server/verify-role.server.test.ts
+++ b/app/features/authorization/server/verify-role.server.test.ts
@@ -9,15 +9,11 @@ vi.mock('~/shared/libs/db.server', () => ({
     user: { findUnique: vi.fn() },
     congregationUserRole: { findFirst: vi.fn() },
   },
-  congregationContext: {
-    getStore: vi.fn(),
-    enterWith: vi.fn(),
-  },
 }))
 
 const { verifyRole } = await import('./verify-role.server')
 const { getSession } = await import('~/features/authentication/server/session.server')
-const { unscopedDb, congregationContext } = await import('~/shared/libs/db.server')
+const { unscopedDb } = await import('~/shared/libs/db.server')
 
 function makeRequest() {
   return new Request('http://localhost/', {
@@ -53,7 +49,7 @@ describe('verifyRole', () => {
 
   it("retourne true quand l'utilisateur a le rôle admin", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → trouvé
     vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce({ id: 1 } as never)
 
@@ -63,7 +59,7 @@ describe('verifyRole', () => {
 
   it("retourne true quand l'utilisateur a le rôle demandé (pas admin)", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 1 } as never)
     // Premier findFirst: admin role → pas trouvé
     vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValueOnce(null as never)
     // Deuxième findFirst: rôle demandé → trouvé
@@ -75,29 +71,15 @@ describe('verifyRole', () => {
 
   it("retourne false quand l'utilisateur n'a ni admin ni le rôle demandé", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
-    vi.mocked(congregationContext.getStore).mockReturnValue({ congregationId: 1 } as never)
+    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 1 } as never)
     vi.mocked(unscopedDb.congregationUserRole.findFirst).mockResolvedValue(null as never)
 
     const result = await verifyRole(makeRequest(), 'board-uploader' as never)
     expect(result).toBe(false)
   })
 
-  it('fait un fallback sur la base quand le contexte AsyncLocalStorage est vide', async () => {
+  it("retourne false quand l'utilisateur n'existe pas", async () => {
     vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
-    vi.mocked(unscopedDb.user.findUnique).mockResolvedValue({ congregationId: 5 } as never)
-    // admin check → non, role check → oui
-    vi.mocked(unscopedDb.congregationUserRole.findFirst)
-      .mockResolvedValueOnce(null as never)
-      .mockResolvedValueOnce({ id: 3 } as never)
-
-    const result = await verifyRole(makeRequest(), 'territories-manager' as never)
-    expect(result).toBe(true)
-  })
-
-  it("retourne false quand le fallback ne trouve pas l'utilisateur", async () => {
-    vi.mocked(getSession).mockResolvedValue(makeSession('42') as never)
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
     vi.mocked(unscopedDb.user.findUnique).mockResolvedValue(null as never)
 
     const result = await verifyRole(makeRequest(), 'territories-manager' as never)

--- a/app/features/authorization/server/verify-role.server.ts
+++ b/app/features/authorization/server/verify-role.server.ts
@@ -1,7 +1,7 @@
 import { getSession } from '~/features/authentication/server/session.server'
 import type { Role } from '~/features/authorization/model/roles.type'
 
-import { congregationContext, unscopedDb } from '~/shared/libs/db.server'
+import { unscopedDb } from '~/shared/libs/db.server'
 
 export async function verifyRole(request: Request, roleKey: Role) {
   const session = await getSession(request.headers.get('Cookie'))
@@ -10,17 +10,12 @@ export async function verifyRole(request: Request, roleKey: Role) {
     return false
   }
 
-  // Prefer AsyncLocalStorage context, but fall back to looking up the user's congregationId
-  // directly. The pg adapter in Prisma 7 can break AsyncLocalStorage context propagation
-  // after awaited queries, causing enterWith() in verifySession to not be visible here.
-  let congregationId = congregationContext.getStore()?.congregationId
-  if (!congregationId) {
-    const user = await unscopedDb.user.findUnique({ where: { id: userId }, select: { congregationId: true } })
-    if (!user) {
-      return false
-    }
-    congregationId = user.congregationId
+  const user = await unscopedDb.user.findUnique({ where: { id: userId }, select: { congregationId: true } })
+  if (!user) {
+    return false
   }
+
+  const { congregationId } = user
 
   const adminRole = await unscopedDb.congregationUserRole.findFirst({
     where: {
@@ -31,8 +26,6 @@ export async function verifyRole(request: Request, roleKey: Role) {
   })
 
   if (adminRole != null) {
-    // Restore ALS context — unscopedDb queries via the pg adapter break it
-    congregationContext.enterWith({ congregationId })
     return true
   }
 
@@ -44,7 +37,5 @@ export async function verifyRole(request: Request, roleKey: Role) {
     },
   })
 
-  // Restaurer le contexte ALS — les requêtes unscopedDb via l'adaptateur pg le cassent
-  congregationContext.enterWith({ congregationId })
   return role != null
 }

--- a/app/features/board/routes/documents/delete.tsx
+++ b/app/features/board/routes/documents/delete.tsx
@@ -3,6 +3,7 @@ import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { deleteFile } from '~/features/board/server/document'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -11,20 +12,27 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
-  const document = await db.boardDocument.findUnique({ where: { id: requireParamId(params.documentId, '/board') } })
+  return withScope(congregationId, async db => {
+    const document = await db.boardDocument.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+    })
 
-  if (document == null) {
-    throw redirect('/board/sections')
-  }
+    if (document == null) {
+      throw redirect('/board/sections')
+    }
 
-  return { document }
+    return { document }
+  })
 }
 
 export default function DeleteDocumentPage({ loaderData }: Route.ComponentProps) {
@@ -47,26 +55,36 @@ export default function DeleteDocumentPage({ loaderData }: Route.ComponentProps)
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { session, currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
     throw redirect('/')
   }
 
-  const document = await db.boardDocument.delete({ where: { id: requireParamId(params.documentId, '/board') } })
+  return withScope(congregationId, async db => {
+    const document = await db.boardDocument.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+    })
 
-  try {
-    await deleteFile(document)
-  } catch (error) {
-    logger.error('Document removal failed. Unexpected error during deletion of the file on the disk', { error })
-  }
+    try {
+      await deleteFile(document)
+    } catch (error) {
+      logger.error('Document removal failed. Unexpected error during deletion of the file on the disk', { error })
+    }
 
-  session.flash('success', `Le document "${document.title}" a été correctement supprimé`)
-  logger.info(`Document removed. User ID: ${currentUser.id}. Document ID: ${document.id}.`, { currentUser, document })
-  return redirect('/board/documents', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    session.flash('success', `Le document "${document.title}" a été correctement supprimé`)
+    logger.info(`Document removed. User ID: ${currentUser.id}. Document ID: ${document.id}.`, {
+      currentUser,
+      document,
+    })
+    return redirect('/board/documents', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/board/routes/documents/edit.tsx
+++ b/app/features/board/routes/documents/edit.tsx
@@ -3,6 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
@@ -25,17 +26,20 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const document = await db.boardDocument.findUnique({
-    where: {
-      id: requireParamId(params.documentId, '/board'),
-    },
+  return withScope(congregationId, async db => {
+    const document = await db.boardDocument.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+    })
+
+    const sections = await db.boardSection.findMany({ where: { congregationId } })
+
+    if (document == null) throw redirect('/board/documents')
+
+    return { document, sections, rights: { canManageBoard, canUploadDocument } }
   })
-
-  const sections = await db.boardSection.findMany()
-
-  if (document == null) throw redirect('/board/documents')
-
-  return { document, sections, rights: { canManageBoard, canUploadDocument } }
 }
 
 export default function EditDocumentPage({ loaderData }: Route.ComponentProps) {
@@ -155,7 +159,7 @@ export default function EditDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   const form = await request.formData()
@@ -174,38 +178,41 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
   }
 
-  const document = await db.boardDocument.update({
-    where: {
-      id: requireParamId(params.documentId, '/board'),
-    },
-    data: {
-      title: String(title),
-      section: {
-        connect: {
-          id: sectionId,
-        },
+  return withScope(congregationId, async db => {
+    const document = await db.boardDocument.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
       },
-      visibleFrom: visibleFrom.getTime() > 0 ? visibleFrom : canManageBoard ? null : undefined,
-      visibleUntil: visibleUntil.getTime() > 0 ? visibleUntil : canManageBoard ? null : undefined,
-      isHighlighted,
-    },
-  })
+      data: {
+        title: String(title),
+        section: {
+          connect: {
+            id: sectionId,
+          },
+        },
+        visibleFrom: visibleFrom.getTime() > 0 ? visibleFrom : canManageBoard ? null : undefined,
+        visibleUntil: visibleUntil.getTime() > 0 ? visibleUntil : canManageBoard ? null : undefined,
+        isHighlighted,
+      },
+    })
 
-  if (document == null) {
-    session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
+    if (document == null) {
+      session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
 
-    return redirect(`/board/document/${params.documentId}/edit`, {
+      return redirect(`/board/document/${params.documentId}/edit`, {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    session.flash('success', `Section "${document.title}" modifiée avec succès.`)
+
+    return redirect(`/board/documents/${document.id}/edit`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  session.flash('success', `Section "${document.title}" modifiée avec succès.`)
-
-  return redirect(`/board/documents/${document.id}/edit`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/documents/list.tsx
+++ b/app/features/board/routes/documents/list.tsx
@@ -3,6 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { DocumentVisibility } from '~/features/board/ui/DocumentVisibility'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardUploader])
   const canUploadDocument = can(Role.BoardUploader)
 
   if (!canUploadDocument) {
@@ -30,24 +31,27 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board documents. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload document.`,
   )
 
-  const documents = await db.boardDocument.findMany({
-    include: {
-      section: true,
-      viewedBy: {
-        select: {
-          id: true,
+  return withScope(congregationId, async db => {
+    const documents = await db.boardDocument.findMany({
+      where: { congregationId },
+      include: {
+        section: true,
+        viewedBy: {
+          select: {
+            id: true,
+          },
         },
       },
-    },
-    orderBy: [
-      {
-        section: { order: 'asc' },
-      },
-      { order: 'asc' },
-    ],
-  })
+      orderBy: [
+        {
+          section: { order: 'asc' },
+        },
+        { order: 'asc' },
+      ],
+    })
 
-  return { documents }
+    return { documents }
+  })
 }
 
 export default function DocumentListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/board/routes/documents/move-down.tsx
+++ b/app/features/board/routes/documents/move-down.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -11,53 +12,61 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const currentDocument = await db.boardDocument.findUnique({
-    where: { id: requireParamId(params.documentId, '/board') },
-  })
+  return withScope(congregationId, async db => {
+    const currentDocument = await db.boardDocument.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+    })
 
-  if (currentDocument == null) {
-    session.flash('error', `Le document n'existe pas`)
+    if (currentDocument == null) {
+      session.flash('error', `Le document n'existe pas`)
+      return redirect('/board/documents', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const documents = await db.boardDocument.findMany({
+      orderBy: { order: 'asc' },
+      where: { sectionId: currentDocument?.sectionId, congregationId },
+    })
+    const orderedDocuments = documents
+      .map((document, index) => ({
+        id: document.id,
+        order: index * 5 + (document.id === currentDocument.id ? 7.5 : 0),
+      }))
+      .sort((a, b) => a.order - b.order)
+      .map((document, index) => ({
+        id: document.id,
+        order: index * 5,
+      }))
+
+    for (const document of orderedDocuments) {
+      await db.boardDocument.update({
+        where: {
+          // biome-ignore lint/style/useNamingConvention: prisma compound key
+          id_congregationId: { id: document.id, congregationId },
+        },
+        data: { order: document.order },
+      })
+    }
+
+    session.flash('success', `La section "${currentDocument.title}" a été correctement déplacée vers le bas`)
+
     return redirect('/board/documents', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const documents = await db.boardDocument.findMany({
-    orderBy: { order: 'asc' },
-    where: { sectionId: currentDocument?.sectionId },
-  })
-  const orderedDocuments = documents
-    .map((document, index) => ({
-      id: document.id,
-      order: index * 5 + (document.id === currentDocument.id ? 7.5 : 0),
-    }))
-    .sort((a, b) => a.order - b.order)
-    .map((document, index) => ({
-      id: document.id,
-      order: index * 5,
-    }))
-
-  for (const document of orderedDocuments) {
-    await db.boardDocument.update({
-      where: { id: document.id },
-      data: { order: document.order },
-    })
-  }
-
-  session.flash('success', `La section "${currentDocument.title}" a été correctement déplacée vers le bas`)
-
-  return redirect('/board/documents', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/documents/move-up.tsx
+++ b/app/features/board/routes/documents/move-up.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -11,53 +12,61 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const currentDocument = await db.boardDocument.findUnique({
-    where: { id: requireParamId(params.documentId, '/board') },
-  })
+  return withScope(congregationId, async db => {
+    const currentDocument = await db.boardDocument.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+    })
 
-  if (currentDocument == null) {
-    session.flash('error', `Le document n'existe pas`)
+    if (currentDocument == null) {
+      session.flash('error', `Le document n'existe pas`)
+      return redirect('/board/documents', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const documents = await db.boardDocument.findMany({
+      orderBy: { order: 'asc' },
+      where: { sectionId: currentDocument?.sectionId, congregationId },
+    })
+    const orderedDocuments = documents
+      .map((document, index) => ({
+        id: document.id,
+        order: index * 5 - (document.id === currentDocument.id ? 7.5 : 0),
+      }))
+      .sort((a, b) => a.order - b.order)
+      .map((document, index) => ({
+        id: document.id,
+        order: index * 5,
+      }))
+
+    for (const document of orderedDocuments) {
+      await db.boardDocument.update({
+        where: {
+          // biome-ignore lint/style/useNamingConvention: prisma compound key
+          id_congregationId: { id: document.id, congregationId },
+        },
+        data: { order: document.order },
+      })
+    }
+
+    session.flash('success', `La section "${currentDocument.title}" a été correctement déplacée vers le haut`)
+
     return redirect('/board/documents', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const documents = await db.boardDocument.findMany({
-    orderBy: { order: 'asc' },
-    where: { sectionId: currentDocument?.sectionId },
-  })
-  const orderedDocuments = documents
-    .map((document, index) => ({
-      id: document.id,
-      order: index * 5 - (document.id === currentDocument.id ? 7.5 : 0),
-    }))
-    .sort((a, b) => a.order - b.order)
-    .map((document, index) => ({
-      id: document.id,
-      order: index * 5,
-    }))
-
-  for (const document of orderedDocuments) {
-    await db.boardDocument.update({
-      where: { id: document.id },
-      data: { order: document.order },
-    })
-  }
-
-  session.flash('success', `La section "${currentDocument.title}" a été correctement déplacée vers le haut`)
-
-  return redirect('/board/documents', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/documents/new.tsx
+++ b/app/features/board/routes/documents/new.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { saveFile } from '~/features/board/server/document'
 import { sendNewDocumentNotificationEmail } from '~/features/board/server/notifications'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
@@ -20,7 +21,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.BoardUploader,
+    Role.BoardValidator,
+  ])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
@@ -35,9 +39,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading creation form for document. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to upload new document to the board.`,
   )
 
-  const sections = await db.boardSection.findMany()
+  return withScope(congregationId, async db => {
+    const sections = await db.boardSection.findMany({ where: { congregationId } })
 
-  return { sections, rights: { canUploadDocument, canManageBoard } }
+    return { sections, rights: { canUploadDocument, canManageBoard } }
+  })
 }
 
 export default function NewDocumentPage({ loaderData }: Route.ComponentProps) {
@@ -131,7 +137,7 @@ export default function NewDocumentPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, session, congregation, congregationId, can } = await authenticateAndAuthorize(request, [
     Role.BoardUploader,
     Role.BoardValidator,
   ])
@@ -190,64 +196,66 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/documents/new')
   }
 
-  const limits = new LimitService(db, congregation)
-  await limits.errorIfWouldGoOverLimit('boardDocuments')
+  return withScope(congregationId, async db => {
+    const limits = new LimitService(db, congregation)
+    await limits.errorIfWouldGoOverLimit('boardDocuments')
 
-  const storageKey = await saveFile(file)
+    const storageKey = await saveFile(congregationId, file)
 
-  const document = await db.boardDocument.create({
-    data: {
-      title: String(name),
-      type: 'pdf',
-      uri: storageKey,
-      sectionId: sectionId,
-      order: 0,
-      congregationId: congregation.id,
-      ...(visibleFrom.getTime() > 0
-        ? {
-            visibleFrom,
-          }
-        : {}),
-      ...(visibleUntil.getTime() > 0
-        ? {
-            visibleUntil,
-          }
-        : {}),
-      ...(form.has('hightlighted')
-        ? {
-            isHighlighted: isHighlighted,
-          }
-        : {}),
-    },
-  })
+    const document = await db.boardDocument.create({
+      data: {
+        title: String(name),
+        type: 'pdf',
+        uri: storageKey,
+        sectionId: sectionId,
+        order: 0,
+        congregationId,
+        ...(visibleFrom.getTime() > 0
+          ? {
+              visibleFrom,
+            }
+          : {}),
+        ...(visibleUntil.getTime() > 0
+          ? {
+              visibleUntil,
+            }
+          : {}),
+        ...(form.has('hightlighted')
+          ? {
+              isHighlighted: isHighlighted,
+            }
+          : {}),
+      },
+    })
 
-  if (document == null) {
-    session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
-    logger.warn(`Document creation failed. User ID: ${currentUser.id}. Database entity not created.`, {
+    if (document == null) {
+      session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
+      logger.warn(`Document creation failed. User ID: ${currentUser.id}. Database entity not created.`, {
+        currentUser,
+        form: { name, sectionId, file },
+        document,
+      })
+      return redirect('/board/documents', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    session.flash('success', `Document "${document.title}" créée avec succès.`)
+    logger.info(`Document created. User ID: ${currentUser.id}. Document ID: ${document.id}. File key: ${storageKey}.`, {
       currentUser,
-      form: { name, sectionId, file },
       document,
     })
-    return redirect('/board/documents', {
+
+    if (!canManageBoard) {
+      sendNewDocumentNotificationEmail(db, congregation, { document })
+    }
+
+    return redirect(`/board/documents/${document.id}/edit`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  session.flash('success', `Document "${document.title}" créée avec succès.`)
-  logger.info(`Document created. User ID: ${currentUser.id}. Document ID: ${document.id}. File key: ${storageKey}.`, {
-    currentUser,
-    document,
-  })
-
-  if (!canManageBoard) {
-    sendNewDocumentNotificationEmail(db, { document })
-  }
-
-  return redirect(`/board/documents/${document.id}/edit`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/documents/pdf-loader.tsx
+++ b/app/features/board/routes/documents/pdf-loader.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'react-router'
 import { getFileStream } from '~/features/board/server/document'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import type { Route } from './+types/pdf-loader'
@@ -10,32 +11,35 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, db } = await authenticateAndAuthorize(request)
+  const { currentUser, congregationId } = await authenticateAndAuthorize(request)
   logger.info(`Loading document ID: ${params.documentId}. User ID: ${currentUser.id}.`, { currentUser })
 
-  const document = await db.boardDocument.update({
-    where: {
-      id: requireParamId(params.documentId, '/board'),
-    },
-    data: {
-      viewedBy: {
-        connect: {
-          id: currentUser.id,
+  return withScope(congregationId, async db => {
+    const document = await db.boardDocument.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.documentId, '/board'), congregationId },
+      },
+      data: {
+        viewedBy: {
+          connect: {
+            id: currentUser.id,
+          },
         },
       },
-    },
+    })
+
+    if (!document) {
+      logger.warn(`Document ID: ${params.documentId} does not exist. User ID: ${currentUser.id}.`, { currentUser })
+      throw redirect('/board')
+    }
+
+    const response = await getFileStream(document)
+    if (!response) {
+      logger.warn(`File not found for document ID: ${document.id}.`, { document })
+      throw redirect('/board')
+    }
+
+    return response
   })
-
-  if (!document) {
-    logger.warn(`Document ID: ${params.documentId} does not exist. User ID: ${currentUser.id}.`, { currentUser })
-    throw redirect('/board')
-  }
-
-  const response = await getFileStream(document)
-  if (!response) {
-    logger.warn(`File not found for document ID: ${document.id}.`, { document })
-    throw redirect('/board')
-  }
-
-  return response
 }

--- a/app/features/board/routes/index.tsx
+++ b/app/features/board/routes/index.tsx
@@ -2,6 +2,7 @@ import { FileText } from 'lucide-react'
 import { Role } from '~/features/authorization/model/roles.type'
 import { DocumentCard } from '~/features/board/ui/DocumentCard'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { EmptyState } from '~/shared/ui/EmptyState'
 
@@ -12,87 +13,94 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardUploader, Role.BoardValidator])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.BoardUploader,
+    Role.BoardValidator,
+  ])
   const canUploadDocument = can(Role.BoardUploader)
   const canManageBoard = can(Role.BoardValidator)
 
-  const folders = await db.boardSection.findMany({
-    where: {},
-    include: {
-      documents: {
-        orderBy: { order: 'asc' },
-        where: {
-          // biome-ignore lint/style/useNamingConvention: prisma ORM
-          OR: [
-            {
-              visibleFrom: {
-                lte: new Date(),
+  return withScope(congregationId, async db => {
+    const folders = await db.boardSection.findMany({
+      where: { congregationId },
+      include: {
+        documents: {
+          orderBy: { order: 'asc' },
+          where: {
+            congregationId,
+            // biome-ignore lint/style/useNamingConvention: prisma ORM
+            OR: [
+              {
+                visibleFrom: {
+                  lte: new Date(),
+                },
+                visibleUntil: {
+                  gte: new Date(),
+                },
               },
-              visibleUntil: {
-                gte: new Date(),
+              {
+                visibleFrom: {
+                  lte: new Date(),
+                },
+                visibleUntil: null,
               },
-            },
-            {
-              visibleFrom: {
-                lte: new Date(),
-              },
-              visibleUntil: null,
-            },
-          ],
-        },
-        include: {
-          viewedBy: {
-            where: {
-              id: {
-                equals: currentUser.id,
+            ],
+          },
+          include: {
+            viewedBy: {
+              where: {
+                id: {
+                  equals: currentUser.id,
+                },
               },
             },
           },
         },
       },
-    },
-    orderBy: {
-      order: 'asc',
-    },
-  })
+      orderBy: {
+        order: 'asc',
+      },
+    })
 
-  const hightlightedDocuments = await db.boardDocument.findMany({
-    where: {
-      isHighlighted: true,
-      // biome-ignore lint/style/useNamingConvention: prisma ORM
-      OR: [
-        {
-          visibleFrom: {
-            lte: new Date(),
+    const hightlightedDocuments = await db.boardDocument.findMany({
+      where: {
+        congregationId,
+        isHighlighted: true,
+        // biome-ignore lint/style/useNamingConvention: prisma ORM
+        OR: [
+          {
+            visibleFrom: {
+              lte: new Date(),
+            },
+            visibleUntil: {
+              gte: new Date(),
+            },
           },
-          visibleUntil: {
-            gte: new Date(),
+          {
+            visibleFrom: {
+              lte: new Date(),
+            },
+            visibleUntil: null,
           },
-        },
-        {
-          visibleFrom: {
-            lte: new Date(),
-          },
-          visibleUntil: null,
-        },
-      ],
-    },
-    orderBy: { order: 'asc' },
-    include: {
-      viewedBy: {
-        where: {
-          id: {
-            equals: currentUser.id,
+        ],
+      },
+      orderBy: { order: 'asc' },
+      include: {
+        viewedBy: {
+          where: {
+            id: {
+              equals: currentUser.id,
+            },
           },
         },
       },
-    },
-  })
+    })
 
-  logger.info(
-    `Loading board. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to update the board.`,
-  )
-  return { folders, canUploadDocument, canManageBoard, hightlightedDocuments }
+    logger.info(
+      `Loading board. User ID: ${currentUser.id}. ${canUploadDocument ? 'Has' : 'Does NOT have'} rights to update the board.`,
+    )
+    return { folders, canUploadDocument, canManageBoard, hightlightedDocuments }
+  })
 }
 
 export default function BoardLayout({ loaderData }: Route.ComponentProps) {

--- a/app/features/board/routes/sections/delete.tsx
+++ b/app/features/board/routes/sections/delete.tsx
@@ -2,6 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -9,20 +10,27 @@ import { Card, CardContent } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const section = await db.boardSection.findUnique({ where: { id: requireParamId(params.sectionId, '/board') } })
+  return withScope(congregationId, async db => {
+    const section = await db.boardSection.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.sectionId, '/board'), congregationId },
+      },
+    })
 
-  if (section == null) {
-    throw redirect('/board/sections')
-  }
+    if (section == null) {
+      throw redirect('/board/sections')
+    }
 
-  return { section }
+    return { section }
+  })
 }
 
 export default function DeleteSectionPage({ loaderData }: Route.ComponentProps) {
@@ -45,20 +53,27 @@ export default function DeleteSectionPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const section = await db.boardSection.delete({ where: { id: requireParamId(params.sectionId, '/board') } })
+  return withScope(congregationId, async db => {
+    const section = await db.boardSection.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.sectionId, '/board'), congregationId },
+      },
+    })
 
-  session.flash('success', `La section "${section.name}" a été correctement supprimée`)
+    session.flash('success', `La section "${section.name}" a été correctement supprimée`)
 
-  return redirect('/board/sections', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    return redirect('/board/sections', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/board/routes/sections/edit.tsx
+++ b/app/features/board/routes/sections/edit.tsx
@@ -3,6 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -17,22 +18,25 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const section = await db.boardSection.findUnique({
-    where: {
-      id: requireParamId(params.sectionId, '/board'),
-    },
+  return withScope(congregationId, async db => {
+    const section = await db.boardSection.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.sectionId, '/board'), congregationId },
+      },
+    })
+
+    if (section == null) throw redirect('/board/sections')
+
+    return { section }
   })
-
-  if (section == null) throw redirect('/board/sections')
-
-  return { section }
 }
 
 export default function EditSectionPage({ loaderData }: Route.ComponentProps) {
@@ -76,7 +80,7 @@ export default function EditSectionPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, db } = await authenticateAndAuthorize(request)
+  const { session, congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -85,30 +89,33 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
-  const section = await db.boardSection.update({
-    where: {
-      id: requireParamId(params.sectionId, '/board'),
-    },
-    data: {
-      name: String(name),
-    },
-  })
+  return withScope(congregationId, async db => {
+    const section = await db.boardSection.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.sectionId, '/board'), congregationId },
+      },
+      data: {
+        name: String(name),
+      },
+    })
 
-  if (section == null) {
-    session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
+    if (section == null) {
+      session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
 
-    return redirect('/board', {
+      return redirect('/board', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    session.flash('success', `Section "${section.name}" modifiée avec succès.`)
+
+    return redirect(`/board/sections/${section.id}/edit`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  session.flash('success', `Section "${section.name}" modifiée avec succès.`)
-
-  return redirect(`/board/sections/${section.id}/edit`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/sections/list.tsx
+++ b/app/features/board/routes/sections/list.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronUp, FolderOpen, Pencil, Trash2 } from 'lucide-react
 import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
@@ -29,16 +30,19 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading board sections. User ID: ${currentUser.id}. ${canManageBoard ? 'Has' : 'Does NOT have'} rights to manage board sections.`,
   )
 
-  const sections = await db.boardSection.findMany({
-    include: {
-      documents: true,
-    },
-    orderBy: {
-      order: 'asc',
-    },
-  })
+  return withScope(congregationId, async db => {
+    const sections = await db.boardSection.findMany({
+      where: { congregationId },
+      include: {
+        documents: true,
+      },
+      orderBy: {
+        order: 'asc',
+      },
+    })
 
-  return { sections }
+    return { sections }
+  })
 }
 
 export default function SectionListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/board/routes/sections/move-down.tsx
+++ b/app/features/board/routes/sections/move-down.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-down'
@@ -11,47 +12,52 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
-  const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
-  if (currentSection == null) {
-    session.flash('error', `La section n'existe pas`)
+  return withScope(congregationId, async db => {
+    const sections = await db.boardSection.findMany({ where: { congregationId }, orderBy: { order: 'asc' } })
+    const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
+    if (currentSection == null) {
+      session.flash('error', `La section n'existe pas`)
+      return redirect('/board/sections', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const orderedSections = sections
+      .map((section, index) => ({
+        id: section.id,
+        order: index * 5 + (section.id === currentSection.id ? 7.5 : 0),
+      }))
+      .sort((a, b) => a.order - b.order)
+      .map((section, index) => ({
+        id: section.id,
+        order: index * 5,
+      }))
+
+    for (const section of orderedSections) {
+      await db.boardSection.update({
+        where: {
+          // biome-ignore lint/style/useNamingConvention: prisma compound key
+          id_congregationId: { id: section.id, congregationId },
+        },
+        data: { order: section.order },
+      })
+    }
+
+    session.flash('success', `La section "${currentSection.name}" a été correctement déplacée vers le bas`)
+
     return redirect('/board/sections', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const orderedSections = sections
-    .map((section, index) => ({
-      id: section.id,
-      order: index * 5 + (section.id === currentSection.id ? 7.5 : 0),
-    }))
-    .sort((a, b) => a.order - b.order)
-    .map((section, index) => ({
-      id: section.id,
-      order: index * 5,
-    }))
-
-  for (const section of orderedSections) {
-    await db.boardSection.update({
-      where: { id: section.id },
-      data: { order: section.order },
-    })
-  }
-
-  session.flash('success', `La section "${currentSection.name}" a été correctement déplacée vers le bas`)
-
-  return redirect('/board/sections', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/sections/move-up.tsx
+++ b/app/features/board/routes/sections/move-up.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/move-up'
@@ -11,47 +12,52 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.BoardValidator])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.BoardValidator])
   const canManageBoard = can(Role.BoardValidator)
 
   if (!canManageBoard) {
     throw redirect('/')
   }
 
-  const sections = await db.boardSection.findMany({ orderBy: { order: 'asc' } })
-  const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
-  if (currentSection == null) {
-    session.flash('error', `La section n'existe pas`)
+  return withScope(congregationId, async db => {
+    const sections = await db.boardSection.findMany({ where: { congregationId }, orderBy: { order: 'asc' } })
+    const currentSection = sections.find(section => section.id === requireParamId(params.sectionId, '/board'))
+    if (currentSection == null) {
+      session.flash('error', `La section n'existe pas`)
+      return redirect('/board/sections', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const orderedSections = sections
+      .map((section, index) => ({
+        id: section.id,
+        order: index * 5 - (section.id === currentSection.id ? 7.5 : 0),
+      }))
+      .sort((a, b) => a.order - b.order)
+      .map((section, index) => ({
+        id: section.id,
+        order: index * 5,
+      }))
+
+    for (const section of orderedSections) {
+      await db.boardSection.update({
+        where: {
+          // biome-ignore lint/style/useNamingConvention: prisma compound key
+          id_congregationId: { id: section.id, congregationId },
+        },
+        data: { order: section.order },
+      })
+    }
+
+    session.flash('success', `La section "${currentSection.name}" a été correctement déplacée vers le haut`)
+
     return redirect('/board/sections', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const orderedSections = sections
-    .map((section, index) => ({
-      id: section.id,
-      order: index * 5 - (section.id === currentSection.id ? 7.5 : 0),
-    }))
-    .sort((a, b) => a.order - b.order)
-    .map((section, index) => ({
-      id: section.id,
-      order: index * 5,
-    }))
-
-  for (const section of orderedSections) {
-    await db.boardSection.update({
-      where: { id: section.id },
-      data: { order: section.order },
-    })
-  }
-
-  session.flash('success', `La section "${currentSection.name}" a été correctement déplacée vers le haut`)
-
-  return redirect('/board/sections', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/routes/sections/new.tsx
+++ b/app/features/board/routes/sections/new.tsx
@@ -2,6 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -48,7 +49,7 @@ export default function NewSectionPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, db } = await authenticateAndAuthorize(request)
+  const { session, congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const name = String(form.get('name'))
 
@@ -57,28 +58,30 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/board/sections/new')
   }
 
-  const section = await db.boardSection.create({
-    data: {
-      name: String(name),
-      congregationId: congregation.id,
-    },
-  })
+  return withScope(congregationId, async db => {
+    const section = await db.boardSection.create({
+      data: {
+        name: String(name),
+        congregationId,
+      },
+    })
 
-  if (section == null) {
-    session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
+    if (section == null) {
+      session.flash('error', `Quelque chose s'est mal passé. Réessayez.`)
 
-    return redirect('/board', {
+      return redirect('/board', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    session.flash('success', `Section "${section.name}" créée avec succès.`)
+
+    return redirect(`/board/sections/${section.id}/edit`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  session.flash('success', `Section "${section.name}" créée avec succès.`)
-
-  return redirect(`/board/sections/${section.id}/edit`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/board/server/document-storage.ts
+++ b/app/features/board/server/document-storage.ts
@@ -1,4 +1,3 @@
-import { congregationContext } from '~/shared/libs/db.server'
 import {
   buildStorageKey,
   deleteFileFromStorage,
@@ -7,18 +6,13 @@ import {
   uploadFile,
 } from '~/shared/libs/file-storage.server'
 
-function getCongregationId(): number {
-  const ctx = congregationContext.getStore()
-  return ctx?.congregationId ?? 0
-}
-
-export function getStorageKey(_filename?: string): string {
+export function getStorageKey(congregationId: number): string {
   const uuid = crypto.randomUUID()
-  return buildStorageKey(getCongregationId(), 'board', `${uuid}.pdf`)
+  return buildStorageKey(congregationId, 'board', `${uuid}.pdf`)
 }
 
-export async function saveBoardFile(file: File): Promise<string> {
-  const key = getStorageKey()
+export async function saveBoardFile(congregationId: number, file: File): Promise<string> {
+  const key = getStorageKey(congregationId)
   const buffer = await file.arrayBuffer()
   await uploadFile(key, buffer, file.type || 'application/pdf')
   return key

--- a/app/features/board/server/document.ts
+++ b/app/features/board/server/document.ts
@@ -2,8 +2,8 @@ import type { BoardDocument } from '~/database/generated/client'
 import logger from '~/shared/libs/logger.server'
 import { deleteBoardFile, getBoardFile, getBoardFileBuffer, saveBoardFile } from './document-storage'
 
-export function saveFile(file: File): Promise<string> {
-  return saveBoardFile(file)
+export function saveFile(congregationId: number, file: File): Promise<string> {
+  return saveBoardFile(congregationId, file)
 }
 
 export async function getFileStream(document: BoardDocument): Promise<Response | null> {

--- a/app/features/board/server/notifications.tsx
+++ b/app/features/board/server/notifications.tsx
@@ -1,12 +1,16 @@
 import NewDocumentInBoard from 'emails/notifications/new-document-in-board'
 import type { BoardDocument } from '~/database/generated/client'
 import { Role } from '~/features/authorization/model/roles.type'
-import { requireCongregation } from '~/shared/libs/congregation.server'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { CongregationInfo } from '~/shared/libs/congregation.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { mailer } from '~/shared/libs/mailer.server'
 
-export async function sendNewDocumentNotificationEmail(db: ScopedDb, { document }: { document: BoardDocument }) {
+export async function sendNewDocumentNotificationEmail(
+  db: TransactionClient,
+  congregation: CongregationInfo,
+  { document }: { document: BoardDocument },
+) {
   const users = await db.user.findMany({
     where: {
       congregationRoles: {
@@ -16,8 +20,6 @@ export async function sendNewDocumentNotificationEmail(db: ScopedDb, { document 
       },
     },
   })
-
-  const congregation = requireCongregation()
 
   for (const user of users) {
     try {

--- a/app/features/events/routes/days-off/delete.tsx
+++ b/app/features/events/routes/days-off/delete.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { EventKind } from '~/features/events/model/event-kind.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -10,19 +11,25 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, db } = await authenticateAndAuthorize(request)
+  const { currentUser, congregationId } = await authenticateAndAuthorize(request)
   logger.info(`Trying to remove days off. User ID: ${currentUser.id}. Event: ${params.eventId}`)
 
-  const event = await db.event.findUnique({
-    where: { id: requireParamId(params.eventId, '/me/days-off'), kind: { key: EventKind.Off } },
-    include: { createdBy: true },
+  return withScope(congregationId, async db => {
+    const event = await db.event.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.eventId, '/me/days-off'), congregationId },
+        kind: { key: EventKind.Off },
+      },
+      include: { createdBy: true },
+    })
+
+    if (event?.createdBy?.id !== currentUser.id) {
+      throw redirect('/me/days-off')
+    }
+
+    return { event }
   })
-
-  if (event?.createdBy?.id !== currentUser.id) {
-    throw redirect('/me/days-off')
-  }
-
-  return { event }
 }
 
 export default function DeleteDayOff({ loaderData }: Route.ComponentProps) {
@@ -53,34 +60,43 @@ export default function DeleteDayOff({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, currentUser, db } = await authenticateAndAuthorize(request)
-  const event = await db.event.findUnique({
-    where: { id: requireParamId(params.eventId, '/me/days-off') },
-    include: { createdBy: true },
-  })
+  const { session, currentUser, congregationId } = await authenticateAndAuthorize(request)
 
-  if (currentUser.id !== event?.createdBy.id) {
-    session.flash('error', "Vous n'êtes pas autorisé à annuler cette absence.")
-    logger.warn(`Tried to remove days off of an other user. User ID: ${currentUser.id}. Event: ${params.eventId}.`)
+  return withScope(congregationId, async db => {
+    const event = await db.event.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.eventId, '/me/days-off'), congregationId },
+      },
+      include: { createdBy: true },
+    })
 
-    return redirect('/me/days-off', {
+    if (currentUser.id !== event?.createdBy.id) {
+      session.flash('error', "Vous n'êtes pas autorisé à annuler cette absence.")
+      logger.warn(`Tried to remove days off of an other user. User ID: ${currentUser.id}. Event: ${params.eventId}.`)
+
+      return redirect('/me/days-off', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const deletedEvent = await db.event.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.eventId, '/me/days-off'), congregationId },
+      },
+    })
+
+    session.flash('success', `L'absence du ${deletedEvent.startDate.toLocaleDateString()} a été supprimée avec succès.`)
+    logger.warn(`Successfully removed days off. User ID: ${currentUser.id}. Event: ${params.eventId}.`)
+
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/me/days-off', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const deletedEvent = await db.event.delete({
-    where: { id: requireParamId(params.eventId, '/me/days-off') },
-  })
-
-  session.flash('success', `L'absence du ${deletedEvent.startDate.toLocaleDateString()} a été supprimée avec succès.`)
-  logger.warn(`Successfully removed days off. User ID: ${currentUser.id}. Event: ${params.eventId}.`)
-
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/me/days-off', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/events/routes/days-off/list.tsx
+++ b/app/features/events/routes/days-off/list.tsx
@@ -2,6 +2,7 @@ import { CalendarOff, X } from 'lucide-react'
 import { Link } from 'react-router'
 import { getNextDaysOffs } from '~/features/events/server/days-off.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -14,16 +15,19 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, db } = await authenticateAndAuthorize(request)
-  const events = await getNextDaysOffs(db, currentUser.id)
+  const { currentUser, session, congregationId } = await authenticateAndAuthorize(request)
 
-  logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)
+  return withScope(congregationId, async db => {
+    const events = await getNextDaysOffs(db, currentUser.id)
 
-  return {
-    user: currentUser,
-    events,
-    error: session.get('error'),
-  }
+    logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)
+
+    return {
+      user: currentUser,
+      events,
+      error: session.get('error'),
+    }
+  })
 }
 
 export default function DaysOffPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/events/routes/days-off/new.tsx
+++ b/app/features/events/routes/days-off/new.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { createDayOff } from '~/features/events/server/days-off.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -74,31 +75,33 @@ export default function DaysOffPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation, db } = await authenticateAndAuthorize(request)
+  const { currentUser, session, congregationId } = await authenticateAndAuthorize(request)
   const formData = await request.formData()
   const startDate = new Date(String(formData.get('start_date')))
   const endDate = new Date(String(formData.get('end_date')))
 
   logger.info(`Creating new days off. User ID: ${currentUser.id}.`)
 
-  const event = await createDayOff(db, currentUser.id, startDate, endDate, congregation.id)
-  if (event == null) {
-    session.flash('error', `Impossible d'ajouter cette absence. Les dates sont invalides.`)
-    logger.info(`Failed to creating new days off. User ID: ${currentUser.id}.`)
+  return withScope(congregationId, async db => {
+    const event = await createDayOff(db, currentUser.id, startDate, endDate, congregationId)
+    if (event == null) {
+      session.flash('error', `Impossible d'ajouter cette absence. Les dates sont invalides.`)
+      logger.info(`Failed to creating new days off. User ID: ${currentUser.id}.`)
+
+      return redirect('/me/days-off', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    session.flash('success', 'Absence ajoutée avec succès.')
+    logger.info(`Successfuly created new days off. User ID: ${currentUser.id}.`)
 
     return redirect('/me/days-off', {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  session.flash('success', 'Absence ajoutée avec succès.')
-  logger.info(`Successfuly created new days off. User ID: ${currentUser.id}.`)
-
-  return redirect('/me/days-off', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/events/routes/programs/days-off.tsx
+++ b/app/features/events/routes/programs/days-off.tsx
@@ -5,6 +5,7 @@ import { EventKind } from '~/features/events/model/event-kind.type'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -19,7 +20,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.ProgramViewer,
+    Role.ProgramManager,
+  ])
   const canViewPrograms = can(Role.ProgramViewer)
   const canManagePrograms = can(Role.ProgramManager)
 
@@ -36,24 +40,27 @@ export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
   selectors.kind = { key: EventKind.Off } // Filter only for days off events
-  logger.info(selectors)
-  const totalAttributions = await db.event.count({ where: selectors })
-  const pagination = paginationFromUrl(url, totalAttributions)
-  const events = await db.event.findMany({
-    skip: pagination.offset,
-    take: pagination.size,
-    where: selectors,
-    include: { createdBy: true },
-    orderBy: [{ startDate: 'asc' }],
-  })
 
-  return {
-    events,
-    pagination,
-    roles: {
-      canManagePrograms,
-    },
-  }
+  return withScope(congregationId, async db => {
+    logger.info(selectors)
+    const totalAttributions = await db.event.count({ where: { ...selectors, congregationId } })
+    const pagination = paginationFromUrl(url, totalAttributions)
+    const events = await db.event.findMany({
+      skip: pagination.offset,
+      take: pagination.size,
+      where: { ...selectors, congregationId },
+      include: { createdBy: true },
+      orderBy: [{ startDate: 'asc' }],
+    })
+
+    return {
+      events,
+      pagination,
+      roles: {
+        canManagePrograms,
+      },
+    }
+  })
 }
 
 export default function DaysOffListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/events/routes/programs/list.tsx
+++ b/app/features/events/routes/programs/list.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { computeFilters } from '~/features/events/server/event-filters.server'
 import EventFilters from '~/features/events/ui/EventFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import { Button } from '~/shared/ui/button'
@@ -18,7 +19,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ProgramViewer, Role.ProgramManager])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.ProgramViewer,
+    Role.ProgramManager,
+  ])
   const canViewPrograms = can(Role.ProgramViewer)
   const canManagePrograms = can(Role.ProgramManager)
 
@@ -35,23 +39,25 @@ export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
 
-  const totalAttributions = await db.event.count({ where: selectors })
-  const pagination = paginationFromUrl(url, totalAttributions)
-  const events = await db.event.findMany({
-    skip: pagination.offset,
-    take: pagination.size,
-    where: selectors,
-    include: { createdBy: true },
-    orderBy: [{ startDate: 'asc' }],
-  })
+  return withScope(congregationId, async db => {
+    const totalAttributions = await db.event.count({ where: { ...selectors, congregationId } })
+    const pagination = paginationFromUrl(url, totalAttributions)
+    const events = await db.event.findMany({
+      skip: pagination.offset,
+      take: pagination.size,
+      where: { ...selectors, congregationId },
+      include: { createdBy: true },
+      orderBy: [{ startDate: 'asc' }],
+    })
 
-  return {
-    events,
-    pagination,
-    roles: {
-      canManagePrograms,
-    },
-  }
+    return {
+      events,
+      pagination,
+      roles: {
+        canManagePrograms,
+      },
+    }
+  })
 }
 
 export default function ProgramListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/events/server/days-off.server.ts
+++ b/app/features/events/server/days-off.server.ts
@@ -1,7 +1,7 @@
 import { EventKind } from '~/features/events/model/event-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export function getNextDaysOffs(db: ScopedDb, userId: number) {
+export function getNextDaysOffs(db: TransactionClient, userId: number) {
   return db.event.findMany({
     where: {
       createdBy: { id: userId },
@@ -18,7 +18,7 @@ export function getNextDaysOffs(db: ScopedDb, userId: number) {
 }
 
 export async function createDayOff(
-  db: ScopedDb,
+  db: TransactionClient,
   userId: number,
   startDate: Date | null | undefined,
   endDate: Date | null | undefined,

--- a/app/features/events/server/event-kind.server.ts
+++ b/app/features/events/server/event-kind.server.ts
@@ -1,5 +1,5 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getAllEventType(db: ScopedDb) {
+export async function getAllEventType(db: TransactionClient) {
   return await db.eventKind.findMany()
 }

--- a/app/features/publishers/routes/activity/delete.tsx
+++ b/app/features/publishers/routes/activity/delete.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -10,27 +11,33 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.ActivityManager])
   const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
-  const activity = await db.publisherActivity.findUnique({
-    where: {
-      id: requireParamId(params.activityId, '/congregation/publishers/activity'),
-    },
-    include: {
-      publisher: true,
-    },
+  return withScope(congregationId, async db => {
+    const activity = await db.publisherActivity.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: {
+          id: requireParamId(params.activityId, '/congregation/publishers/activity'),
+          congregationId,
+        },
+      },
+      include: {
+        publisher: true,
+      },
+    })
+
+    if (activity == null) {
+      throw redirect('/congregation/publishers/activity')
+    }
+
+    return { activity }
   })
-
-  if (activity == null) {
-    throw redirect('/congregation/publishers/activity')
-  }
-
-  return { activity }
 }
 
 export default function DeleteActivity({ loaderData }: Route.ComponentProps) {
@@ -63,27 +70,35 @@ export default function DeleteActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.ActivityManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.ActivityManager])
   const canManageActivity = can(Role.ActivityManager)
 
   if (!canManageActivity) {
     throw redirect('/')
   }
 
-  const activity = await db.publisherActivity.delete({
-    where: { id: requireParamId(params.activityId, '/congregation/publishers/activity') },
-    include: { publisher: true },
-  })
+  return withScope(congregationId, async db => {
+    const activity = await db.publisherActivity.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: {
+          id: requireParamId(params.activityId, '/congregation/publishers/activity'),
+          congregationId,
+        },
+      },
+      include: { publisher: true },
+    })
 
-  session.flash(
-    'success',
-    `Le rapport d'activité de ${activity.publisher.firstname} ${activity.publisher.lastname?.toLocaleUpperCase()} a été correctement supprimé`,
-  )
+    session.flash(
+      'success',
+      `Le rapport d'activité de ${activity.publisher.firstname} ${activity.publisher.lastname?.toLocaleUpperCase()} a été correctement supprimé`,
+    )
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/congregation/publishers/activity', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/congregation/publishers/activity', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/activity/edit.tsx
+++ b/app/features/publishers/routes/activity/edit.tsx
@@ -4,6 +4,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -30,28 +31,30 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const activity = await db.publisherActivity.findFirst({
-    where: {
-      id: requireParamId(params.activityId, '/congregation/publishers/activity'),
-    },
-    include: {
-      publisher: {
-        include: {
-          publisherGroup: true,
-          activities: true,
+  return withScope(congregationId, async db => {
+    const activity = await db.publisherActivity.findFirst({
+      where: {
+        id: requireParamId(params.activityId, '/congregation/publishers/activity'),
+      },
+      include: {
+        publisher: {
+          include: {
+            publisherGroup: true,
+            activities: true,
+          },
         },
       },
-    },
+    })
+
+    if (activity == null) {
+      // If the activity already exists, redirect to the edit page
+      throw redirect('/congregation/publishers/activity')
+    }
+
+    return {
+      activity,
+    }
   })
-
-  if (activity == null) {
-    // If the activity already exists, redirect to the edit page
-    throw redirect('/congregation/publishers/activity')
-  }
-
-  return {
-    activity,
-  }
 }
 
 export default function EditActivity({ loaderData }: Route.ComponentProps) {
@@ -169,7 +172,7 @@ export default function EditActivity({ loaderData }: Route.ComponentProps) {
 
 export async function action({ request, params }: Route.ActionArgs) {
   const previousPage = request.headers.get('referer')
-  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -181,50 +184,61 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   const form = await request.formData()
-  const activity = await db.publisherActivity.findUnique({
-    where: {
-      id: requireParamId(params.activityId, '/congregation/publishers/activity'),
-    },
-    include: {
-      publisher: true,
-    },
-  })
 
-  const preached = form.get('preached') === 'on'
-  const hours = Number(form.get('hours'))
-  const studies = Number(form.get('studies'))
-  const observations = String(form.get('observations'))
+  return withScope(congregationId, async db => {
+    const activity = await db.publisherActivity.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: {
+          id: requireParamId(params.activityId, '/congregation/publishers/activity'),
+          congregationId,
+        },
+      },
+      include: {
+        publisher: true,
+      },
+    })
 
-  if (activity?.publisher == null) {
-    session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
-    throw redirect(previousPage ?? '/congregation/publishers/activity/new', {
+    const preached = form.get('preached') === 'on'
+    const hours = Number(form.get('hours'))
+    const studies = Number(form.get('studies'))
+    const observations = String(form.get('observations'))
+
+    if (activity?.publisher == null) {
+      session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
+      throw redirect(previousPage ?? '/congregation/publishers/activity/new', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const type = form.get('type') as PublisherType
+    await db.publisherActivity.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: {
+          id: requireParamId(params.activityId, '/congregation/publishers/activity'),
+          congregationId,
+        },
+      },
+      data: {
+        type,
+        isPublisher: hours > 0 ? true : preached,
+        hours,
+        studies,
+        notes: observations,
+      },
+    })
+
+    session.flash(
+      'success',
+      `Le rapport d'activité de ${activity.publisher.firstname} ${activity.publisher.lastname} à été enregistré avec succès`,
+    )
+    return redirect(previousPage ?? `/congregation/publishers/activity?month=${activity.month}&year=${activity.year}`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const type = form.get('type') as PublisherType
-  await db.publisherActivity.update({
-    where: {
-      id: requireParamId(params.activityId, '/congregation/publishers/activity'),
-    },
-    data: {
-      type,
-      isPublisher: hours > 0 ? true : preached,
-      hours,
-      studies,
-      notes: observations,
-    },
-  })
-
-  session.flash(
-    'success',
-    `Le rapport d'activité de ${activity.publisher.firstname} ${activity.publisher.lastname} à été enregistré avec succès`,
-  )
-  return redirect(previousPage ?? `/congregation/publishers/activity?month=${activity.month}&year=${activity.year}`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { generatePublishersYearlyActivityXlsx } from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -12,7 +13,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
   const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
@@ -25,13 +26,16 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   logger.info(`Generating publishers' activities XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })
-  const file = await generatePublishersYearlyActivityXlsx(db, Number(params.year))
 
-  return new Response(file, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/vnd.ms-excel',
-      'Content-Disposition': `attachment; filename="Activité-Proclamateurs-${params.year}.xlsx"`,
-    },
+  return withScope(congregationId, async db => {
+    const file = await generatePublishersYearlyActivityXlsx(db, Number(params.year))
+
+    return new Response(file, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.ms-excel',
+        'Content-Disposition': `attachment; filename="Activité-Proclamateurs-${params.year}.xlsx"`,
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -5,6 +5,7 @@ import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { getPublishers } from '~/features/publishers/server/publishers'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -18,7 +19,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -30,44 +31,48 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const groupFilter = canManageMyGroupActivity && !canManagePublisher ? currentUser.publisherGroupId : undefined
-  const publishers = await getPublishers(db, { groupId: groupFilter })
 
   const timeRange = new Date()
   const searchParams = new URL(request.url).searchParams
   const month = Number(searchParams.get('month') ?? timeRange.getMonth())
   const year = Number(searchParams.get('year') ?? timeRange.getFullYear())
 
-  const activity = await db.publisherActivity.findFirst({
-    where: {
-      year,
-      month,
-      publisherId: Number(searchParams.get('publisherId')),
-    },
-  })
+  return withScope(congregationId, async db => {
+    const publishers = await getPublishers(db, { groupId: groupFilter })
 
-  if (activity != null) {
-    // If the activity already exists, redirect to the edit page
-    throw redirect(`/congregation/publishers/activity/${activity.id}/edit`)
-  }
-
-  let publisher = null
-  if (searchParams.has('publisherId')) {
-    publisher = await db.user.findUnique({
+    const activity = await db.publisherActivity.findFirst({
       where: {
-        id: Number(searchParams.get('publisherId')),
-      },
-      include: {
-        activities: true,
+        year,
+        month,
+        publisherId: Number(searchParams.get('publisherId')),
       },
     })
-  }
 
-  return {
-    publishers: publishers.map(sanitizeUser),
-    publisher: publisher != null ? sanitizeUser(publisher) : null,
-    selectedMonth: { month, year },
-    previousPage: request.headers.get('referer'),
-  }
+    if (activity != null) {
+      // If the activity already exists, redirect to the edit page
+      throw redirect(`/congregation/publishers/activity/${activity.id}/edit`)
+    }
+
+    let publisher = null
+    if (searchParams.has('publisherId')) {
+      publisher = await db.user.findUnique({
+        where: {
+          // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+          id_congregationId: { id: Number(searchParams.get('publisherId')), congregationId },
+        },
+        include: {
+          activities: true,
+        },
+      })
+    }
+
+    return {
+      publishers: publishers.map(sanitizeUser),
+      publisher: publisher != null ? sanitizeUser(publisher) : null,
+      selectedMonth: { month, year },
+      previousPage: request.headers.get('referer'),
+    }
+  })
 }
 
 export default function NewActivity({ loaderData }: Route.ComponentProps) {
@@ -273,9 +278,7 @@ export default function NewActivity({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { currentUser, session, congregation, can, db } = await authenticateAndAuthorize(request, [
-    Role.PublisherManager,
-  ])
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   const canManageMyGroupActivity =
@@ -292,51 +295,54 @@ export async function action({ request }: Route.ActionArgs) {
   const month = Number(form.get('month'))
   const year = Number(form.get('year'))
 
-  const publisher = await db.user.findUnique({
-    where: {
-      id: publisherId,
-    },
-  })
+  return withScope(congregationId, async db => {
+    const publisher = await db.user.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: publisherId, congregationId },
+      },
+    })
 
-  const preached = form.get('preached') === 'on'
-  const hours = Number(form.get('hours'))
-  const studies = Number(form.get('studies'))
-  const observations = String(form.get('observations'))
+    const preached = form.get('preached') === 'on'
+    const hours = Number(form.get('hours'))
+    const studies = Number(form.get('studies'))
+    const observations = String(form.get('observations'))
 
-  if (publisher == null) {
-    session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
-    throw redirect(previousPage ?? '/congregation/publishers/activity/new', {
+    if (publisher == null) {
+      session.flash('error', 'Veuillez remplir entièrement le formulaire avant soumission')
+      throw redirect(previousPage ?? '/congregation/publishers/activity/new', {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    const type =
+      publisher.type === PublisherType.Normal
+        ? (form.get('type') as PublisherType)
+        : (publisher.type ?? PublisherType.Normal)
+    const activity = await db.publisherActivity.create({
+      data: {
+        publisherId: publisher.id,
+        month,
+        year,
+        type,
+        isPublisher: hours > 0 ? true : preached,
+        hours,
+        studies,
+        notes: observations,
+        congregationId,
+      },
+    })
+
+    session.flash(
+      'success',
+      `Le rapport d'activité de ${publisher.firstname} ${publisher.lastname} à été enregistré avec succès`,
+    )
+    return redirect(previousPage ?? `/congregation/publishers/activity?month=${activity.month}&year=${activity.year}`, {
       headers: {
         'Set-Cookie': await commitSession(session),
       },
     })
-  }
-
-  const type =
-    publisher.type === PublisherType.Normal
-      ? (form.get('type') as PublisherType)
-      : (publisher.type ?? PublisherType.Normal)
-  const activity = await db.publisherActivity.create({
-    data: {
-      publisherId: publisher.id,
-      month,
-      year,
-      type,
-      isPublisher: hours > 0 ? true : preached,
-      hours,
-      studies,
-      notes: observations,
-      congregationId: congregation.id,
-    },
-  })
-
-  session.flash(
-    'success',
-    `Le rapport d'activité de ${publisher.firstname} ${publisher.lastname} à été enregistré avec succès`,
-  )
-  return redirect(previousPage ?? `/congregation/publishers/activity?month=${activity.month}&year=${activity.year}`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { renderActivityPdfZip } from '~/features/publishers/server/render-activity-pdf-zip.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -12,7 +13,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.ActivityViewer])
   const canViewActivities = can(Role.ActivityViewer)
 
   if (!canViewActivities) {
@@ -26,14 +27,16 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     currentUser,
   })
 
-  const today = new Date()
-  const file = await renderActivityPdfZip(db, Number(params.year))
+  return withScope(congregationId, async db => {
+    const today = new Date()
+    const file = await renderActivityPdfZip(db, Number(params.year))
 
-  return new Response(file, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/zip',
-      'Content-Disposition': `attachment; filename="Activité-${params.year}_${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}.zip"`,
-    },
+    return new Response(file, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="Activité-${params.year}_${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}.zip"`,
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/activity/publisher-list.tsx
+++ b/app/features/publishers/routes/activity/publisher-list.tsx
@@ -6,6 +6,7 @@ import { getPublisherStats } from '~/features/publishers/server/get-publisher-st
 import { getPublisherWithActivities } from '~/features/publishers/server/get-publisher-with-activities.server'
 import PublisherActivityStats from '~/features/publishers/ui/PublisherActivityStats'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +22,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.ActivityViewer, Role.ActivityManager])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.ActivityViewer,
+    Role.ActivityManager,
+  ])
   const canViewActivities = can(Role.ActivityViewer)
   const canManageActivities = can(Role.ActivityManager)
 
@@ -39,35 +43,37 @@ export async function loader({ request }: Route.LoaderArgs) {
   const month = Number(searchParams.get('month') ?? timeRange.getMonth())
   const year = Number(searchParams.get('year') ?? timeRange.getFullYear())
 
-  const users = await getPublisherWithActivities(db, month, year)
+  return withScope(congregationId, async db => {
+    const users = await getPublisherWithActivities(db, month, year)
 
-  return {
-    firstMonth: {
-      month: 8,
-      year: month < 8 ? year - 1 : year,
-    },
-    selectedMonth: {
-      month,
-      year,
-    },
-    stats: await getPublisherStats(db, month, year),
-    publishers: users
-      .map(sanitizeUser)
-      .map(({ activities, ...member }) => ({
-        ...member,
-        lastActivity: activities.length < 1 ? null : activities[0],
-        notRegular:
-          activities[0] != null &&
-          activities[0].isPublisher === false &&
-          (activities[0].hours == null || activities[0].hours === 0),
-      }))
-      .map(publisher => ({
-        ...publisher,
-        newActivityUrl: `./new?publisherId=${publisher.id}&month=${month}&year=${year}`,
-        editActivityUrl: `./${publisher.lastActivity?.id}/edit`,
-      })),
-    canManageActivities,
-  }
+    return {
+      firstMonth: {
+        month: 8,
+        year: month < 8 ? year - 1 : year,
+      },
+      selectedMonth: {
+        month,
+        year,
+      },
+      stats: await getPublisherStats(db, month, year),
+      publishers: users
+        .map(sanitizeUser)
+        .map(({ activities, ...member }) => ({
+          ...member,
+          lastActivity: activities.length < 1 ? null : activities[0],
+          notRegular:
+            activities[0] != null &&
+            activities[0].isPublisher === false &&
+            (activities[0].hours == null || activities[0].hours === 0),
+        }))
+        .map(publisher => ({
+          ...publisher,
+          newActivityUrl: `./new?publisherId=${publisher.id}&month=${month}&year=${year}`,
+          editActivityUrl: `./${publisher.lastActivity?.id}/edit`,
+        })),
+      canManageActivities,
+    }
+  })
 }
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]

--- a/app/features/publishers/routes/publishers/delete-group.tsx
+++ b/app/features/publishers/routes/publishers/delete-group.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter } from '~/shared/ui/card'
@@ -10,24 +11,27 @@ import { Card, CardContent, CardFooter } from '~/shared/ui/card'
 import type { Route } from './+types/delete-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const group = await db.publisherGroup.findUnique({
-    where: {
-      id: requireParamId(params.groupId, '/congregation/publisher-groups'),
-    },
+  return withScope(congregationId, async db => {
+    const group = await db.publisherGroup.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.groupId, '/congregation/publisher-groups'), congregationId },
+      },
+    })
+
+    if (group == null) {
+      throw redirect('/congregation/publisher-groups/')
+    }
+
+    return { group }
   })
-
-  if (group == null) {
-    throw redirect('/congregation/publisher-groups/')
-  }
-
-  return { group }
 }
 
 export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
@@ -54,23 +58,28 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const group = await db.publisherGroup.delete({
-    where: { id: requireParamId(params.groupId, '/congregation/publisher-groups') },
-  })
+  return withScope(congregationId, async db => {
+    const group = await db.publisherGroup.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.groupId, '/congregation/publisher-groups'), congregationId },
+      },
+    })
 
-  session.flash('success', `Le groupe ${group.name} a été correctement supprimé`)
+    session.flash('success', `Le groupe ${group.name} a été correctement supprimé`)
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/congregation/publisher-groups/', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/congregation/publisher-groups/', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -3,6 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -13,31 +14,34 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/edit-group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const brothers = await db.user.findMany({
-    where: {
-      // biome-ignore lint/style/useNamingConvention: Prisma OR operator
-      OR: [{ isHelder: true }, { isServant: true }],
-    },
+  return withScope(congregationId, async db => {
+    const brothers = await db.user.findMany({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+        OR: [{ isHelder: true }, { isServant: true }],
+      },
+    })
+
+    const group = await db.publisherGroup.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.groupId, '/congregation/publisher-groups'), congregationId },
+      },
+    })
+
+    if (group == null) {
+      throw redirect('/congregation/publisher-groups/')
+    }
+
+    return { brothers, group }
   })
-
-  const group = await db.publisherGroup.findUnique({
-    where: {
-      id: requireParamId(params.groupId, '/congregation/publisher-groups'),
-    },
-  })
-
-  if (group == null) {
-    throw redirect('/congregation/publisher-groups/')
-  }
-
-  return { brothers, group }
 }
 
 export default function EditGroup({ loaderData }: Route.ComponentProps) {
@@ -132,7 +136,7 @@ export default function EditGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 
@@ -166,26 +170,29 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
   }
 
-  const membersToConnect = [{ id: responsibleId }]
-  if (deputyId != null) membersToConnect.push({ id: deputyId })
+  return withScope(congregationId, async db => {
+    const membersToConnect = [{ id: responsibleId }]
+    if (deputyId != null) membersToConnect.push({ id: deputyId })
 
-  const group = await db.publisherGroup.update({
-    where: {
-      id: requireParamId(params.groupId, '/congregation/publisher-groups'),
-    },
-    data: {
-      name: String(name),
-      adress: String(address),
-      deputyId,
-      responsibleId,
-      members: { connect: membersToConnect },
-    },
-  })
+    const group = await db.publisherGroup.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.groupId, '/congregation/publisher-groups'), congregationId },
+      },
+      data: {
+        name: String(name),
+        adress: String(address),
+        deputyId,
+        responsibleId,
+        members: { connect: membersToConnect },
+      },
+    })
 
-  session.flash('success', `Le groupe de prédication ${group.name} à été modifié avec succès`)
-  return redirect('/congregation/publisher-groups', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    session.flash('success', `Le groupe de prédication ${group.name} à été modifié avec succès`)
+    return redirect('/congregation/publisher-groups', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -7,6 +7,7 @@ import PublisherNominationForm from '~/features/publishers/ui/PublisherNominatio
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
 import { getBoolSetting } from '~/features/settings/server/settings'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -18,32 +19,35 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const result = await db.user.findUnique({
-    where: {
-      id: requireParamId(params.publisherId, '/congregation/publishers'),
-    },
+  return withScope(congregationId, async db => {
+    const result = await db.user.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.publisherId, '/congregation/publishers'), congregationId },
+      },
+    })
+
+    if (result == null) throw redirect('/congregation/publishers')
+
+    const showAuxiliaryPioneer = await getBoolSetting(db, CongregationSettingKey.AuxiliaryPioneerProfileActivated)
+    const groups = await db.publisherGroup.findMany()
+    const { email, password, ...user } = result
+    return {
+      user: {
+        ...user,
+        email: email.includes('@placeholder.unitae.app') ? undefined : email,
+      },
+      groups,
+      hideAuxiliaryPioneer: !showAuxiliaryPioneer,
+    }
   })
-
-  if (result == null) throw redirect('/congregation/publishers')
-
-  const showAuxiliaryPioneer = await getBoolSetting(db, CongregationSettingKey.AuxiliaryPioneerProfileActivated)
-  const groups = await db.publisherGroup.findMany()
-  const { email, password, ...user } = result
-  return {
-    user: {
-      ...user,
-      email: email.includes('@placeholder.unitae.app') ? undefined : email,
-    },
-    groups,
-    hideAuxiliaryPioneer: !showAuxiliaryPioneer,
-  }
 }
 
 export default function EditPublisher({ loaderData }: Route.ComponentProps) {
@@ -90,7 +94,7 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { db } = await authenticateAndAuthorize(request)
+  const { congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = form.get('firstname')
   const lastname = form.get('lastname')
@@ -111,31 +115,34 @@ export async function action({ request, params }: Route.ActionArgs) {
     return redirect(previousPage ?? `/congregation/publishers/${params.publisherId}/view`)
   }
 
-  const user = await db.user.update({
-    where: {
-      id: requireParamId(params.publisherId, '/congregation/publishers'),
-    },
-    data: {
-      firstname: String(firstname),
-      lastname: String(lastname),
-      isMale: String(gender) === 'male',
-      baptismDate: baptismDate ? new Date(baptismDate.toString()) : null,
-      birthDate: birthDate ? new Date(birthDate.toString()) : null,
-      isHelder: Boolean(isHelder),
-      isServant: Boolean(isServant),
-      isAnointed: Boolean(isAnointed),
-      publisherGroupId: Number.isNaN(groupId) ? null : groupId,
-      ...(!email ? {} : { email: String(email) }),
-      type: String(type),
-      address: String(address),
-      phone: String(phone),
-    },
-  })
-  const session = await getSession(request.headers.get('Cookie'))
-  session.flash('success', `La fiche de proclammateur pour ${user.firstname} à été modifiée avec succès`)
-  return redirect(previousPage ?? `/congregation/publishers/${user.id}/view`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+  return withScope(congregationId, async db => {
+    const user = await db.user.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.publisherId, '/congregation/publishers'), congregationId },
+      },
+      data: {
+        firstname: String(firstname),
+        lastname: String(lastname),
+        isMale: String(gender) === 'male',
+        baptismDate: baptismDate ? new Date(baptismDate.toString()) : null,
+        birthDate: birthDate ? new Date(birthDate.toString()) : null,
+        isHelder: Boolean(isHelder),
+        isServant: Boolean(isServant),
+        isAnointed: Boolean(isAnointed),
+        publisherGroupId: Number.isNaN(groupId) ? null : groupId,
+        ...(!email ? {} : { email: String(email) }),
+        type: String(type),
+        address: String(address),
+        phone: String(phone),
+      },
+    })
+    const session = await getSession(request.headers.get('Cookie'))
+    session.flash('success', `La fiche de proclammateur pour ${user.firstname} à été modifiée avec succès`)
+    return redirect(previousPage ?? `/congregation/publishers/${user.id}/view`, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -2,6 +2,7 @@ import { Eye, Pencil, UsersRound } from 'lucide-react'
 import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.PublisherViewer,
     Role.PublisherManager,
   ])
@@ -35,18 +36,20 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading publisher groups. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )
 
-  const groups = await db.publisherGroup.findMany({
-    include: {
-      responsible: true,
-      deputy: true,
-      _count: { select: { members: { where: { isPublisher: true } } } },
-    },
-    orderBy: [{ name: 'asc' }],
+  return withScope(congregationId, async db => {
+    const groups = await db.publisherGroup.findMany({
+      include: {
+        responsible: true,
+        deputy: true,
+        _count: { select: { members: { where: { isPublisher: true } } } },
+      },
+      orderBy: [{ name: 'asc' }],
+    })
+    return {
+      groups,
+      canManagePublisher,
+    }
   })
-  return {
-    groups,
-    canManagePublisher,
-  }
 }
 
 export default function GroupListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/publishers/routes/publishers/group.tsx
+++ b/app/features/publishers/routes/publishers/group.tsx
@@ -4,6 +4,7 @@ import { commitSession, getSession } from '~/features/authentication/server/sess
 import { Role } from '~/features/authorization/model/roles.type'
 import { getGroup } from '~/features/publishers/server/groups'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -14,7 +15,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~
 import type { Route } from './+types/group'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.PublisherViewer,
     Role.PublisherManager,
     Role.ActivityManager,
@@ -27,20 +28,22 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const group = await getGroup(db, requireParamId(params.groupId, '/congregation/publisher-groups'))
-  if (group == null) {
-    throw redirect('/congregation/publisher-groups/')
-  }
+  return withScope(congregationId, async db => {
+    const group = await getGroup(db, requireParamId(params.groupId, '/congregation/publisher-groups'))
+    if (group == null) {
+      throw redirect('/congregation/publisher-groups/')
+    }
 
-  return {
-    group,
-    roles: {
-      canManagePublisher,
-      canViewPublishers,
-      canManageActivity:
-        canManageActivity || group.responsible.id === currentUser.id || group.deputy?.id === currentUser.id,
-    },
-  }
+    return {
+      group,
+      roles: {
+        canManagePublisher,
+        canViewPublishers,
+        canManageActivity:
+          canManageActivity || group.responsible.id === currentUser.id || group.deputy?.id === currentUser.id,
+      },
+    }
+  })
 }
 
 export default function ViewGroup({ loaderData }: Route.ComponentProps) {
@@ -232,7 +235,7 @@ export default function ViewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 
@@ -266,26 +269,29 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
   }
 
-  const membersToConnect = [{ id: responsibleId }]
-  if (deputyId != null) membersToConnect.push({ id: deputyId })
+  return withScope(congregationId, async db => {
+    const membersToConnect = [{ id: responsibleId }]
+    if (deputyId != null) membersToConnect.push({ id: deputyId })
 
-  const group = await db.publisherGroup.update({
-    where: {
-      id: requireParamId(params.groupId, '/congregation/publisher-groups'),
-    },
-    data: {
-      name: String(name),
-      adress: String(address),
-      deputyId,
-      responsibleId,
-      members: { connect: membersToConnect },
-    },
-  })
+    const group = await db.publisherGroup.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.groupId, '/congregation/publisher-groups'), congregationId },
+      },
+      data: {
+        name: String(name),
+        adress: String(address),
+        deputyId,
+        responsibleId,
+        members: { connect: membersToConnect },
+      },
+    })
 
-  session.flash('success', `Le groupe de prédication ${group.name} à été modifié avec succès`)
-  return redirect('/congregation/publisher-groups', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    session.flash('success', `Le groupe de prédication ${group.name} à été modifié avec succès`)
+    return redirect('/congregation/publisher-groups', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -12,27 +13,29 @@ import { PageHeader } from '~/shared/ui/PageHeader'
 import type { Route } from './+types/new-group'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const brothers = await db.user.findMany({
-    where: {
-      // biome-ignore lint/style/useNamingConvention: Prisma OR operator
-      OR: [{ isHelder: true }, { isServant: true }],
-      responsibleFor: {
-        is: null,
+  return withScope(congregationId, async db => {
+    const brothers = await db.user.findMany({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma OR operator
+        OR: [{ isHelder: true }, { isServant: true }],
+        responsibleFor: {
+          is: null,
+        },
+        deputyFor: {
+          is: null,
+        },
       },
-      deputyFor: {
-        is: null,
-      },
-    },
-  })
+    })
 
-  return { brothers }
+    return { brothers }
+  })
 }
 
 export default function NewGroup({ loaderData }: Route.ComponentProps) {
@@ -107,7 +110,7 @@ export default function NewGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const previousPage = request.headers.get('referer')
   const canManagePublisher = can(Role.PublisherManager)
 
@@ -141,24 +144,26 @@ export async function action({ request }: Route.ActionArgs) {
     })
   }
 
-  const membersToConnect = [{ id: responsibleId }]
-  if (deputyId != null) membersToConnect.push({ id: deputyId })
+  return withScope(congregationId, async db => {
+    const membersToConnect = [{ id: responsibleId }]
+    if (deputyId != null) membersToConnect.push({ id: deputyId })
 
-  const group = await db.publisherGroup.create({
-    data: {
-      name: String(name),
-      adress: String(address),
-      deputyId,
-      responsibleId,
-      members: { connect: membersToConnect },
-      congregationId: congregation.id,
-    },
-  })
+    const group = await db.publisherGroup.create({
+      data: {
+        name: String(name),
+        adress: String(address),
+        deputyId,
+        responsibleId,
+        members: { connect: membersToConnect },
+        congregationId,
+      },
+    })
 
-  session.flash('success', `Le groupe de prédication ${group.name} à été créé avec succès`)
-  return redirect('/congregation/publisher-groups', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    session.flash('success', `Le groupe de prédication ${group.name} à été créé avec succès`)
+    return redirect('/congregation/publisher-groups', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -5,6 +5,7 @@ import PublisherFieldServiceForm from '~/features/publishers/ui/PublisherFieldSe
 import PublisherNominationForm from '~/features/publishers/ui/PublisherNominationForm'
 import PublisherPersonalInformationForm from '~/features/publishers/ui/PublisherPersonalInformationForm'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -16,16 +17,18 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const groups = await db.publisherGroup.findMany()
+  return withScope(congregationId, async db => {
+    const groups = await db.publisherGroup.findMany()
 
-  return { groups, hideAuxiliaryPioneer: false }
+    return { groups, hideAuxiliaryPioneer: false }
+  })
 }
 
 export default function NewPublisher({ loaderData }: Route.ComponentProps) {
@@ -49,7 +52,7 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, db } = await authenticateAndAuthorize(request)
+  const { congregation, congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -67,35 +70,39 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/congregation/publishers/new')
   }
 
-  const limits = new LimitService(db, congregation)
-  await limits.errorIfWouldGoOverLimit('publishers')
+  return withScope(congregationId, async db => {
+    const limits = new LimitService(db, congregation)
+    await limits.errorIfWouldGoOverLimit('publishers')
 
-  const user = await db.user.create({
-    data: {
-      firstname: firstname,
-      lastname: lastname,
-      email:
-        form.has('email') && email.length > 0 ? email : `${firstname}.${lastname}@placeholder.unitae.app`.toLowerCase(),
-      active: true,
-      password: 'password',
-      isPublisher: true,
-      isMale: String(gender) === 'male',
-      baptismDate: baptismDate ? new Date(baptismDate.toString()) : null,
-      birthDate: birthDate ? new Date(birthDate.toString()) : null,
-      isHelder: Boolean(isHelder),
-      isServant: Boolean(isServant),
-      isAnointed: Boolean(isAnointed),
-      publisherGroupId: Number.isNaN(groupId) ? null : groupId,
-      type: String(type),
-      congregationId: congregation.id,
-    },
-  })
+    const user = await db.user.create({
+      data: {
+        firstname: firstname,
+        lastname: lastname,
+        email:
+          form.has('email') && email.length > 0
+            ? email
+            : `${firstname}.${lastname}@placeholder.unitae.app`.toLowerCase(),
+        active: true,
+        password: 'password',
+        isPublisher: true,
+        isMale: String(gender) === 'male',
+        baptismDate: baptismDate ? new Date(baptismDate.toString()) : null,
+        birthDate: birthDate ? new Date(birthDate.toString()) : null,
+        isHelder: Boolean(isHelder),
+        isServant: Boolean(isServant),
+        isAnointed: Boolean(isAnointed),
+        publisherGroupId: Number.isNaN(groupId) ? null : groupId,
+        type: String(type),
+        congregationId,
+      },
+    })
 
-  const session = await getSession(request.headers.get('Cookie'))
-  session.flash('success', `La fiche de proclammateur pour ${user.firstname} à été créé avec succès`)
-  return redirect(`/congregation/publishers/${user.id}/edit`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const session = await getSession(request.headers.get('Cookie'))
+    session.flash('success', `La fiche de proclammateur pour ${user.firstname} à été créé avec succès`)
+    return redirect(`/congregation/publishers/${user.id}/edit`, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -3,6 +3,7 @@ import { Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { getPublishersWithGroup } from '~/features/publishers/server/publishers'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Button } from '~/shared/ui/button'
 
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.PublisherViewer,
     Role.PublisherManager,
     Role.ActivityViewer,
@@ -38,21 +39,23 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading publishers. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage groups and publishers.`,
   )
 
-  const users = await getPublishersWithGroup(db)
+  return withScope(congregationId, async db => {
+    const users = await getPublishersWithGroup(db)
 
-  return {
-    users: users.map(user => ({
-      email: user.email,
-      id: user.id,
-      active: user.active,
-      firstname: user.firstname,
-      lastname: user.lastname,
-      isPublisher: user.isPublisher,
-      publisherGroup: user.publisherGroup,
-    })),
-    canManagePublisher,
-    canViewActivities,
-  }
+    return {
+      users: users.map(user => ({
+        email: user.email,
+        id: user.id,
+        active: user.active,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        isPublisher: user.isPublisher,
+        publisherGroup: user.publisherGroup,
+      })),
+      canManagePublisher,
+      canViewActivities,
+    }
+  })
 }
 
 export default function PublisherListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/publishers/routes/publishers/publisher.tsx
+++ b/app/features/publishers/routes/publishers/publisher.tsx
@@ -7,6 +7,7 @@ import { findActiveAttributionsForPublisher } from '~/features/territories/serve
 import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
 import { PublisherActivityDownloadLink } from '~/features/publishers/ui/PublisherActivityDownloadLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
@@ -22,7 +23,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.PublisherViewer,
     Role.PublisherManager,
     Role.ActivityManager,
@@ -42,64 +43,69 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     `Loading publisher file for ${params.publisherId}. User ID: ${currentUser.id}. ${canManagePublisher ? 'Has' : 'Does NOT have'} rights to manage publishers.`,
   )
 
-  const today = new Date()
-  const yearBegining = new Date(today.getFullYear(), 8, 1)
-  if (today < yearBegining) {
-    yearBegining.setFullYear(today.getFullYear() - 1)
-  }
-  const publisher = await db.user.findUnique({
-    where: { id: requireParamId(params.publisherId, '/congregation/publishers') },
-    include: {
-      publisherGroup: {
-        include: {
-          responsible: true,
-          deputy: true,
+  return withScope(congregationId, async db => {
+    const today = new Date()
+    const yearBegining = new Date(today.getFullYear(), 8, 1)
+    if (today < yearBegining) {
+      yearBegining.setFullYear(today.getFullYear() - 1)
+    }
+    const publisher = await db.user.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: requireParamId(params.publisherId, '/congregation/publishers'), congregationId },
+      },
+      include: {
+        publisherGroup: {
+          include: {
+            responsible: true,
+            deputy: true,
+          },
+        },
+        activities: {
+          where: {
+            // biome-ignore lint/style/useNamingConvention: prisma syntax
+            OR: [
+              {
+                year: yearBegining.getFullYear(),
+                month: {
+                  gte: 8,
+                },
+              },
+              {
+                year: yearBegining.getFullYear() + 1,
+                month: {
+                  lte: 11,
+                },
+              },
+            ],
+          },
         },
       },
-      activities: {
-        where: {
-          // biome-ignore lint/style/useNamingConvention: prisma syntax
-          OR: [
-            {
-              year: yearBegining.getFullYear(),
-              month: {
-                gte: 8,
-              },
-            },
-            {
-              year: yearBegining.getFullYear() + 1,
-              month: {
-                lte: 11,
-              },
-            },
-          ],
-        },
+    })
+
+    if (!publisher) {
+      throw redirect('/congregation/publishers')
+    }
+
+    const messages = { success: session.get('success'), error: session.get('error') }
+
+    const attributions = await findActiveAttributionsForPublisher(db, publisher.id, congregationId)
+
+    return {
+      publisher: sanitizeUser(publisher),
+      attributions,
+      messages,
+      roles: {
+        canViewPublisher,
+        canManagePublisher,
+        canViewTerritories,
+        canManageActivity:
+          canManageActivity ||
+          publisher.publisherGroup?.responsible.id === currentUser.id ||
+          publisher.publisherGroup?.deputy?.id === currentUser.id,
       },
-    },
+    }
   })
-
-  if (!publisher) {
-    throw redirect('/congregation/publishers')
-  }
-
-  const attributions = await findActiveAttributionsForPublisher(db, publisher.id)
-
-  const messages = { success: session.get('success'), error: session.get('error') }
-
-  return {
-    publisher: sanitizeUser(publisher),
-    attributions,
-    messages,
-    roles: {
-      canViewPublisher,
-      canManagePublisher,
-      canViewTerritories,
-      canManageActivity:
-        canManageActivity ||
-        publisher.publisherGroup?.responsible.id === currentUser.id ||
-        publisher.publisherGroup?.deputy?.id === currentUser.id,
-    },
-  }
 }
 
 export default function PublisherPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
@@ -1,10 +1,10 @@
 import excelJs from 'exceljs'
 
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { PublisherType, publisherTypeReportsHours } from '~/shared/types/publisher-type'
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
-export async function generatePublishersYearlyActivityXlsx(db: ScopedDb, year: number) {
+export async function generatePublishersYearlyActivityXlsx(db: TransactionClient, year: number) {
   const months = Array.from({ length: 12 }, (_, i) => (i + 8 > 11 ? i - 4 : i + 8))
   const workbook = new excelJs.Workbook()
 
@@ -92,7 +92,7 @@ export async function generatePublishersYearlyActivityXlsx(db: ScopedDb, year: n
   return await workbook.xlsx.writeBuffer()
 }
 
-function getPublishersMonthlyActivity(db: ScopedDb, month: number, year: number) {
+function getPublishersMonthlyActivity(db: TransactionClient, month: number, year: number) {
   return db.publisherActivity.findMany({
     where: {
       month,

--- a/app/features/publishers/server/get-publisher-stats.server.test.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.test.ts
@@ -20,7 +20,7 @@ function makeFigure(type: PublisherType, count: number, hours: number, studies: 
     type,
     _count: { _all: count },
     _sum: { hours, studies },
-  }
+  } as never
 }
 
 describe('getPublisherStats', () => {

--- a/app/features/publishers/server/get-publisher-stats.server.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.ts
@@ -1,7 +1,7 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 
-export async function getPublisherStats(db: ScopedDb, month: number, year: number) {
+export async function getPublisherStats(db: TransactionClient, month: number, year: number) {
   const publishers = await db.user.count({
     where: {
       activities: {
@@ -22,7 +22,7 @@ export async function getPublisherStats(db: ScopedDb, month: number, year: numbe
   }
 }
 
-async function getFiguresMap(db: ScopedDb, month: number, year: number) {
+async function getFiguresMap(db: TransactionClient, month: number, year: number) {
   const figures = await db.publisherActivity.groupBy({
     _count: {
       _all: true,

--- a/app/features/publishers/server/get-publisher-with-activities.server.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.ts
@@ -1,6 +1,6 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export function getPublisherWithActivities(db: ScopedDb, selectedMonth: number, selectedYear: number) {
+export function getPublisherWithActivities(db: TransactionClient, selectedMonth: number, selectedYear: number) {
   return db.user.findMany({
     where: {
       // biome-ignore lint/style/useNamingConvention: prisma keywords

--- a/app/features/publishers/server/groups.ts
+++ b/app/features/publishers/server/groups.ts
@@ -1,11 +1,11 @@
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getGroups(db: ScopedDb) {
+export async function getGroups(db: TransactionClient) {
   return await db.publisherGroup.findMany()
 }
 
-export async function getGroup(db: ScopedDb, groupId: number) {
+export async function getGroup(db: TransactionClient, groupId: number) {
   const today = new Date()
   const lastMonth = new Date()
   lastMonth.setMonth(today.getMonth() - 1)

--- a/app/features/publishers/server/publishers.ts
+++ b/app/features/publishers/server/publishers.ts
@@ -1,6 +1,6 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getPublishers(db: ScopedDb, options?: { groupId?: number | null }) {
+export async function getPublishers(db: TransactionClient, options?: { groupId?: number | null }) {
   return await db.user.findMany({
     where: {
       isPublisher: true,
@@ -10,7 +10,7 @@ export async function getPublishers(db: ScopedDb, options?: { groupId?: number |
   })
 }
 
-export async function getPublishersWithGroup(db: ScopedDb) {
+export async function getPublishersWithGroup(db: TransactionClient) {
   return await db.user.findMany({
     where: { isPublisher: true },
     include: { publisherGroup: true },

--- a/app/features/publishers/server/render-activity-pdf-zip.server.tsx
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.tsx
@@ -2,9 +2,9 @@ import { pdf } from '@react-pdf/renderer'
 import JsZip from 'jszip'
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import { PublisherActivityDocument } from '~/features/publishers/ui/PublisherActivityDocument'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function renderActivityPdfZip(db: ScopedDb, year: number) {
+export async function renderActivityPdfZip(db: TransactionClient, year: number) {
   const yearBegining = new Date(year, 0, 1)
   const users = await db.user.findMany({
     where: {

--- a/app/features/settings/routes/congregation/event-kind-list.tsx
+++ b/app/features/settings/routes/congregation/event-kind-list.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { getAllEventType } from '~/features/events/server/event-kind.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Badge } from '~/shared/ui/badge'
 
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -13,18 +14,20 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  const kinds = await getAllEventType(db)
+  return withScope(congregationId, async db => {
+    const kinds = await getAllEventType(db)
 
-  return {
-    kinds,
-  }
+    return {
+      kinds,
+    }
+  })
 }
 
 export default function EventKindSettingsPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -3,7 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 import { Role } from '~/features/authorization/model/roles.type'
 import { getBoolSetting, setSetting } from '~/features/settings/server/settings'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
-import { unscopedDb } from '~/shared/libs/db.server'
+import { unscopedDb, withScope } from '~/shared/libs/db.server'
 import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { Button } from '~/shared/ui/button'
@@ -19,22 +19,24 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { congregation, can, congregationId } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
     throw redirect('/')
   }
 
-  const auxiliaryPioneerProfileActivated = await getBoolSetting(
-    db,
-    CongregationSettingKey.AuxiliaryPioneerProfileActivated,
-  )
+  return withScope(congregationId, async db => {
+    const auxiliaryPioneerProfileActivated = await getBoolSetting(
+      db,
+      CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+    )
 
-  return {
-    auxiliaryPioneerProfileActivated: auxiliaryPioneerProfileActivated ?? false,
-    congregationDisplayName: congregation.displayName,
-  }
+    return {
+      auxiliaryPioneerProfileActivated: auxiliaryPioneerProfileActivated ?? false,
+      congregationDisplayName: congregation.displayName,
+    }
+  })
 }
 
 export default function BuildingSettingsPage({ loaderData }: Route.ComponentProps) {
@@ -109,7 +111,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.Admin])
+  const { congregation, can, congregationId } = await authenticateAndAuthorize(request, [Role.Admin])
   const canManageSettings = can(Role.Admin)
 
   if (!canManageSettings) {
@@ -127,22 +129,25 @@ export async function action({ request }: Route.ActionArgs) {
     data: { displayName: displayName ? String(displayName) : null },
   })
 
-  await setSetting(
-    db,
-    CongregationSettingKey.AuxiliaryPioneerProfileActivated,
-    auxiliaryPioneerProfileActivated,
-    congregation.id,
-  )
-  if (auxiliaryPioneerProfileActivated === 'false') {
-    await db.user.updateMany({
-      where: {
-        type: PublisherType.PionnierAuxiliaires,
-      },
-      data: {
-        type: PublisherType.Normal,
-      },
-    })
-  }
+  return withScope(congregationId, async db => {
+    await setSetting(
+      db,
+      CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+      auxiliaryPioneerProfileActivated,
+      congregationId,
+    )
+    if (auxiliaryPioneerProfileActivated === 'false') {
+      await db.user.updateMany({
+        where: {
+          congregationId,
+          type: PublisherType.PionnierAuxiliaires,
+        },
+        data: {
+          type: PublisherType.Normal,
+        },
+      })
+    }
 
-  return redirect('/settings')
+    return redirect('/settings')
+  })
 }

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -10,6 +10,7 @@ import {
   serializeZips,
 } from '~/features/territories/server/settings'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -26,26 +27,28 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const territory = await getTerritoryPolygon(db)
-  const zips = await getAllowedZips(db)
-  const banoUrl = await getSetting(db, TerritorySettingKey.BanoUrl)
-  const prospectionValidity = await getSetting(db, TerritorySettingKey.ProspectionValidity)
-  const phoneTypeActivated = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+  return withScope(congregationId, async db => {
+    const territory = await getTerritoryPolygon(db)
+    const zips = await getAllowedZips(db)
+    const banoUrl = await getSetting(db, TerritorySettingKey.BanoUrl)
+    const prospectionValidity = await getSetting(db, TerritorySettingKey.ProspectionValidity)
+    const phoneTypeActivated = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  return {
-    territory: serializeTerritoryPolygon(territory),
-    zips: serializeZips(zips),
-    banoUrl: banoUrl ?? '',
-    prospectionValidity: Number(prospectionValidity ?? '24'),
-    phoneTypeActivated: phoneTypeActivated ?? false,
-  }
+    return {
+      territory: serializeTerritoryPolygon(territory),
+      zips: serializeZips(zips),
+      banoUrl: banoUrl ?? '',
+      prospectionValidity: Number(prospectionValidity ?? '24'),
+      phoneTypeActivated: phoneTypeActivated ?? false,
+    }
+  })
 }
 
 export default function BuildingSettingsPage({ loaderData }: Route.ComponentProps) {
@@ -134,7 +137,7 @@ export default function BuildingSettingsPage({ loaderData }: Route.ComponentProp
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -148,11 +151,13 @@ export async function action({ request }: Route.ActionArgs) {
   const prospectionValidity = String(form.get('prospection-validity'))
   const phoneTypeActivated = String(Boolean(form.get('phone-territory-active')))
 
-  await setSetting(db, TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregation.id)
-  await setSetting(db, TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregation.id)
-  await setSetting(db, TerritorySettingKey.BanoUrl, banoUrl, congregation.id)
-  await setSetting(db, TerritorySettingKey.ProspectionValidity, prospectionValidity, congregation.id)
-  await setSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregation.id)
+  return withScope(congregationId, async db => {
+    await setSetting(db, TerritorySettingKey.TerritoryPolygone, JSON.stringify(territory), congregationId)
+    await setSetting(db, TerritorySettingKey.TerritoryZipCodes, JSON.stringify(zips), congregationId)
+    await setSetting(db, TerritorySettingKey.BanoUrl, banoUrl, congregationId)
+    await setSetting(db, TerritorySettingKey.ProspectionValidity, prospectionValidity, congregationId)
+    await setSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, phoneTypeActivated, congregationId)
 
-  return redirect('/settings')
+    return redirect('/settings')
+  })
 }

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -3,6 +3,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Button } from '~/shared/ui/button'
@@ -20,7 +21,10 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.SettingsUserManager, Role.Admin])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.SettingsUserManager,
+    Role.Admin,
+  ])
   const canManageUser = can(Role.SettingsUserManager)
   const isAdmin = can(Role.Admin)
 
@@ -28,39 +32,42 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const user = await db.user.findUnique({
-    where: {
-      id: requireParamId(params.userId, '/settings/users'),
-    },
-    include: {
-      congregationRoles: { include: { role: true } },
-    },
-  })
-
-  if (user == null) throw redirect('/settings/users')
-
-  const roleList = await db.userRole.findMany()
-  const missEmail = user.email.includes('@placeholder.unitae.app')
-
-  return data(
-    {
-      email: missEmail ? null : user.email,
-      id: user.id,
-      active: user.active,
-      firstname: user.firstname,
-      lastname: user.lastname,
-      roles: user.congregationRoles.map(cr => cr.role),
-      messages: { success: session.get('success'), error: session.get('error') },
-      roleList,
-      isPublisher: user.isPublisher,
-      isAdmin,
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+  return withScope(congregationId, async db => {
+    const user = await db.user.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.userId, '/settings/users'), congregationId },
       },
-    },
-  )
+      include: {
+        congregationRoles: { include: { role: true } },
+      },
+    })
+
+    if (user == null) throw redirect('/settings/users')
+
+    const roleList = await db.userRole.findMany()
+    const missEmail = user.email.includes('@placeholder.unitae.app')
+
+    return data(
+      {
+        email: missEmail ? null : user.email,
+        id: user.id,
+        active: user.active,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        roles: user.congregationRoles.map(cr => cr.role),
+        messages: { success: session.get('success'), error: session.get('error') },
+        roleList,
+        isPublisher: user.isPublisher,
+        isAdmin,
+      },
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      },
+    )
+  })
 }
 
 export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
@@ -209,7 +216,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const { congregationId, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
   const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) {
@@ -225,34 +232,39 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const userId = requireParamId(params.userId, '/settings/users')
 
-  await db.user.update({
-    where: { id: userId },
-    data: {
-      firstname: String(firstname),
-      lastname: String(lastname),
-      email: String(email).toLocaleLowerCase(),
-      active: Boolean(active),
-    },
-  })
-
-  // Update congregation-scoped roles: delete existing, create new
-  await db.congregationUserRole.deleteMany({
-    where: { userId, congregationId: congregation.id },
-  })
-
-  const roleRecords = await db.userRole.findMany({
-    where: { key: { in: roles.map(String) } },
-  })
-
-  if (roleRecords.length > 0) {
-    await db.congregationUserRole.createMany({
-      data: roleRecords.map(role => ({
-        userId,
-        roleId: role.id,
-        congregationId: congregation.id,
-      })),
+  return withScope(congregationId, async db => {
+    await db.user.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: userId, congregationId },
+      },
+      data: {
+        firstname: String(firstname),
+        lastname: String(lastname),
+        email: String(email).toLocaleLowerCase(),
+        active: Boolean(active),
+      },
     })
-  }
 
-  return redirect('/settings/users')
+    // Update congregation-scoped roles: delete existing, create new
+    await db.congregationUserRole.deleteMany({
+      where: { userId, congregationId },
+    })
+
+    const roleRecords = await db.userRole.findMany({
+      where: { key: { in: roles.map(String) } },
+    })
+
+    if (roleRecords.length > 0) {
+      await db.congregationUserRole.createMany({
+        data: roleRecords.map(role => ({
+          userId,
+          roleId: role.id,
+          congregationId,
+        })),
+      })
+    }
+
+    return redirect('/settings/users')
+  })
 }

--- a/app/features/settings/routes/users/make-publisher.tsx
+++ b/app/features/settings/routes/users/make-publisher.tsx
@@ -2,30 +2,39 @@ import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/make-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const user = await db.user.update({
-    where: { id: requireParamId(params.userId, '/settings/users') },
-    data: {
-      isPublisher: true,
-    },
-  })
-  if (user.isPublisher === true) {
-    session.flash('success', `La fiche proclamateur pour l'utilisateur ${user.email} a été correctement créé.`)
-  } else {
-    session.flash('error', `La fiche proclamateur pour l'utilisateur ${user.email} n'a pas pu être créé correctement.`)
-  }
+  return withScope(congregationId, async db => {
+    const user = await db.user.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.userId, '/settings/users'), congregationId },
+      },
+      data: {
+        isPublisher: true,
+      },
+    })
+    if (user.isPublisher === true) {
+      session.flash('success', `La fiche proclamateur pour l'utilisateur ${user.email} a été correctement créé.`)
+    } else {
+      session.flash(
+        'error',
+        `La fiche proclamateur pour l'utilisateur ${user.email} n'a pas pu être créé correctement.`,
+      )
+    }
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/settings/users')
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/settings/users')
+  })
 }

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -3,6 +3,7 @@ import { createPasswordResetToken } from '~/features/authentication/server/inval
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -59,7 +60,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, db } = await authenticateAndAuthorize(request)
+  const { congregation, congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -69,43 +70,45 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/settings/users/new')
   }
 
-  const existingUser = await db.user.findUnique({
-    where: {
-      email: String(email),
-    },
+  return withScope(congregationId, async db => {
+    const existingUser = await db.user.findUnique({
+      where: {
+        email: String(email),
+      },
+    })
+
+    if (existingUser != null) {
+      throw redirect('/settings/users/new')
+    }
+
+    const limits = new LimitService(db, congregation)
+    await limits.errorIfWouldGoOverLimit('users')
+
+    const user = await db.user.create({
+      data: {
+        firstname: String(firstname),
+        lastname: String(lastname),
+        email: String(email).toLocaleLowerCase(),
+        active: true,
+        password: 'password',
+        congregationId,
+      },
+    })
+
+    const token = await createPasswordResetToken(user.id)
+
+    const ResetPasswordRequired = (await import('emails/reset-password-required')).default
+    await sendResetUserPasswordEmail(
+      user.id,
+      <ResetPasswordRequired
+        email={user.email}
+        firstname={user.firstname || undefined}
+        token={token}
+        baseUrl={congregation.baseUrl}
+        platformName={congregation.displayName}
+      />,
+    )
+
+    return redirect('/settings/users')
   })
-
-  if (existingUser != null) {
-    throw redirect('/settings/users/new')
-  }
-
-  const limits = new LimitService(db, congregation)
-  await limits.errorIfWouldGoOverLimit('users')
-
-  const user = await db.user.create({
-    data: {
-      firstname: String(firstname),
-      lastname: String(lastname),
-      email: String(email).toLocaleLowerCase(),
-      active: true,
-      password: 'password',
-      congregationId: congregation.id,
-    },
-  })
-
-  const token = await createPasswordResetToken(user.id)
-
-  const ResetPasswordRequired = (await import('emails/reset-password-required')).default
-  await sendResetUserPasswordEmail(
-    user.id,
-    <ResetPasswordRequired
-      email={user.email}
-      firstname={user.firstname || undefined}
-      token={token}
-      baseUrl={congregation.baseUrl}
-      platformName={congregation.displayName}
-    />,
-  )
-
-  return redirect('/settings/users')
 }

--- a/app/features/settings/routes/users/unmake-publisher.tsx
+++ b/app/features/settings/routes/users/unmake-publisher.tsx
@@ -2,33 +2,39 @@ import { redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/unmake-publisher'
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.PublisherManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.PublisherManager])
   const canManagePublisher = can(Role.PublisherManager)
 
   if (!canManagePublisher) {
     throw redirect('/')
   }
 
-  const user = await db.user.update({
-    where: { id: requireParamId(params.userId, '/settings/users') },
-    data: {
-      isPublisher: false,
-    },
-  })
-  if (user.isPublisher === true) {
-    session.flash('success', `La fiche proclamateur pour l'utilisateur ${user.email} a été correctement supprimée.`)
-  } else {
-    session.flash(
-      'error',
-      `La fiche proclamateur pour l'utilisateur ${user.email} n'a pas pu être supprimée correctement.`,
-    )
-  }
+  return withScope(congregationId, async db => {
+    const user = await db.user.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: prisma compound key
+        id_congregationId: { id: requireParamId(params.userId, '/settings/users'), congregationId },
+      },
+      data: {
+        isPublisher: false,
+      },
+    })
+    if (user.isPublisher === true) {
+      session.flash('success', `La fiche proclamateur pour l'utilisateur ${user.email} a été correctement supprimée.`)
+    } else {
+      session.flash(
+        'error',
+        `La fiche proclamateur pour l'utilisateur ${user.email} n'a pas pu être supprimée correctement.`,
+      )
+    }
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/settings/users')
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/settings/users')
+  })
 }

--- a/app/features/settings/routes/users/user-list.tsx
+++ b/app/features/settings/routes/users/user-list.tsx
@@ -3,6 +3,7 @@ import { Form, Link, redirect } from 'react-router'
 
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { Badge } from '~/shared/ui/badge'
 import { Button } from '~/shared/ui/button'
@@ -17,7 +18,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.SettingsUserManager,
     Role.PublisherViewer,
     Role.PublisherManager,
@@ -36,37 +37,40 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading users. User ID: ${currentUser.id}. ${canManageUser ? 'Has' : 'Does NOT have'} rights to manage users.`,
   )
 
-  const users = await db.user.findMany({
-    include: {
-      congregationRoles: { include: { role: true } },
-    },
-    orderBy: [
-      {
-        lastname: 'asc',
+  return withScope(congregationId, async db => {
+    const users = await db.user.findMany({
+      where: { congregationId },
+      include: {
+        congregationRoles: { include: { role: true } },
       },
-      {
-        firstname: 'asc',
-      },
-    ],
-  })
+      orderBy: [
+        {
+          lastname: 'asc',
+        },
+        {
+          firstname: 'asc',
+        },
+      ],
+    })
 
-  return {
-    users: users.map(user => ({
-      email: user.email.includes('@placeholder.unitae.app') ? null : user.email,
-      roles: user.congregationRoles.map(cr => cr.role),
-      id: user.id,
-      active: user.active,
-      firstname: user.firstname,
-      lastname: user.lastname,
-      isAdmin: user.congregationRoles.some(cr => cr.role.key === 'admin'),
-      isPublisher: user.isPublisher,
-    })),
-    roles: {
-      canViewPublishers,
-      canManageUser,
-      canManagePublishers,
-    },
-  }
+    return {
+      users: users.map(user => ({
+        email: user.email.includes('@placeholder.unitae.app') ? null : user.email,
+        roles: user.congregationRoles.map(cr => cr.role),
+        id: user.id,
+        active: user.active,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        isAdmin: user.congregationRoles.some(cr => cr.role.key === 'admin'),
+        isPublisher: user.isPublisher,
+      })),
+      roles: {
+        canViewPublishers,
+        canManageUser,
+        canManagePublishers,
+      },
+    }
+  })
 }
 
 export default function SettingsLayout({ loaderData }: Route.ComponentProps) {

--- a/app/features/settings/server/settings.ts
+++ b/app/features/settings/server/settings.ts
@@ -1,22 +1,22 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import type { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import type { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 
 type SettingKey = TerritorySettingKey | CongregationSettingKey
 
-export async function getSetting(db: ScopedDb, key: SettingKey): Promise<string | undefined> {
+export async function getSetting(db: TransactionClient, key: SettingKey): Promise<string | undefined> {
   const setting = await db.setting.findFirst({ where: { key } })
 
   return setting?.value
 }
 
-export async function getBoolSetting(db: ScopedDb, key: SettingKey): Promise<boolean | undefined> {
+export async function getBoolSetting(db: TransactionClient, key: SettingKey): Promise<boolean | undefined> {
   const settingValue = await getSetting(db, key)
 
   return settingValue === 'true'
 }
 
-export async function setSetting(db: ScopedDb, key: SettingKey, value: string, congregationId: number) {
+export async function setSetting(db: TransactionClient, key: SettingKey, value: string, congregationId: number) {
   if (key == null || value.length < 1) {
     return
   }

--- a/app/features/territories/routes/attributions/delete.tsx
+++ b/app/features/territories/routes/attributions/delete.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -10,23 +11,28 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const attribution = await db.attribution.findUnique({
-    where: { id: requireParamId(params.attributionId, '/territories/attributions') },
-    include: { publisher: true, territory: true },
+  return withScope(congregationId, async db => {
+    const attribution = await db.attribution.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.attributionId, '/territories/attributions'), congregationId },
+      },
+      include: { publisher: true, territory: true },
+    })
+
+    if (attribution == null) {
+      throw redirect('/territories/attributions')
+    }
+
+    return { attribution }
   })
-
-  if (attribution == null) {
-    throw redirect('/territories/attributions')
-  }
-
-  return { attribution }
 }
 
 export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
@@ -57,27 +63,32 @@ export default function DeleteGroup({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const attribution = await db.attribution.delete({
-    where: { id: requireParamId(params.attributionId, '/territories/attributions') },
-    include: { publisher: true },
-  })
+  return withScope(congregationId, async db => {
+    const attribution = await db.attribution.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.attributionId, '/territories/attributions'), congregationId },
+      },
+      include: { publisher: true },
+    })
 
-  session.flash(
-    'success',
-    `L'attribution de ${attribution.publisher.lastname?.toLocaleUpperCase()} ${attribution.publisher.firstname} a été annulée`,
-  )
+    session.flash(
+      'success',
+      `L'attribution de ${attribution.publisher.lastname?.toLocaleUpperCase()} ${attribution.publisher.firstname} a été annulée`,
+    )
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/territories/attributions', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/territories/attributions', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/attributions/edit.tsx
+++ b/app/features/territories/routes/attributions/edit.tsx
@@ -9,6 +9,7 @@ import { TerritoryAttributionKind } from '~/features/territories/model/territory
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -24,27 +25,32 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const attribution = await db.attribution.findUnique({
-    where: { id: requireParamId(params.attributionId, '/territories/attributions') },
-    include: { territory: { include: { entrances: { include: { buildings: true } } } }, publisher: true },
+    const attribution = await db.attribution.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.attributionId, '/territories/attributions'), congregationId },
+      },
+      include: { territory: { include: { entrances: { include: { buildings: true } } } }, publisher: true },
+    })
+
+    if (attribution == null) {
+      throw redirect('/territories/attributions')
+    }
+
+    const users = await getPublishers(db)
+
+    return { users, phoneTypeActive, attribution, entrances: attribution.territory.entrances.map(aggregateEntrance) }
   })
-
-  if (attribution == null) {
-    throw redirect('/territories/attributions')
-  }
-
-  const users = await getPublishers(db)
-
-  return { users, phoneTypeActive, attribution, entrances: attribution.territory.entrances.map(aggregateEntrance) }
 }
 
 export default function EditAttributionPage({ loaderData }: Route.ComponentProps) {
@@ -185,7 +191,7 @@ export default function EditAttributionPage({ loaderData }: Route.ComponentProps
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -200,7 +206,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const notes = String(form.get('notes'))
   const type = String(form.get('type'))
 
-  const data: Prisma.XOR<Prisma.AttributionUpdateInput, Prisma.AttributionUncheckedUpdateInput> = {
+  const updateData: Prisma.XOR<Prisma.AttributionUpdateInput, Prisma.AttributionUncheckedUpdateInput> = {
     publisherId: publisherId,
     notes,
     type,
@@ -209,18 +215,23 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const hasLateDate = lateDateText.length > 0 && lateDateText !== 'null'
   if (hasLateDate) {
-    data.lateDate = new Date(lateDateText)
+    updateData.lateDate = new Date(lateDateText)
   }
 
   const hasEndDate = endDateText.length > 0 && endDateText !== 'null'
   if (hasEndDate) {
-    data.endDate = new Date(endDateText)
+    updateData.endDate = new Date(endDateText)
   }
 
-  const attribution = await db.attribution.update({
-    where: { id: requireParamId(params.attributionId, '/territories/attributions') },
-    data,
-  })
+  return withScope(congregationId, async db => {
+    const attribution = await db.attribution.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.attributionId, '/territories/attributions'), congregationId },
+      },
+      data: updateData,
+    })
 
-  return redirect(hasEndDate ? '/territories/attributions' : `/territories/attributions/${attribution.id}/edit`)
+    return redirect(hasEndDate ? '/territories/attributions' : `/territories/attributions/${attribution.id}/edit`)
+  })
 }

--- a/app/features/territories/routes/attributions/excel-export.tsx
+++ b/app/features/territories/routes/attributions/excel-export.tsx
@@ -3,6 +3,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { generateS13ExportExcel } from '~/features/territories/server/s13-export.server'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/excel-export'
@@ -12,7 +13,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -25,14 +26,17 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   logger.info(`Generating S-13 XLSX report Year: ${params.year}. User ID: ${currentUser.id}.`, {
     currentUser,
   })
-  const data = await getTerritoriesExportData(db, Number(params.year))
-  const file = await generateS13ExportExcel(data, params.year)
 
-  return new Response(await file.xlsx.writeBuffer(), {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/vnd.ms-excel',
-      'Content-Disposition': `attachment; filename="S-13_F-${params.year}.xlsx"`,
-    },
+  return withScope(congregationId, async db => {
+    const exportData = await getTerritoriesExportData(db, Number(params.year))
+    const file = await generateS13ExportExcel(exportData, params.year)
+
+    return new Response(await file.xlsx.writeBuffer(), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.ms-excel',
+        'Content-Disposition': `attachment; filename="S-13_F-${params.year}.xlsx"`,
+      },
+    })
   })
 }

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -11,6 +11,7 @@ import { getCurrentTheocraticYear } from '~/features/territories/server/theocrat
 import AttributionFilters from '~/features/territories/ui/AttributionFilters'
 import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -28,7 +29,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.TerritoriesViewer,
     Role.PublisherManager,
     Role.PublisherViewer,
@@ -57,39 +58,41 @@ export async function loader({ request }: Route.LoaderArgs) {
     `Loading territory attributions. User ID: ${currentUser.id}. ${canManageTerritories ? 'Has' : 'Does NOT have'} rights to manage territories.`,
   )
 
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const url = new URL(request.url)
-  const selectors = computeFilters(url.searchParams)
-  selectors.endDate = null
+    const url = new URL(request.url)
+    const selectors = computeFilters(url.searchParams)
+    selectors.endDate = null
 
-  const { attributions, pagination } = await findActiveAttributionsPaginated(db, selectors, url)
+    const { attributions, pagination } = await findActiveAttributionsPaginated(db, selectors, url)
 
-  const messages = { success: session.get('success'), error: session.get('error') }
-  const groups = await getGroups(db)
-  const theocraticYear = getCurrentTheocraticYear()
+    const messages = { success: session.get('success'), error: session.get('error') }
+    const groups = await getGroups(db)
+    const theocraticYear = getCurrentTheocraticYear()
 
-  return data(
-    {
-      messages,
-      stats: {
-        total: pagination.total,
+    return data(
+      {
+        messages,
+        stats: {
+          total: pagination.total,
+        },
+        attributions,
+        pagination,
+        canManageTerritories,
+        canManagePublisher,
+        canViewPublisher,
+        groups,
+        phoneTypeActive,
+        theocraticYear,
       },
-      attributions,
-      pagination,
-      canManageTerritories,
-      canManagePublisher,
-      canViewPublisher,
-      groups,
-      phoneTypeActive,
-      theocraticYear,
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function AttributionListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -5,6 +5,7 @@ import { TerritoryAttributionKind } from '~/features/territories/model/territory
 import { aggregateEntrance } from '~/features/territories/server/buildings'
 import { TerritoryCardLink } from '~/features/territories/ui/TerritoryCardLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
@@ -19,42 +20,47 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
-
   const url = new URL(request.url)
   if (!url.searchParams.has('territory')) {
     throw redirect('/territories/attributions/new/available-territories')
   }
 
-  const territory = await db.territory.findUnique({
-    where: { id: Number(url.searchParams.get('territory')) },
-    include: { entrances: { include: { buildings: true } } },
-  })
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  if (territory === null) {
-    throw redirect('/territories/attributions/new/available-territories')
-  }
-
-  const users = await db.user.findMany({
-    where: {
-      isPublisher: true,
-    },
-    orderBy: [
-      {
-        lastname: 'asc',
+    const territory = await db.territory.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: Number(url.searchParams.get('territory')), congregationId },
       },
-      { firstname: 'asc' },
-    ],
-  })
+      include: { entrances: { include: { buildings: true } } },
+    })
 
-  return { users, phoneTypeActive, territory, territoryEntrances: territory.entrances.map(aggregateEntrance) }
+    if (territory === null) {
+      throw redirect('/territories/attributions/new/available-territories')
+    }
+
+    const users = await db.user.findMany({
+      where: {
+        isPublisher: true,
+      },
+      orderBy: [
+        {
+          lastname: 'asc',
+        },
+        { firstname: 'asc' },
+      ],
+    })
+
+    return { users, phoneTypeActive, territory, territoryEntrances: territory.entrances.map(aggregateEntrance) }
+  })
 }
 
 export default function CreateAttributionPage({ loaderData }: Route.ComponentProps) {
@@ -122,7 +128,7 @@ export default function CreateAttributionPage({ loaderData }: Route.ComponentPro
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { congregation, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -143,17 +149,19 @@ export async function action({ request }: Route.ActionArgs) {
   const lateDate = new Date(startDateText)
   lateDate.setMonth(lateDate.getMonth() + 4)
 
-  const attribution = await db.attribution.create({
-    data: {
-      publisherId: publisherId,
-      territoryId: territoryId,
-      notes,
-      type,
-      startDate: new Date(startDateText),
-      lateDate: lateDate,
-      congregationId: congregation.id,
-    },
-  })
+  return withScope(congregationId, async db => {
+    const attribution = await db.attribution.create({
+      data: {
+        publisherId: publisherId,
+        territoryId: territoryId,
+        notes,
+        type,
+        startDate: new Date(startDateText),
+        lateDate: lateDate,
+        congregationId: congregation.id,
+      },
+    })
 
-  return redirect(`/territories/attributions/${attribution.id}/edit`)
+    return redirect(`/territories/attributions/${attribution.id}/edit`)
+  })
 }

--- a/app/features/territories/routes/attributions/pdf-export.tsx
+++ b/app/features/territories/routes/attributions/pdf-export.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { getTerritoriesExportData } from '~/features/territories/server/territories-export-data.server'
 import { TerritoryAttributionDocument } from '~/features/territories/ui/TerritoryAttributionDocument'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 import type { Route } from './+types/pdf-export'
@@ -13,7 +14,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const { currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { currentUser, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -27,14 +28,18 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     currentUser,
   })
 
-  const territories = await getTerritoriesExportData(db, Number(params.year))
-  const file = await pdf(<TerritoryAttributionDocument year={Number(params.year)} territories={territories} />).toBlob()
+  return withScope(congregationId, async db => {
+    const territories = await getTerritoriesExportData(db, Number(params.year))
+    const file = await pdf(
+      <TerritoryAttributionDocument year={Number(params.year)} territories={territories} />,
+    ).toBlob()
 
-  return new Response(file, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/pdf',
-      'Content-Disposition': `attachment; filename="S-13_F-${params.year}.zip"`,
-    },
+    return new Response(file, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="S-13_F-${params.year}.zip"`,
+      },
+    })
   })
 }

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -9,6 +9,7 @@ import { computeFilters } from '~/features/territories/server/territory-filters'
 import { checkAvailabilityStatus, TerritoryAvaibilityStatus } from '~/features/territories/ui/TerritoryAvaibilityStatus'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -23,7 +24,9 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesManager,
+  ])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -35,32 +38,34 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   logger.info(`Loading territories available for attribution. User ID: ${currentUser.id}.`)
 
-  const url = new URL(request.url)
-  const selectors = await computeFilters(url.searchParams)
-  selectors.attributions = { none: { endDate: null } }
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const selectors = await computeFilters(url.searchParams)
+    selectors.attributions = { none: { endDate: null } }
 
-  const { territories, pagination } = await findAvailableTerritoriesPaginated(db, selectors, url)
+    const { territories, pagination } = await findAvailableTerritoriesPaginated(db, selectors, url)
 
-  const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips(db)
+    const messages = { success: session.get('success'), error: session.get('error') }
+    const zips = await getZips(db)
 
-  return data(
-    {
-      messages,
-      zips,
-      stats: {
-        total: pagination.total,
+    return data(
+      {
+        messages,
+        zips,
+        stats: {
+          total: pagination.total,
+        },
+        territories,
+        pagination,
+        canManageTerritories,
       },
-      territories,
-      pagination,
-      canManageTerritories,
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function TerritorySelectorPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -7,6 +7,7 @@ import { TerritoryAccess } from '~/features/territories/model/territory-access.t
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { Button } from '~/shared/ui/button'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.ProspectionManager,
     Role.TerritoriesManager,
@@ -32,103 +33,105 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
-  const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
-  if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
-  const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
-  if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
-  const warningDate = new Date()
-  warningDate.setMonth(warningDate.getMonth() - 3)
+  return withScope(congregationId, async db => {
+    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
+    const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+    if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
+    const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+    if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
+    const warningDate = new Date()
+    warningDate.setMonth(warningDate.getMonth() - 3)
 
-  const totalBuildings = await db.building.count()
-  const totalActiveBuildings = await db.building.count({ where: { active: true } })
-  const totalRemovedBuildings = await db.building.count({ where: { inOpenData: false, active: true } })
-  const totalCreatedBuildings = await db.building.count({
-    where: { inOpenData: true, active: true, prospectionDate: null },
-  })
-  const totalStaleBuildings = await db.building.count({
-    where: {
-      // biome-ignore lint/style/useNamingConvention: OR is a keywork for prisma ORM
-      OR: [
-        {
-          prospectionDate: {
-            lt: staleDate,
+    const totalBuildings = await db.building.count()
+    const totalActiveBuildings = await db.building.count({ where: { active: true } })
+    const totalRemovedBuildings = await db.building.count({ where: { inOpenData: false, active: true } })
+    const totalCreatedBuildings = await db.building.count({
+      where: { inOpenData: true, active: true, prospectionDate: null },
+    })
+    const totalStaleBuildings = await db.building.count({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: OR is a keywork for prisma ORM
+        OR: [
+          {
+            prospectionDate: {
+              lt: staleDate,
+            },
+            active: true,
           },
-          active: true,
-        },
-        {
-          prospectionDate: {
-            lt: inactiveStaleDate,
+          {
+            prospectionDate: {
+              lt: inactiveStaleDate,
+            },
+            active: false,
+            inTerritory: true,
           },
-          active: false,
-          inTerritory: true,
-        },
-        {
-          entrance: { access: TerritoryAccess.Intercom },
-          homes: { equals: null },
-          inTerritory: true,
-        },
-        {
-          entrance: { access: TerritoryAccess.Doorbell },
-          homes: { equals: null },
-          inTerritory: true,
-        },
-        {
-          entrance: { access: TerritoryAccess.Code, isOpenEarly: true },
+          {
+            entrance: { access: TerritoryAccess.Intercom },
+            homes: { equals: null },
+            inTerritory: true,
+          },
+          {
+            entrance: { access: TerritoryAccess.Doorbell },
+            homes: { equals: null },
+            inTerritory: true,
+          },
+          {
+            entrance: { access: TerritoryAccess.Code, isOpenEarly: true },
 
-          homes: { equals: null },
-          inTerritory: true,
-        },
-        {
-          entrance: { access: TerritoryAccess.Code, isOpenEarly: false },
-          phones: { equals: null },
-          inTerritory: true,
-        },
-        {
-          inTerritory: false,
-          active: true,
-          createdAt: {
-            lt: warningDate,
+            homes: { equals: null },
+            inTerritory: true,
           },
-        },
-        {
-          inTerritory: true,
-          homes: { gt: 0 },
-          entrance: {
-            access: {
-              equals: null,
+          {
+            entrance: { access: TerritoryAccess.Code, isOpenEarly: false },
+            phones: { equals: null },
+            inTerritory: true,
+          },
+          {
+            inTerritory: false,
+            active: true,
+            createdAt: {
+              lt: warningDate,
             },
           },
-        },
-      ],
-    },
-  })
-  const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
-  const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips(db)
+          {
+            inTerritory: true,
+            homes: { gt: 0 },
+            entrance: {
+              access: {
+                equals: null,
+              },
+            },
+          },
+        ],
+      },
+    })
+    const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
+    const messages = { success: session.get('success'), error: session.get('error') }
+    const zips = await getZips(db)
 
-  return data(
-    {
-      zips,
-      messages,
-      openDataAvailable: banoUrl?.value != null && banoUrl.value !== '',
-      staleDate,
-      canManageTerritories,
-      canManageProspection,
-      stats: {
-        total: totalBuildings,
-        active: totalActiveBuildings,
-        removed: totalRemovedBuildings,
-        stale: totalStaleBuildings,
-        created: totalCreatedBuildings,
+    return data(
+      {
+        zips,
+        messages,
+        openDataAvailable: banoUrl?.value != null && banoUrl.value !== '',
+        staleDate,
+        canManageTerritories,
+        canManageProspection,
+        stats: {
+          total: totalBuildings,
+          active: totalActiveBuildings,
+          removed: totalRemovedBuildings,
+          stale: totalStaleBuildings,
+          created: totalCreatedBuildings,
+        },
       },
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/active-building-list.tsx
+++ b/app/features/territories/routes/prospection/active-building-list.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -15,7 +16,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.ProspectionManager,
     Role.TerritoriesManager,
@@ -28,18 +29,20 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const url = new URL(request.url)
-  const staleDate = await getProspectionStaleDate(db)
-  const { buildings, pagination } = await findBuildingsPaginated(db, { active: true }, url)
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const staleDate = await getProspectionStaleDate(db)
+    const { buildings, pagination } = await findBuildingsPaginated(db, { active: true }, url)
 
-  return {
-    buildings,
-    pagination,
-    staleDate,
-    canManageTerritories,
-    canViewProspection,
-    canManageProspection,
-  }
+    return {
+      buildings,
+      pagination,
+      staleDate,
+      canManageTerritories,
+      canViewProspection,
+      canManageProspection,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/building-list.tsx
+++ b/app/features/territories/routes/prospection/building-list.tsx
@@ -5,6 +5,7 @@ import { computeFilters } from '~/features/territories/server/building-filters'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.TerritoriesManager,
     Role.ProspectionManager,
@@ -29,19 +30,21 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const url = new URL(request.url)
-  const selectors = computeFilters(url.searchParams)
-  const staleDate = await getProspectionStaleDate(db)
-  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const selectors = computeFilters(url.searchParams)
+    const staleDate = await getProspectionStaleDate(db)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
-  return {
-    buildings,
-    pagination,
-    staleDate,
-    canManageTerritories,
-    canManageProspection,
-    canViewProspection,
-  }
+    return {
+      buildings,
+      pagination,
+      staleDate,
+      canManageTerritories,
+      canManageProspection,
+      canViewProspection,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/building.tsx
+++ b/app/features/territories/routes/prospection/building.tsx
@@ -8,6 +8,7 @@ import ArchiveBuildingToggleButton from '~/features/territories/ui/ArchiveBuildi
 import BuildingProspectionInfo from '~/features/territories/ui/BuildingProspectionInfo'
 import BuildingTerritoryInfo from '~/features/territories/ui/BuildingTerritoryInfo'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -22,7 +23,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { currentUser, session, can, db } = await authenticateAndAuthorize(request, [
+  const { currentUser, session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.ProspectionManager,
     Role.TerritoriesViewer,
@@ -44,23 +45,25 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     `Loading building data for building nº${params.buildingId}. User ID: ${currentUser.id}. ${canManageProspection ? 'Has' : 'Does NOT have'} rights to modify prospection data.`,
   )
 
-  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
-  if (!building) {
-    throw redirect('../', { status: 404 })
-  }
+  return withScope(congregationId, async db => {
+    const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
+    if (!building) {
+      throw redirect('../', { status: 404 })
+    }
 
-  const messages = { success: session.get('success'), error: session.get('error') }
+    const messages = { success: session.get('success'), error: session.get('error') }
 
-  return {
-    building,
-    messages,
-    roles: {
-      canViewProspection,
-      canManageProspection,
-      canViewTerritories,
-      canManageTerritories,
-    },
-  }
+    return {
+      building,
+      messages,
+      roles: {
+        canViewProspection,
+        canManageProspection,
+        canViewTerritories,
+        canManageTerritories,
+      },
+    }
+  })
 }
 
 export default function BuildingPage({ loaderData }: Route.ComponentProps) {
@@ -128,7 +131,7 @@ export default function BuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -139,22 +142,24 @@ export async function action({ request, params }: Route.ActionArgs) {
   const notes = form.get('notes')
   const importantNotes = form.get('important-notes')
 
-  try {
-    await setBuildingNotes(db, requireParamId(params.buildingId, '/territories/buildings'), {
-      notes: String(notes),
-      importantNotes: String(importantNotes),
+  return withScope(congregationId, async db => {
+    try {
+      await setBuildingNotes(db, requireParamId(params.buildingId, '/territories/buildings'), {
+        notes: String(notes),
+        importantNotes: String(importantNotes),
+      })
+
+      session.flash('success', 'Les notes ont été correctement modifiées pour ce batiment.')
+    } catch (e) {
+      logger.error('Error updating building', { error: e, buildingId: params.buildingId })
+      session.flash('error', 'Erreur lors de la modification des notes')
+    }
+
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? `/territories/building/${params.buildingId}/`, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
     })
-
-    session.flash('success', 'Les notes ont été correctement modifiées pour ce batiment.')
-  } catch (e) {
-    logger.error('Error updating building', { error: e, buildingId: params.buildingId })
-    session.flash('error', 'Erreur lors de la modification des notes')
-  }
-
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? `/territories/building/${params.buildingId}/`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/territories/routes/prospection/delete-building.tsx
+++ b/app/features/territories/routes/prospection/delete-building.tsx
@@ -3,6 +3,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -10,22 +11,27 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete-building'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.ProspectionManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.ProspectionManager])
   const canManageProspection = can(Role.ProspectionManager)
 
   if (!canManageProspection) {
     throw redirect('/')
   }
 
-  const building = await db.building.findUnique({
-    where: { id: requireParamId(params.buildingId, '/territories/buildings') },
+  return withScope(congregationId, async db => {
+    const building = await db.building.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.buildingId, '/territories/buildings'), congregationId },
+      },
+    })
+
+    if (building == null) {
+      throw redirect('/territories/attributions')
+    }
+
+    return { building }
   })
-
-  if (building == null) {
-    throw redirect('/territories/attributions')
-  }
-
-  return { building }
 }
 
 export default function DeleteBuilding({ loaderData }: Route.ComponentProps) {
@@ -56,26 +62,31 @@ export default function DeleteBuilding({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const building = await db.building.delete({
-    where: { id: requireParamId(params.buildingId, '/territories/buildings') },
-  })
+  return withScope(congregationId, async db => {
+    const building = await db.building.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.buildingId, '/territories/buildings'), congregationId },
+      },
+    })
 
-  session.flash(
-    'success',
-    `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement supprimé`,
-  )
+    session.flash(
+      'success',
+      `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement supprimé`,
+    )
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/territories/buildings', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/territories/buildings', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/prospection/disable-building.tsx
+++ b/app/features/territories/routes/prospection/disable-building.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/disable-building'
@@ -12,34 +13,39 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const building = await db.building.update({
-    where: { id: requireParamId(params.buildingId, '/territories/buildings') },
-    data: { active: false },
-  })
+  return withScope(congregationId, async db => {
+    const building = await db.building.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.buildingId, '/territories/buildings'), congregationId },
+      },
+      data: { active: false },
+    })
 
-  if (building.active === false) {
-    session.flash(
-      'success',
-      `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement désactivé`,
-    )
-  } else {
-    session.flash(
-      'error',
-      `Le batiment au ${building.number} ${building.street}, ${building.zip} n'a pas pu être désactivé`,
-    )
-  }
+    if (building.active === false) {
+      session.flash(
+        'success',
+        `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement désactivé`,
+      )
+    } else {
+      session.flash(
+        'error',
+        `Le batiment au ${building.number} ${building.street}, ${building.zip} n'a pas pu être désactivé`,
+      )
+    }
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/territories/buildings', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/territories/buildings', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -14,6 +14,7 @@ import BuildingProspectionForDoorToDoorFields from '~/features/territories/ui/Bu
 import OtherBuildingProspectionFields from '~/features/territories/ui/OtherBuildingProspectionFields'
 import SharedEntranceField from '~/features/territories/ui/SharedEntranceField'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -29,7 +30,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionManager,
     Role.TerritoriesManager,
   ])
@@ -40,25 +41,27 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
-  if (building == null) {
-    throw redirect('/territories/buildings', { status: 404 })
-  }
+  return withScope(congregationId, async db => {
+    const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
+    if (building == null) {
+      throw redirect('/territories/buildings', { status: 404 })
+    }
 
-  const buildings = await getBuildings(db, building.zip, building.street)
-  const messages = {
-    success: session.get('success'),
-    error: session.get('error'),
-  }
+    const buildings = await getBuildings(db, building.zip, building.street)
+    const messages = {
+      success: session.get('success'),
+      error: session.get('error'),
+    }
 
-  return data(
-    { building, buildings, messages, roles: { canManageTerritories } },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+    return data(
+      { building, buildings, messages, roles: { canManageTerritories } },
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
@@ -127,7 +130,7 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [
+  const { session, congregation, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionManager,
     Role.TerritoriesManager,
   ])
@@ -139,49 +142,52 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   const previousPage = request.headers.get('referer') ?? '/territories/buildings'
-  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
-  if (building == null) {
-    throw redirect('/territories/buildings', { status: 404 })
-  }
 
-  const form = await request.formData()
-
-  // manage modification shared entrance
-  if (canManageTerritories) {
-    const currentEntranceIdsSerialized = serializeSharedEntranceFromBuilding(building)
-    const entranceIds = unserializeSharedEntranceFormValue(form.get('shared-entrance-buildings'), building.id)
-    const entranceIdsSerialized = entranceIds.join(',')
-
-    if (currentEntranceIdsSerialized !== entranceIdsSerialized) {
-      try {
-        await updateBuildingsInEntrance(db, Number(building.entrance?.id), entranceIds, congregation.id)
-        session.flash('success', 'Le batiment a été correctement modifié')
-      } catch (e) {
-        logger.error('Error updating building', { error: e, buildingId: params.buildingId })
-        session.flash('error', `Erreur lors de l'enregistrement du batiment`)
-      }
-
-      return redirect(previousPage, {
-        headers: {
-          'Set-Cookie': await commitSession(session),
-        },
-      })
+  return withScope(congregationId, async db => {
+    const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
+    if (building == null) {
+      throw redirect('/territories/buildings', { status: 404 })
     }
-  }
 
-  // manage changes in classic data
-  try {
-    await setBuildingProspectionData(db, building.id, form)
+    const form = await request.formData()
 
-    session.flash('success', 'Les données de prospection ont été correctement mise à jour')
-  } catch (e) {
-    logger.error(e)
-    session.flash('error', 'Erreur lors de la mise à jour des données de prospection du batiment')
-  }
+    // manage modification shared entrance
+    if (canManageTerritories) {
+      const currentEntranceIdsSerialized = serializeSharedEntranceFromBuilding(building)
+      const entranceIds = unserializeSharedEntranceFormValue(form.get('shared-entrance-buildings'), building.id)
+      const entranceIdsSerialized = entranceIds.join(',')
 
-  return redirect(previousPage, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+      if (currentEntranceIdsSerialized !== entranceIdsSerialized) {
+        try {
+          await updateBuildingsInEntrance(db, Number(building.entrance?.id), entranceIds, congregation.id)
+          session.flash('success', 'Le batiment a été correctement modifié')
+        } catch (e) {
+          logger.error('Error updating building', { error: e, buildingId: params.buildingId })
+          session.flash('error', `Erreur lors de l'enregistrement du batiment`)
+        }
+
+        return redirect(previousPage, {
+          headers: {
+            'Set-Cookie': await commitSession(session),
+          },
+        })
+      }
+    }
+
+    // manage changes in classic data
+    try {
+      await setBuildingProspectionData(db, building.id, form)
+
+      session.flash('success', 'Les données de prospection ont été correctement mise à jour')
+    } catch (e) {
+      logger.error(e)
+      session.flash('error', 'Erreur lors de la mise à jour des données de prospection du batiment')
+    }
+
+    return redirect(previousPage, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/prospection/edit-building.tsx
+++ b/app/features/territories/routes/prospection/edit-building.tsx
@@ -5,6 +5,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { editBuilding } from '~/features/territories/server/edit-building.server'
 import { getBuildingDetails } from '~/features/territories/server/get-building-details.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -25,31 +26,33 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
-  if (building == null) {
-    throw redirect('/territories/buildings', { status: 404 })
-  }
+  return withScope(congregationId, async db => {
+    const building = await getBuildingDetails(db, requireParamId(params.buildingId, '/territories/buildings'))
+    if (building == null) {
+      throw redirect('/territories/buildings', { status: 404 })
+    }
 
-  const messages = {
-    success: session.get('success'),
-    error: session.get('error'),
-  }
+    const messages = {
+      success: session.get('success'),
+      error: session.get('error'),
+    }
 
-  return data(
-    { building, messages },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+    return data(
+      { building, messages },
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
@@ -121,7 +124,7 @@ export default function EditBuildingPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -139,29 +142,31 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw redirect(`/territories/building/${params.buildingId}/edit`)
   }
 
-  try {
-    await editBuilding(db, requireParamId(params.buildingId, '/territories/buildings'), {
-      coordinates: {
-        latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
-        longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,
-      },
-      address: {
-        number: String(number),
-        street: String(street),
-        zip: String(zip),
+  return withScope(congregationId, async db => {
+    try {
+      await editBuilding(db, requireParamId(params.buildingId, '/territories/buildings'), {
+        coordinates: {
+          latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
+          longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,
+        },
+        address: {
+          number: String(number),
+          street: String(street),
+          zip: String(zip),
+        },
+      })
+
+      session.flash('success', 'Le batiment a été correctement modifié')
+    } catch (e) {
+      logger.error('Error updating building', { error: e, buildingId: params.buildingId })
+      session.flash('error', `Erreur lors de l'enregistrement du batiment`)
+    }
+
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? `/territories/building/${params.buildingId}/view`, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
       },
     })
-
-    session.flash('success', 'Le batiment a été correctement modifié')
-  } catch (e) {
-    logger.error('Error updating building', { error: e, buildingId: params.buildingId })
-    session.flash('error', `Erreur lors de l'enregistrement du batiment`)
-  }
-
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? `/territories/building/${params.buildingId}/view`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
   })
 }

--- a/app/features/territories/routes/prospection/enable-building.tsx
+++ b/app/features/territories/routes/prospection/enable-building.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 
 import type { Route } from './+types/enable-building'
@@ -12,33 +13,38 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const building = await db.building.update({
-    where: { id: requireParamId(params.buildingId, '/territories/buildings') },
-    data: { active: true },
-  })
-  if (building.active === true) {
-    session.flash(
-      'success',
-      `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement activé`,
-    )
-  } else {
-    session.flash(
-      'error',
-      `Le batiment au ${building.number} ${building.street}, ${building.zip} n'a pas pu être activé`,
-    )
-  }
+  return withScope(congregationId, async db => {
+    const building = await db.building.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.buildingId, '/territories/buildings'), congregationId },
+      },
+      data: { active: true },
+    })
+    if (building.active === true) {
+      session.flash(
+        'success',
+        `Le batiment au ${building.number} ${building.street}, ${building.zip} a été correctement activé`,
+      )
+    } else {
+      session.flash(
+        'error',
+        `Le batiment au ${building.number} ${building.street}, ${building.zip} n'a pas pu être activé`,
+      )
+    }
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/territories/buildings', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/territories/buildings', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/prospection/missing-building-list.tsx
+++ b/app/features/territories/routes/prospection/missing-building-list.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.ProspectionManager,
     Role.TerritoriesManager,
@@ -29,20 +30,22 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const staleDate = await getProspectionStaleDate(db)
+  return withScope(congregationId, async db => {
+    const staleDate = await getProspectionStaleDate(db)
 
-  const selectors = { inOpenData: false, active: true }
-  const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+    const selectors = { inOpenData: false, active: true }
+    const url = new URL(request.url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
-  return {
-    buildings,
-    pagination,
-    staleDate,
-    canManageTerritories,
-    canManageProspection,
-    canViewProspection,
-  }
+    return {
+      buildings,
+      pagination,
+      staleDate,
+      canManageTerritories,
+      canManageProspection,
+      canViewProspection,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -8,6 +8,7 @@ import { findBuildingsWithEntrancePaginated } from '~/features/territories/serve
 import { BuildingCheckReason } from '~/features/territories/ui/BuildingCheckReason'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
 
@@ -20,7 +21,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.ProspectionManager,
     Role.TerritoriesManager,
@@ -33,80 +34,82 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
-  const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
-  if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
-  const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
-  if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
-  const warningDate = new Date()
-  warningDate.setMonth(warningDate.getMonth() - 3)
+  return withScope(congregationId, async db => {
+    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
+    const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+    if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
+    const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
+    if (prospectionValidity > 0) inactiveStaleDate.setMonth(inactiveStaleDate.getMonth() - prospectionValidity * 2)
+    const warningDate = new Date()
+    warningDate.setMonth(warningDate.getMonth() - 3)
 
-  const selector: Prisma.BuildingWhereInput = {
-    // biome-ignore lint/style/useNamingConvention: OR is a keywork for prisma ORM
-    OR: [
-      {
-        prospectionDate: {
-          lt: staleDate,
+    const selector: Prisma.BuildingWhereInput = {
+      // biome-ignore lint/style/useNamingConvention: OR is a keywork for prisma ORM
+      OR: [
+        {
+          prospectionDate: {
+            lt: staleDate,
+          },
+          active: true,
         },
-        active: true,
-      },
-      {
-        prospectionDate: {
-          lt: inactiveStaleDate,
+        {
+          prospectionDate: {
+            lt: inactiveStaleDate,
+          },
+          active: false,
+          inTerritory: true,
         },
-        active: false,
-        inTerritory: true,
-      },
-      {
-        entrance: { access: TerritoryAccess.Intercom },
-        homes: { equals: null },
-        inTerritory: true,
-      },
-      {
-        entrance: { access: TerritoryAccess.Doorbell },
-        homes: { equals: null },
-        inTerritory: true,
-      },
-      {
-        entrance: { access: TerritoryAccess.Code, isOpenEarly: true },
-        homes: { equals: null },
-        inTerritory: true,
-      },
-      {
-        entrance: { access: TerritoryAccess.Code, isOpenEarly: false },
-        phones: { equals: null },
-        inTerritory: true,
-      },
-      {
-        inTerritory: false,
-        active: true,
-        createdAt: {
-          lt: warningDate,
+        {
+          entrance: { access: TerritoryAccess.Intercom },
+          homes: { equals: null },
+          inTerritory: true,
         },
-      },
-      {
-        inTerritory: true,
-        homes: { gt: 0 },
-        entrance: {
-          access: {
-            equals: null,
+        {
+          entrance: { access: TerritoryAccess.Doorbell },
+          homes: { equals: null },
+          inTerritory: true,
+        },
+        {
+          entrance: { access: TerritoryAccess.Code, isOpenEarly: true },
+          homes: { equals: null },
+          inTerritory: true,
+        },
+        {
+          entrance: { access: TerritoryAccess.Code, isOpenEarly: false },
+          phones: { equals: null },
+          inTerritory: true,
+        },
+        {
+          inTerritory: false,
+          active: true,
+          createdAt: {
+            lt: warningDate,
           },
         },
-      },
-    ],
-  }
+        {
+          inTerritory: true,
+          homes: { gt: 0 },
+          entrance: {
+            access: {
+              equals: null,
+            },
+          },
+        },
+      ],
+    }
 
-  const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsWithEntrancePaginated(db, selector, url)
+    const url = new URL(request.url)
+    const { buildings, pagination } = await findBuildingsWithEntrancePaginated(db, selector, url)
 
-  return {
-    buildings,
-    pagination,
-    staleDate,
-    canManageTerritories,
-    canManageProspection,
-    canViewProspection,
-  }
+    return {
+      buildings,
+      pagination,
+      staleDate,
+      canManageTerritories,
+      canManageProspection,
+      canViewProspection,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/new-building-list.tsx
+++ b/app/features/territories/routes/prospection/new-building-list.tsx
@@ -4,6 +4,7 @@ import { Role } from '~/features/authorization/model/roles.type'
 import { findBuildingsPaginated, getProspectionStaleDate } from '~/features/territories/server/buildings'
 import { BuildingStatus } from '~/features/territories/ui/BuildingStatus'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 
 import Pagination from '~/shared/ui/Pagination'
@@ -16,7 +17,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.ProspectionViewer,
     Role.TerritoriesManager,
     Role.ProspectionManager,
@@ -29,19 +30,21 @@ export async function loader({ request }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const staleDate = await getProspectionStaleDate(db)
+  return withScope(congregationId, async db => {
+    const staleDate = await getProspectionStaleDate(db)
 
-  const selectors = { inOpenData: true, active: true, prospectionDate: null }
-  const url = new URL(request.url)
-  const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+    const selectors = { inOpenData: true, active: true, prospectionDate: null }
+    const url = new URL(request.url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
 
-  return {
-    buildings,
-    pagination,
-    staleDate,
-    canManageTerritories,
-    canManageProspection,
-  }
+    return {
+      buildings,
+      pagination,
+      staleDate,
+      canManageTerritories,
+      canManageProspection,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/prospection/new-building.tsx
+++ b/app/features/territories/routes/prospection/new-building.tsx
@@ -3,6 +3,7 @@ import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { createBuilding } from '~/features/territories/server/create-building.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
@@ -67,7 +68,9 @@ export default function CreateBuildingPage() {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, congregation, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesManager,
+  ])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -85,28 +88,30 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/buildings/new')
   }
 
-  const building = await createBuilding(db, {
-    address: {
-      number: String(number),
-      street: String(street),
-      zip: String(zip),
-    },
-    coordinates: {
-      latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
-      longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,
-    },
-    congregationId: congregation.id,
-  })
+  return withScope(congregationId, async db => {
+    const building = await createBuilding(db, {
+      address: {
+        number: String(number),
+        street: String(street),
+        zip: String(zip),
+      },
+      coordinates: {
+        latitude: latitude ? Number.parseFloat(latitude.toString()) : undefined,
+        longitude: longitude ? Number.parseFloat(longitude.toString()) : undefined,
+      },
+      congregationId: congregation.id,
+    })
 
-  if (building == null) {
-    session.flash('error', `Erreur lors de l'enregistrement du batiment`)
-  } else {
-    session.flash('success', 'Le batiment a été correctement modifié')
-  }
+    if (building == null) {
+      session.flash('error', `Erreur lors de l'enregistrement du batiment`)
+    } else {
+      session.flash('success', 'Le batiment a été correctement modifié')
+    }
 
-  return redirect(`/territories/building/${building.id}/view`, {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    return redirect(`/territories/building/${building.id}/view`, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/prospection/sync-buildings.tsx
+++ b/app/features/territories/routes/prospection/sync-buildings.tsx
@@ -4,6 +4,7 @@ import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { syncQueue } from '~/features/territories/server/sync-queue.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 
 import type { Route } from './+types/sync-buildings'
 
@@ -16,37 +17,42 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, currentUser, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, currentUser, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesManager,
+  ])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const user = await db.user.findUnique({
-    where: {
-      id: Number(session.get('userId')) ?? 0,
-    },
-  })
+  return withScope(congregationId, async db => {
+    const user = await db.user.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: Number(session.get('userId')) ?? 0, congregationId },
+      },
+    })
 
-  if (user == null) {
-    throw redirect('/')
-  }
+    if (user == null) {
+      throw redirect('/')
+    }
 
-  await syncQueue.add('sync', {
-    userName: user.firstname ?? undefined,
-    userEmail: user.email,
-    congregationId: currentUser.congregationId,
-  })
+    await syncQueue.add('sync', {
+      userName: user.firstname ?? undefined,
+      userEmail: user.email,
+      congregationId: currentUser.congregationId,
+    })
 
-  session.flash(
-    'success',
-    `Les données sont en cours d'importation. Nous vous enverrons un email une fois l'opération terminée.`,
-  )
+    session.flash(
+      'success',
+      `Les données sont en cours d'importation. Nous vous enverrons un email une fois l'opération terminée.`,
+    )
 
-  return redirect('/territories/buildings', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    return redirect('/territories/buildings', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/split-tool/_layout.tsx
+++ b/app/features/territories/routes/split-tool/_layout.tsx
@@ -6,6 +6,7 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { getZips } from '~/features/territories/server/buildings'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -17,133 +18,135 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
-  const totalBuildingsForDoors = await db.building.count({
-    where: {
-      active: true,
-      entrance: {
-        territories: {
-          none: { type: TerritoryKind.Classical },
-        },
-      },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      NOT: {
-        prospectionDate: null,
-      },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      OR: [
-        {
-          entrance: {
-            access: 1, // interphone
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const totalBuildingsForDoors = await db.building.count({
+      where: {
+        active: true,
+        entrance: {
+          territories: {
+            none: { type: TerritoryKind.Classical },
           },
         },
-        {
-          entrance: {
-            access: 2, // sonnette
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        NOT: {
+          prospectionDate: null,
+        },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        OR: [
+          {
+            entrance: {
+              access: 1, // interphone
+            },
+          },
+          {
+            entrance: {
+              access: 2, // sonnette
+            },
+          },
+          phoneTypeActive ? { entrance: { access: 4, isOpenEarly: true } } : { entrance: { access: 4 } }, // code ouvert le matin
+        ],
+      },
+    })
+    const totalBuildingsForPhone = await db.building.count({
+      where: {
+        active: true,
+        entrance: {
+          territories: {
+            none: { type: TerritoryKind.Classical },
           },
         },
-        phoneTypeActive ? { entrance: { access: 4, isOpenEarly: true } } : { entrance: { access: 4 } }, // code ouvert le matin
-      ],
-    },
-  })
-  const totalBuildingsForPhone = await db.building.count({
-    where: {
-      active: true,
-      entrance: {
-        territories: {
-          none: { type: TerritoryKind.Classical },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        NOT: {
+          prospectionDate: null,
         },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        OR: [
+          {
+            phones: {
+              gt: 0,
+            },
+          },
+          { entrance: { access: 4, isOpenEarly: false } }, // code ouvert le matin
+        ],
       },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      NOT: {
-        prospectionDate: null,
-      },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      OR: [
-        {
-          phones: {
-            gt: 0,
+    })
+    const totalBuildingsForCommerce = await db.building.count({
+      where: {
+        active: true,
+        entrance: {
+          territories: {
+            none: { type: TerritoryKind.Commerces },
           },
         },
-        { entrance: { access: 4, isOpenEarly: false } }, // code ouvert le matin
-      ],
-    },
-  })
-  const totalBuildingsForCommerce = await db.building.count({
-    where: {
-      active: true,
-      entrance: {
-        territories: {
-          none: { type: TerritoryKind.Commerces },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        NOT: {
+          prospectionDate: null,
         },
+        hasShops: true,
       },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      NOT: {
-        prospectionDate: null,
-      },
-      hasShops: true,
-    },
-  })
-  const totalBuildingsForCampus = await db.building.count({
-    where: {
-      active: true,
-      entrance: {
-        territories: {
-          none: { type: TerritoryKind.Univ },
+    })
+    const totalBuildingsForCampus = await db.building.count({
+      where: {
+        active: true,
+        entrance: {
+          territories: {
+            none: { type: TerritoryKind.Univ },
+          },
         },
-      },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      NOT: {
-        prospectionDate: null,
-      },
-      hasCampus: true,
-    },
-  })
-  const totalBuildingsForHotel = await db.building.count({
-    where: {
-      active: true,
-      entrance: {
-        territories: {
-          none: { type: TerritoryKind.Hotel },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        NOT: {
+          prospectionDate: null,
         },
+        hasCampus: true,
       },
-      // biome-ignore lint/style/useNamingConvention: prisma keywords
-      NOT: {
-        prospectionDate: null,
+    })
+    const totalBuildingsForHotel = await db.building.count({
+      where: {
+        active: true,
+        entrance: {
+          territories: {
+            none: { type: TerritoryKind.Hotel },
+          },
+        },
+        // biome-ignore lint/style/useNamingConvention: prisma keywords
+        NOT: {
+          prospectionDate: null,
+        },
+        hasHotel: true,
       },
-      hasHotel: true,
-    },
-  })
+    })
 
-  const messages = { success: session.get('success'), error: session.get('error') }
-  const zips = await getZips(db)
+    const messages = { success: session.get('success'), error: session.get('error') }
+    const zips = await getZips(db)
 
-  return data(
-    {
-      messages,
-      zips,
-      stats: {
-        classical: totalBuildingsForDoors,
-        hotel: totalBuildingsForHotel,
-        campus: totalBuildingsForCampus,
-        phones: totalBuildingsForPhone,
-        commerce: totalBuildingsForCommerce,
+    return data(
+      {
+        messages,
+        zips,
+        stats: {
+          classical: totalBuildingsForDoors,
+          hotel: totalBuildingsForHotel,
+          campus: totalBuildingsForCampus,
+          phones: totalBuildingsForPhone,
+          commerce: totalBuildingsForCommerce,
+        },
+        phoneTypeActive,
       },
-      phoneTypeActive,
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -8,6 +8,7 @@ import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -27,25 +28,28 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const url = new URL(request.url)
-  const filters = computeFilters(url.searchParams)
-  const selectors: Prisma.BuildingWhereInput = {
-    ...filters,
-    active: true,
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    NOT: {
-      prospectionDate: null,
-    },
-    hasShops: true,
-    entrance: { territories: { none: { type: TerritoryKind.Commerces } } },
-  }
-  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
-  return {
-    entrances,
-    pagination,
-    apiKey,
-  }
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const filters = computeFilters(url.searchParams)
+    const selectors: Prisma.BuildingWhereInput = {
+      ...filters,
+      active: true,
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      NOT: {
+        prospectionDate: null,
+      },
+      hasShops: true,
+      entrance: { territories: { none: { type: TerritoryKind.Commerces } } },
+    }
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+
+    return {
+      entrances,
+      pagination,
+      apiKey,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -4,6 +4,7 @@ import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
 
 import type { Route } from './+types/create'
@@ -13,7 +14,9 @@ export function loader(_args: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, congregation, can, congregationId } = await authenticateAndAuthorize(request, [
+    Role.TerritoriesManager,
+  ])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -28,46 +31,48 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/buildings/split-territories')
   }
 
-  const count = await db.territory.count({
-    where: { type: String(type) },
-  })
+  return withScope(congregationId, async db => {
+    const count = await db.territory.count({
+      where: { type: String(type) },
+    })
 
-  let prefix = 'D'
+    let prefix = 'D'
 
-  if (type === TerritoryKind.Hotel) {
-    prefix = 'H'
-  } else if (type === TerritoryKind.Univ) {
-    prefix = 'U'
-  } else if (type === TerritoryKind.Commerces) {
-    prefix = 'C'
-  } else if (type === TerritoryKind.Phone) {
-    prefix = 'P'
-  }
+    if (type === TerritoryKind.Hotel) {
+      prefix = 'H'
+    } else if (type === TerritoryKind.Univ) {
+      prefix = 'U'
+    } else if (type === TerritoryKind.Commerces) {
+      prefix = 'C'
+    } else if (type === TerritoryKind.Phone) {
+      prefix = 'P'
+    }
 
-  const number = `${prefix}${String(count + 1).padStart(3, '0')}`
+    const number = `${prefix}${String(count + 1).padStart(3, '0')}`
 
-  const limits = new LimitService(db, congregation)
-  await limits.errorIfWouldGoOverLimit('territories')
+    const limits = new LimitService(db, congregation)
+    await limits.errorIfWouldGoOverLimit('territories')
 
-  await db.territory.create({
-    data: {
-      number: number,
-      type: String(type),
-      entrances: {
-        connect: String(entrances)
-          .split(',')
-          .map(el => ({ id: Number(el) })),
+    await db.territory.create({
+      data: {
+        number: number,
+        type: String(type),
+        entrances: {
+          connect: String(entrances)
+            .split(',')
+            .map(el => ({ id: Number(el) })),
+        },
+        congregationId: congregation.id,
       },
-      congregationId: congregation.id,
-    },
-  })
+    })
 
-  session.flash('success', `Le territoire ${number} a été créé avec succès.`)
+    session.flash('success', `Le territoire ${number} a été créé avec succès.`)
 
-  const previousPage = request.headers.get('referer')
-  return redirect(previousPage ?? '/territories/buildings/split-territories', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    const previousPage = request.headers.get('referer')
+    return redirect(previousPage ?? '/territories/buildings/split-territories', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -8,6 +8,7 @@ import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -27,25 +28,28 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const url = new URL(request.url)
-  const filters = computeFilters(url.searchParams)
-  const selectors: Prisma.BuildingWhereInput = {
-    ...filters,
-    active: true,
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    NOT: {
-      prospectionDate: null,
-    },
-    hasHotel: true,
-    entrance: { territories: { none: { type: TerritoryKind.Hotel } } },
-  }
-  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
-  return {
-    entrances,
-    pagination,
-    apiKey,
-  }
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const filters = computeFilters(url.searchParams)
+    const selectors: Prisma.BuildingWhereInput = {
+      ...filters,
+      active: true,
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      NOT: {
+        prospectionDate: null,
+      },
+      hasHotel: true,
+      entrance: { territories: { none: { type: TerritoryKind.Hotel } } },
+    }
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+
+    return {
+      entrances,
+      pagination,
+      apiKey,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -9,6 +9,7 @@ import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +22,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -29,38 +30,41 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const url = new URL(request.url)
-  const filters = computeFilters(url.searchParams)
-  const selectors: Prisma.BuildingWhereInput = {
-    ...filters,
-    active: true,
-    hasCampus: false,
-    hasHotel: false,
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    NOT: {
-      prospectionDate: null,
-    },
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    OR: [
-      { entrance: { access: 1 } }, // interphone
-      { entrance: { access: 2 } }, // sonnette
-      { hasShops: true, homes: { gt: 0 } }, // commerces si foyers dans le batiment
-      phoneTypeActive ? { entrance: { access: 4, isOpenEarly: true } } : { entrance: { access: 4 } }, // code ouvert le matin ou tous les codes si territoires téléphone désactivé
-    ],
-    entrance: {
-      territories: { none: { type: TerritoryKind.Classical } },
-    },
-  }
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const url = new URL(request.url)
+    const filters = computeFilters(url.searchParams)
+    const selectors: Prisma.BuildingWhereInput = {
+      ...filters,
+      active: true,
+      hasCampus: false,
+      hasHotel: false,
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      NOT: {
+        prospectionDate: null,
+      },
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      OR: [
+        { entrance: { access: 1 } }, // interphone
+        { entrance: { access: 2 } }, // sonnette
+        { hasShops: true, homes: { gt: 0 } }, // commerces si foyers dans le batiment
+        phoneTypeActive ? { entrance: { access: 4, isOpenEarly: true } } : { entrance: { access: 4 } }, // code ouvert le matin ou tous les codes si territoires téléphone désactivé
+      ],
+      entrance: {
+        territories: { none: { type: TerritoryKind.Classical } },
+      },
+    }
 
-  return {
-    entrances,
-    pagination,
-    apiKey,
-  }
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+
+    return {
+      entrances,
+      pagination,
+      apiKey,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -9,6 +9,7 @@ import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { Button } from '~/shared/ui/button'
@@ -21,7 +22,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -29,38 +30,41 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
-  if (!phoneTypeActive) {
-    throw redirect('/territories/buildings/split-territories')
-  }
 
-  const url = new URL(request.url)
-  const filters = computeFilters(url.searchParams)
-  const selectors: Prisma.BuildingWhereInput = {
-    ...filters,
-    active: true,
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    NOT: {
-      prospectionDate: null,
-    },
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    OR: [
-      {
-        phones: {
-          gt: 0,
-        },
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    if (!phoneTypeActive) {
+      throw redirect('/territories/buildings/split-territories')
+    }
+
+    const url = new URL(request.url)
+    const filters = computeFilters(url.searchParams)
+    const selectors: Prisma.BuildingWhereInput = {
+      ...filters,
+      active: true,
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      NOT: {
+        prospectionDate: null,
       },
-      { entrance: { access: 4, isOpenEarly: false } }, // code ouvert le matin
-    ],
-    entrance: { territories: { none: { type: TerritoryKind.Phone } } },
-  }
-  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      OR: [
+        {
+          phones: {
+            gt: 0,
+          },
+        },
+        { entrance: { access: 4, isOpenEarly: false } }, // code ouvert le matin
+      ],
+      entrance: { territories: { none: { type: TerritoryKind.Phone } } },
+    }
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
-  return {
-    entrances,
-    pagination,
-    apiKey,
-  }
+    return {
+      entrances,
+      pagination,
+      apiKey,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -8,6 +8,7 @@ import { findEntrancesPaginated } from '~/features/territories/server/buildings'
 import BuildingEntranceList from '~/features/territories/ui/BuildingEntranceList'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { Button } from '~/shared/ui/button'
 import Pagination from '~/shared/ui/Pagination'
@@ -19,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesViewer])
   const canViewTerritories = can(Role.TerritoriesViewer)
 
   if (!canViewTerritories) {
@@ -27,25 +28,28 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const url = new URL(request.url)
-  const filters = computeFilters(url.searchParams)
-  const selectors: Prisma.BuildingWhereInput = {
-    ...filters,
-    active: true,
-    // biome-ignore lint/style/useNamingConvention: prisma keywords
-    NOT: {
-      prospectionDate: null,
-    },
-    hasCampus: true,
-    entrance: { territories: { none: { type: TerritoryKind.Univ } } },
-  }
-  const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
 
-  return {
-    entrances,
-    pagination,
-    apiKey,
-  }
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const filters = computeFilters(url.searchParams)
+    const selectors: Prisma.BuildingWhereInput = {
+      ...filters,
+      active: true,
+      // biome-ignore lint/style/useNamingConvention: prisma keywords
+      NOT: {
+        prospectionDate: null,
+      },
+      hasCampus: true,
+      entrance: { territories: { none: { type: TerritoryKind.Univ } } },
+    }
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+
+    return {
+      entrances,
+      pagination,
+      apiKey,
+    }
+  })
 }
 
 export default function BuildingListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -38,6 +38,7 @@ import StatsFilters from '~/features/territories/ui/StatsFilters'
 import TerritoriesNeverWorkedList from '~/features/territories/ui/TerritoriesNeverWorkedList'
 import YearOverYearTable from '~/features/territories/ui/YearOverYearTable'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import S13ExportButton from '~/shared/ui/S13ExportButton'
@@ -49,144 +50,146 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const url = new URL(request.url)
-  const params = url.searchParams
+  return withScope(congregationId, async db => {
+    const url = new URL(request.url)
+    const params = url.searchParams
 
-  const theocraticYear = getCurrentTheocraticYear()
-  const filterParams = parseStatsFilterParams(params, theocraticYear)
+    const theocraticYear = getCurrentTheocraticYear()
+    const filterParams = parseStatsFilterParams(params, theocraticYear)
 
-  // Paramètres pour l'année précédente (comparaison annuelle)
-  const prevYear = getPreviousTheocraticYear()
-  const prevParams = {
-    ...filterParams,
-    startDate: getBeginingDateOfTheocraticYear(prevYear),
-    endDate: getEndDateOfTheocraticYear(prevYear),
-  }
+    // Paramètres pour l'année précédente (comparaison annuelle)
+    const prevYear = getPreviousTheocraticYear()
+    const prevParams = {
+      ...filterParams,
+      startDate: getBeginingDateOfTheocraticYear(prevYear),
+      endDate: getEndDateOfTheocraticYear(prevYear),
+    }
 
-  // Requêtes parallèles
-  const [
-    activeWorkingTerritoriesCount,
-    delayedWorkingTerritoriesCount,
-    restingTerritoriesCount,
-    availableTerritoriesCount,
-    percentageCovered,
-    percentageTotallyCovered,
-    attributions,
-    prevAttributions,
-    territoryCounts,
-    allTerritoryCounts,
-    neverWorked,
-    attributionsByGroup,
-    groups,
-  ] = await Promise.all([
-    countActiveWorkingTerritories(db),
-    countDelayedWorkingTerritories(db),
-    countRestingTerritories(db),
-    countAvailableTerritories(db),
-    computeTerritoryCoverage(
-      db,
-      filterParams.territoryKind,
-      filterParams.attributionKind,
-      filterParams.startDate,
-      filterParams.endDate,
-    ),
-    computeTerritoryCoverageTotal(
-      db,
-      filterParams.territoryKind,
-      filterParams.attributionKind.length > 0
-        ? filterParams.attributionKind
-        : [TerritoryAttributionKind.Default, TerritoryAttributionKind.Campaign],
-      filterParams.startDate,
-      filterParams.endDate,
-    ),
-    fetchAttributionsForStats(db, filterParams),
-    fetchAttributionsForStats(db, prevParams),
-    fetchTerritoryCounts(db, filterParams.territoryKind),
-    fetchTerritoryCounts(db),
-    getTerritoriesNeverWorked(db, filterParams),
-    fetchActiveAttributionsByGroup(db),
-    getGroups(db),
-  ])
-
-  const workingTerritoriesCount = activeWorkingTerritoriesCount + delayedWorkingTerritoriesCount
-  const unavailableTerritoriesCount = restingTerritoriesCount + workingTerritoriesCount
-  const territoriesCount = unavailableTerritoriesCount + availableTerritoriesCount
-
-  // Calculs synchrones à partir des données récupérées
-  const ranked = computeRankedTerritories(attributions)
-  const durationStats = computeDurationStats(attributions)
-  const overdueRate = computeOverdueRate(attributions)
-  const availabilityGap = computeAvailabilityGap(attributions)
-  const attributionsPerMonth = computeAttributionsPerMonth(attributions, filterParams.startDate, filterParams.endDate)
-  const monthlyCoverage = computeMonthlyCoverageEvolution(
-    attributions,
-    territoryCounts,
-    filterParams.startDate,
-    filterParams.endDate,
-  )
-  const coverageByType = computeCoverageByTerritoryType(attributions, allTerritoryCounts)
-  const restUtilization = computeRestPeriodUtilization(attributions)
-
-  // Métriques de l'année précédente pour la comparaison
-  const prevDuration = computeDurationStats(prevAttributions)
-  const prevOverdueRate = computeOverdueRate(prevAttributions)
-  const prevTotalCount = getTotalTerritoryCount(territoryCounts)
-  const prevTouchedTerritories = new Set(prevAttributions.map(a => a.territoryId))
-  const prevCoverage = prevTotalCount > 0 ? (prevAttributions.length / prevTotalCount) * 100 : 0
-  const prevTotalCoverage = prevTotalCount > 0 ? (prevTouchedTerritories.size / prevTotalCount) * 100 : 0
-
-  return {
-    stats: {
-      total: territoriesCount,
-      available: availableTerritoriesCount,
-      unavailable: unavailableTerritoriesCount,
-      resting: restingTerritoriesCount,
-      working: workingTerritoriesCount,
-      active: activeWorkingTerritoriesCount,
-      delayed: delayedWorkingTerritoriesCount,
-      coverage: percentageCovered,
-      totalCoverage: percentageTotallyCovered,
-    },
-    progression: {
-      ranked,
-      durationStats,
-      overdueRate,
-      availabilityGap,
-      attributionsPerMonth,
-      restUtilization,
-    },
-    coverageOverTime: {
-      monthlyCoverage,
-      coverageByType,
+    // Requêtes parallèles
+    const [
+      activeWorkingTerritoriesCount,
+      delayedWorkingTerritoriesCount,
+      restingTerritoriesCount,
+      availableTerritoriesCount,
+      percentageCovered,
+      percentageTotallyCovered,
+      attributions,
+      prevAttributions,
+      territoryCounts,
+      allTerritoryCounts,
       neverWorked,
-    },
-    yearOverYear: {
-      current: {
+      attributionsByGroup,
+      groups,
+    ] = await Promise.all([
+      countActiveWorkingTerritories(db),
+      countDelayedWorkingTerritories(db),
+      countRestingTerritories(db),
+      countAvailableTerritories(db),
+      computeTerritoryCoverage(
+        db,
+        filterParams.territoryKind,
+        filterParams.attributionKind,
+        filterParams.startDate,
+        filterParams.endDate,
+      ),
+      computeTerritoryCoverageTotal(
+        db,
+        filterParams.territoryKind,
+        filterParams.attributionKind.length > 0
+          ? filterParams.attributionKind
+          : [TerritoryAttributionKind.Default, TerritoryAttributionKind.Campaign],
+        filterParams.startDate,
+        filterParams.endDate,
+      ),
+      fetchAttributionsForStats(db, filterParams),
+      fetchAttributionsForStats(db, prevParams),
+      fetchTerritoryCounts(db, filterParams.territoryKind),
+      fetchTerritoryCounts(db),
+      getTerritoriesNeverWorked(db, filterParams),
+      fetchActiveAttributionsByGroup(db),
+      getGroups(db),
+    ])
+
+    const workingTerritoriesCount = activeWorkingTerritoriesCount + delayedWorkingTerritoriesCount
+    const unavailableTerritoriesCount = restingTerritoriesCount + workingTerritoriesCount
+    const territoriesCount = unavailableTerritoriesCount + availableTerritoriesCount
+
+    // Calculs synchrones à partir des données récupérées
+    const ranked = computeRankedTerritories(attributions)
+    const durationStats = computeDurationStats(attributions)
+    const overdueRate = computeOverdueRate(attributions)
+    const availabilityGap = computeAvailabilityGap(attributions)
+    const attributionsPerMonth = computeAttributionsPerMonth(attributions, filterParams.startDate, filterParams.endDate)
+    const monthlyCoverage = computeMonthlyCoverageEvolution(
+      attributions,
+      territoryCounts,
+      filterParams.startDate,
+      filterParams.endDate,
+    )
+    const coverageByType = computeCoverageByTerritoryType(attributions, allTerritoryCounts)
+    const restUtilization = computeRestPeriodUtilization(attributions)
+
+    // Métriques de l'année précédente pour la comparaison
+    const prevDuration = computeDurationStats(prevAttributions)
+    const prevOverdueRate = computeOverdueRate(prevAttributions)
+    const prevTotalCount = getTotalTerritoryCount(territoryCounts)
+    const prevTouchedTerritories = new Set(prevAttributions.map(a => a.territoryId))
+    const prevCoverage = prevTotalCount > 0 ? (prevAttributions.length / prevTotalCount) * 100 : 0
+    const prevTotalCoverage = prevTotalCount > 0 ? (prevTouchedTerritories.size / prevTotalCount) * 100 : 0
+
+    return {
+      stats: {
+        total: territoriesCount,
+        available: availableTerritoriesCount,
+        unavailable: unavailableTerritoriesCount,
+        resting: restingTerritoriesCount,
+        working: workingTerritoriesCount,
+        active: activeWorkingTerritoriesCount,
+        delayed: delayedWorkingTerritoriesCount,
         coverage: percentageCovered,
         totalCoverage: percentageTotallyCovered,
-        averageDurationDays: durationStats.averageDays,
+      },
+      progression: {
+        ranked,
+        durationStats,
         overdueRate,
-        attributionCount: attributions.length,
+        availabilityGap,
+        attributionsPerMonth,
+        restUtilization,
       },
-      previous: {
-        coverage: prevCoverage,
-        totalCoverage: prevTotalCoverage,
-        averageDurationDays: prevDuration.averageDays,
-        overdueRate: prevOverdueRate,
-        attributionCount: prevAttributions.length,
+      coverageOverTime: {
+        monthlyCoverage,
+        coverageByType,
+        neverWorked,
       },
-    },
-    attributionsByGroup,
-    theocraticYear,
-    groups,
-  }
+      yearOverYear: {
+        current: {
+          coverage: percentageCovered,
+          totalCoverage: percentageTotallyCovered,
+          averageDurationDays: durationStats.averageDays,
+          overdueRate,
+          attributionCount: attributions.length,
+        },
+        previous: {
+          coverage: prevCoverage,
+          totalCoverage: prevTotalCoverage,
+          averageDurationDays: prevDuration.averageDays,
+          overdueRate: prevOverdueRate,
+          attributionCount: prevAttributions.length,
+        },
+      },
+      attributionsByGroup,
+      theocraticYear,
+      groups,
+    }
+  })
 }
 
 const PIE_COLORS = ['var(--color-chart-1)', 'var(--color-chart-2)', 'var(--color-chart-4)', 'var(--color-chart-3)']

--- a/app/features/territories/routes/territory/delete.tsx
+++ b/app/features/territories/routes/territory/delete.tsx
@@ -2,6 +2,7 @@ import { Form, redirect } from 'react-router'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { Button } from '~/shared/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
@@ -9,20 +10,27 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/u
 import type { Route } from './+types/delete'
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const territory = await db.territory.findUnique({ where: { id: requireParamId(params.territoryId, '/territories') } })
+  return withScope(congregationId, async db => {
+    const territory = await db.territory.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.territoryId, '/territories'), congregationId },
+      },
+    })
 
-  if (territory == null) {
-    throw redirect('/territories')
-  }
+    if (territory == null) {
+      throw redirect('/territories')
+    }
 
-  return { territory }
+    return { territory }
+  })
 }
 
 export default function DeleteTerritory({ loaderData }: Route.ComponentProps) {
@@ -52,20 +60,27 @@ export default function DeleteTerritory({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const territory = await db.territory.delete({ where: { id: requireParamId(params.territoryId, '/territories') } })
+  return withScope(congregationId, async db => {
+    const territory = await db.territory.delete({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.territoryId, '/territories'), congregationId },
+      },
+    })
 
-  session.flash('success', `Le territoire nº${territory.number} a été correctement supprimé`)
+    session.flash('success', `Le territoire nº${territory.number} a été correctement supprimé`)
 
-  return redirect('/territories', {
-    headers: {
-      'Set-Cookie': await commitSession(session),
-    },
+    return redirect('/territories', {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
   })
 }

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -16,6 +16,7 @@ import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
@@ -31,75 +32,79 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
     throw redirect('/')
   }
 
-  const territory = await db.territory.findUnique({
-    where: {
-      id: requireParamId(params.territoryId, '/territories'),
-    },
-    include: {
-      entrances: { include: { buildings: { where: { active: true } } } },
-      attributions: { where: { endDate: null }, include: { publisher: true } },
-    },
-  })
-
-  if (territory == null) {
-    throw redirect('/territories', {
-      status: 404,
-    })
-  }
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const zips = await getAvailableZips(db, territory.type as TerritoryKind)
-  const url = new URL(request.url)
-  const entrances = await getAvailableEntrances(
-    db,
-    String(url.searchParams.get('zip')),
-    String(url.searchParams.get('street')),
-    territory.type as TerritoryKind,
-  )
+  return withScope(congregationId, async db => {
+    const territory = await db.territory.findUnique({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.territoryId, '/territories'), congregationId },
+      },
+      include: {
+        entrances: { include: { buildings: { where: { active: true } } } },
+        attributions: { where: { endDate: null }, include: { publisher: true } },
+      },
+    })
 
-  if (!url.searchParams.has('zip')) {
-    return {
-      zips,
-      territoryEntrances: territory.entrances.map(aggregateEntrance),
-      entrances: entrances.map(aggregateEntrance),
-      streets: [],
-      territory,
-      googleMaps: { mapId, apiKey },
-      phoneTypeActive,
+    if (territory == null) {
+      throw redirect('/territories', {
+        status: 404,
+      })
     }
-  }
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const streets = await getAvailableStreets(db, String(url.searchParams.get('zip')), territory.type as TerritoryKind)
-  if (!url.searchParams.has('street')) {
+    const zips = await getAvailableZips(db, territory.type as TerritoryKind)
+    const url = new URL(request.url)
+    const entrances = await getAvailableEntrances(
+      db,
+      String(url.searchParams.get('zip')),
+      String(url.searchParams.get('street')),
+      territory.type as TerritoryKind,
+    )
+
+    if (!url.searchParams.has('zip')) {
+      return {
+        zips,
+        territoryEntrances: territory.entrances.map(aggregateEntrance),
+        entrances: entrances.map(aggregateEntrance),
+        streets: [],
+        territory,
+        googleMaps: { mapId, apiKey },
+        phoneTypeActive,
+      }
+    }
+
+    const streets = await getAvailableStreets(db, String(url.searchParams.get('zip')), territory.type as TerritoryKind)
+    if (!url.searchParams.has('street')) {
+      return {
+        territory,
+        zips,
+        territoryEntrances: territory.entrances.map(aggregateEntrance),
+        entrances: entrances.map(aggregateEntrance),
+        streets,
+        googleMaps: { mapId, apiKey },
+        phoneTypeActive,
+      }
+    }
+
     return {
       territory,
-      zips,
       territoryEntrances: territory.entrances.map(aggregateEntrance),
       entrances: entrances.map(aggregateEntrance),
+      zips,
       streets,
       googleMaps: { mapId, apiKey },
       phoneTypeActive,
     }
-  }
-
-  return {
-    territory,
-    territoryEntrances: territory.entrances.map(aggregateEntrance),
-    entrances: entrances.map(aggregateEntrance),
-    zips,
-    streets,
-    googleMaps: { mapId, apiKey },
-    phoneTypeActive,
-  }
+  })
 }
 export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) {
   const {
@@ -293,7 +298,7 @@ export default function EditTerritoryPage({ loaderData }: Route.ComponentProps) 
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -304,17 +309,20 @@ export async function action({ request, params }: Route.ActionArgs) {
   const entrances = form.getAll('entrances')
   const notes = form.get('notes')
 
-  await db.territory.update({
-    where: {
-      id: requireParamId(params.territoryId, '/territories'),
-    },
-    data: {
-      entrances: {
-        set: entrances.map(el => ({ id: Number(el) })),
+  return withScope(congregationId, async db => {
+    await db.territory.update({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound key
+        id_congregationId: { id: requireParamId(params.territoryId, '/territories'), congregationId },
       },
-      notes: String(notes),
-    },
-  })
+      data: {
+        entrances: {
+          set: entrances.map(el => ({ id: Number(el) })),
+        },
+        notes: String(notes),
+      },
+    })
 
-  return redirect('/territories')
+    return redirect('/territories')
+  })
 }

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -11,6 +11,7 @@ import { computeFilters } from '~/features/territories/server/territory-filters'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
 import TerritoryFilters from '~/features/territories/ui/TerritoryFilters'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 import { AlertMessages } from '~/shared/ui/AlertMessages'
@@ -28,7 +29,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { session, can, db } = await authenticateAndAuthorize(request, [
+  const { session, can, congregationId } = await authenticateAndAuthorize(request, [
     Role.TerritoriesViewer,
     Role.TerritoriesManager,
   ])
@@ -40,39 +41,42 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const canManageTerritories = can(Role.TerritoriesManager)
 
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
 
-  const url = new URL(request.url)
-  const selectors = await computeFilters(url.searchParams)
-  const { territories, pagination } = await findTerritoriesWithDetailsPaginated(db, selectors, url)
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  const messages = {
-    success: session.get('success'),
-    error: session.get('error'),
-  }
-  const zips = await getZips(db)
+    const url = new URL(request.url)
+    const selectors = await computeFilters(url.searchParams)
+    const { territories, pagination } = await findTerritoriesWithDetailsPaginated(db, selectors, url)
 
-  return data(
-    {
-      messages,
-      zips,
-      stats: {
-        total: pagination.total,
+    const messages = {
+      success: session.get('success'),
+      error: session.get('error'),
+    }
+    const zips = await getZips(db)
+
+    return data(
+      {
+        messages,
+        zips,
+        stats: {
+          total: pagination.total,
+        },
+        territories,
+        pagination,
+        googleMaps: { mapId, apiKey },
+        canManageTerritories,
+        phoneTypeActive,
       },
-      territories,
-      pagination,
-      googleMaps: { mapId, apiKey },
-      canManageTerritories,
-      phoneTypeActive,
-    },
-    {
-      headers: {
-        'Set-Cookie': await commitSession(session),
+      {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
       },
-    },
-  )
+    )
+  })
 }
 
 export default function TerritoryListPage({ loaderData }: Route.ComponentProps) {

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -8,6 +8,7 @@ import { aggregateEntrance } from '~/features/territories/server/buildings'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import BuildingSelector from '~/features/territories/ui/BuildingSelector'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { LimitService } from '~/shared/libs/limits.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
@@ -24,7 +25,7 @@ export const meta: Route.MetaFunction = () => {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -32,39 +33,42 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
-  const url = new URL(request.url)
-  const zips = await db.building.groupBy({
-    by: ['zip'],
-    where: { active: true },
+
+  return withScope(congregationId, async db => {
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const url = new URL(request.url)
+    const zips = await db.building.groupBy({
+      by: ['zip'],
+      where: { active: true },
+    })
+
+    const buildings = await db.building.findMany({
+      where: {
+        active: true,
+        street: String(url.searchParams.get('street')),
+        zip: String(url.searchParams.get('zip')),
+      },
+      select: { entrance: { include: { buildings: true } } },
+    })
+    const entrances = buildings
+      .map(building => building.entrance)
+      .filter(entrance => entrance !== null)
+      .map(aggregateEntrance)
+    if (!url.searchParams.has('zip')) {
+      return { zips, buildings: [], streets: [], phoneTypeActive, entrances }
+    }
+
+    const streets = await db.building.groupBy({
+      by: ['street'],
+      where: { active: true, zip: String(url.searchParams.get('zip')) },
+    })
+
+    if (!url.searchParams.has('street')) {
+      return { zips, buildings: [], streets, phoneTypeActive, entrances }
+    }
+
+    return { entrances, zips, streets, phoneTypeActive, apiKey }
   })
-
-  const buildings = await db.building.findMany({
-    where: {
-      active: true,
-      street: String(url.searchParams.get('street')),
-      zip: String(url.searchParams.get('zip')),
-    },
-    select: { entrance: { include: { buildings: true } } },
-  })
-  const entrances = buildings
-    .map(building => building.entrance)
-    .filter(entrance => entrance !== null)
-    .map(aggregateEntrance)
-  if (!url.searchParams.has('zip')) {
-    return { zips, buildings: [], streets: [], phoneTypeActive, entrances }
-  }
-
-  const streets = await db.building.groupBy({
-    by: ['street'],
-    where: { active: true, zip: String(url.searchParams.get('zip')) },
-  })
-
-  if (!url.searchParams.has('street')) {
-    return { zips, buildings: [], streets, phoneTypeActive, entrances }
-  }
-
-  return { entrances, zips, streets, phoneTypeActive, apiKey }
 }
 
 export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
@@ -154,7 +158,7 @@ export default function NewTerritoryPage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, can, db } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
+  const { congregation, can, congregationId } = await authenticateAndAuthorize(request, [Role.TerritoriesManager])
   const canManageTerritories = can(Role.TerritoriesManager)
 
   if (!canManageTerritories) {
@@ -170,19 +174,21 @@ export async function action({ request }: Route.ActionArgs) {
     throw redirect('/territories/territory/new')
   }
 
-  const limits = new LimitService(db, congregation)
-  await limits.errorIfWouldGoOverLimit('territories')
+  return withScope(congregationId, async db => {
+    const limits = new LimitService(db, congregation)
+    await limits.errorIfWouldGoOverLimit('territories')
 
-  await db.territory.create({
-    data: {
-      number: String(number),
-      type: String(type),
-      entrances: {
-        connect: entrances.map(el => ({ id: Number(el) })),
+    await db.territory.create({
+      data: {
+        number: String(number),
+        type: String(type),
+        entrances: {
+          connect: entrances.map(el => ({ id: Number(el) })),
+        },
+        congregationId: congregation.id,
       },
-      congregationId: congregation.id,
-    },
-  })
+    })
 
-  return redirect('/territories')
+    return redirect('/territories')
+  })
 }

--- a/app/features/territories/routes/territory/view.tsx
+++ b/app/features/territories/routes/territory/view.tsx
@@ -12,6 +12,7 @@ import { AttributionStatus } from '~/features/territories/ui/AttributionStatus'
 import BuildingEntranceMap from '~/features/territories/ui/BuildingEntranceMap'
 import { TerritoryDownloadLink } from '~/features/territories/ui/TerritoryDownloadLink'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
+import { withScope } from '~/shared/libs/db.server'
 import { getOptionalEnv } from '~/shared/libs/env.server'
 import { requireParamId } from '~/shared/libs/params.server'
 import { TerritorySettingKey } from '~/shared/types/territory-setting-key'
@@ -28,7 +29,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const { can, db } = await authenticateAndAuthorize(request, [
+  const { can, congregationId } = await authenticateAndAuthorize(request, [
     Role.TerritoriesViewer,
     Role.TerritoriesManager,
     Role.PublisherViewer,
@@ -41,24 +42,30 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  const territory = await findTerritoryWithHistory(db, requireParamId(params.territoryId, '/territories'))
+  return withScope(congregationId, async db => {
+    const territory = await findTerritoryWithHistory(
+      db,
+      requireParamId(params.territoryId, '/territories'),
+      congregationId,
+    )
 
-  if (territory == null) {
-    throw redirect('/territories', { status: 404 })
-  }
+    if (territory == null) {
+      throw redirect('/territories', { status: 404 })
+    }
 
-  const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
-  const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
-  const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
+    const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
 
-  return {
-    territory,
-    territoryEntrances: territory.entrances.map(aggregateEntrance),
-    googleMaps: { mapId, apiKey },
-    phoneTypeActive,
-    canManageTerritories,
-    canViewPublisher,
-  }
+    return {
+      territory,
+      territoryEntrances: territory.entrances.map(aggregateEntrance),
+      googleMaps: { mapId, apiKey },
+      phoneTypeActive,
+      canManageTerritories,
+      canViewPublisher,
+    }
+  })
 }
 
 const territoryTypeLabels: Record<string, string> = {

--- a/app/features/territories/server/active-working-territories.server.ts
+++ b/app/features/territories/server/active-working-territories.server.ts
@@ -1,6 +1,6 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function countActiveWorkingTerritories(db: ScopedDb) {
+export async function countActiveWorkingTerritories(db: TransactionClient) {
   return await db.territory.count({
     where: {
       attributions: {

--- a/app/features/territories/server/attributions.server.test.ts
+++ b/app/features/territories/server/attributions.server.test.ts
@@ -26,11 +26,11 @@ describe('findActiveAttributionsForPublisher', () => {
     ]
     vi.mocked(db.attribution.findMany).mockResolvedValue(fakeAttributions as never)
 
-    const result = await findActiveAttributionsForPublisher(db, 42)
+    const result = await findActiveAttributionsForPublisher(db as never, 42, 1)
 
     expect(result).toEqual(fakeAttributions)
     expect(db.attribution.findMany).toHaveBeenCalledWith({
-      where: { publisherId: 42, endDate: null },
+      where: { publisherId: 42, endDate: null, congregationId: 1 },
       include: { territory: true },
       orderBy: [{ startDate: 'asc' }],
     })
@@ -39,7 +39,7 @@ describe('findActiveAttributionsForPublisher', () => {
   it("retourne un tableau vide quand le proclamateur n'a pas d'attribution", async () => {
     vi.mocked(db.attribution.findMany).mockResolvedValue([])
 
-    const result = await findActiveAttributionsForPublisher(db, 99)
+    const result = await findActiveAttributionsForPublisher(db as never, 99, 1)
 
     expect(result).toEqual([])
   })
@@ -58,11 +58,14 @@ describe('findTerritoryWithHistory', () => {
     }
     vi.mocked(db.territory.findUnique).mockResolvedValue(fakeTerritory as never)
 
-    const result = await findTerritoryWithHistory(db, 10)
+    const result = await findTerritoryWithHistory(db as never, 10, 1)
 
     expect(result).toEqual(fakeTerritory)
     expect(db.territory.findUnique).toHaveBeenCalledWith({
-      where: { id: 10 },
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        id_congregationId: { id: 10, congregationId: 1 },
+      },
       include: {
         entrances: { include: { buildings: { where: { active: true } } } },
         attributions: {
@@ -76,7 +79,7 @@ describe('findTerritoryWithHistory', () => {
   it("retourne null quand le territoire n'existe pas", async () => {
     vi.mocked(db.territory.findUnique).mockResolvedValue(null)
 
-    const result = await findTerritoryWithHistory(db, 999)
+    const result = await findTerritoryWithHistory(db as never, 999, 1)
 
     expect(result).toBeNull()
   })

--- a/app/features/territories/server/attributions.ts
+++ b/app/features/territories/server/attributions.ts
@@ -1,8 +1,12 @@
 import type { Prisma } from '~/database/generated/client'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 
-export async function findActiveAttributionsPaginated(db: ScopedDb, selectors: Prisma.AttributionWhereInput, url: URL) {
+export async function findActiveAttributionsPaginated(
+  db: TransactionClient,
+  selectors: Prisma.AttributionWhereInput,
+  url: URL,
+) {
   const total = await db.attribution.count({ where: selectors })
   const pagination = paginationFromUrl(url, total)
 
@@ -17,17 +21,20 @@ export async function findActiveAttributionsPaginated(db: ScopedDb, selectors: P
   return { attributions, pagination }
 }
 
-export function findActiveAttributionsForPublisher(db: ScopedDb, publisherId: number) {
+export function findActiveAttributionsForPublisher(db: TransactionClient, publisherId: number, congregationId: number) {
   return db.attribution.findMany({
-    where: { publisherId, endDate: null },
+    where: { publisherId, endDate: null, congregationId },
     include: { territory: true },
     orderBy: [{ startDate: 'asc' }],
   })
 }
 
-export function findTerritoryWithHistory(db: ScopedDb, territoryId: number) {
+export function findTerritoryWithHistory(db: TransactionClient, territoryId: number, congregationId: number) {
   return db.territory.findUnique({
-    where: { id: territoryId },
+    where: {
+      // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+      id_congregationId: { id: territoryId, congregationId },
+    },
     include: {
       entrances: { include: { buildings: { where: { active: true } } } },
       attributions: {

--- a/app/features/territories/server/available-territories.server.ts
+++ b/app/features/territories/server/available-territories.server.ts
@@ -1,12 +1,12 @@
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import {
   RESTING_PERIOD_FOR_CAMPAIGN,
   RESTING_PERIOD_FOR_DOORS_TO_DOORS,
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countAvailableTerritories(db: ScopedDb) {
+export async function countAvailableTerritories(db: TransactionClient) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()

--- a/app/features/territories/server/buildings.ts
+++ b/app/features/territories/server/buildings.ts
@@ -1,6 +1,6 @@
 import type { Building, Prisma } from '~/database/generated/client'
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 import type { AggregatedEntrance, Entrance } from '~/shared/types/entrance'
 
@@ -27,7 +27,7 @@ function sortEntrancesByAddress(entrances: Entrance[]) {
   return entrances
 }
 
-export async function findBuildingsPaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findBuildingsPaginated(db: TransactionClient, selectors: Prisma.BuildingWhereInput, url: URL) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -43,7 +43,11 @@ export async function findBuildingsPaginated(db: ScopedDb, selectors: Prisma.Bui
   return { buildings, pagination }
 }
 
-export async function findBuildingsWithEntrancePaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findBuildingsWithEntrancePaginated(
+  db: TransactionClient,
+  selectors: Prisma.BuildingWhereInput,
+  url: URL,
+) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -60,7 +64,7 @@ export async function findBuildingsWithEntrancePaginated(db: ScopedDb, selectors
   return { buildings, pagination }
 }
 
-export async function findEntrancesPaginated(db: ScopedDb, selectors: Prisma.BuildingWhereInput, url: URL) {
+export async function findEntrancesPaginated(db: TransactionClient, selectors: Prisma.BuildingWhereInput, url: URL) {
   const totalBuildings = await db.building.count({ where: selectors })
   const pagination = paginationFromUrl(url, totalBuildings)
 
@@ -78,7 +82,7 @@ export async function findEntrancesPaginated(db: ScopedDb, selectors: Prisma.Bui
   return { entrances: sortEntrancesByAddress(entrances), pagination }
 }
 
-export async function getProspectionStaleDate(db: ScopedDb): Promise<Date> {
+export async function getProspectionStaleDate(db: TransactionClient): Promise<Date> {
   const prospectionValidity = Number(
     (await db.setting.findFirst({ where: { key: 'prospection-validity' } }))?.value ?? '0',
   )
@@ -112,7 +116,7 @@ export function aggregateEntrance(entrance: Entrance): AggregatedEntrance {
   }
 }
 
-export async function getZips(db: ScopedDb, territoryType?: TerritoryKind) {
+export async function getZips(db: TransactionClient, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (territoryType != null) {
@@ -128,7 +132,7 @@ export async function getZips(db: ScopedDb, territoryType?: TerritoryKind) {
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getAvailableZips(db: ScopedDb, territoryType?: TerritoryKind) {
+export async function getAvailableZips(db: TransactionClient, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (territoryType != null) {
@@ -144,7 +148,7 @@ export async function getAvailableZips(db: ScopedDb, territoryType?: TerritoryKi
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getStreets(db: ScopedDb, zip?: string, territoryType?: TerritoryKind) {
+export async function getStreets(db: TransactionClient, zip?: string, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {
@@ -164,7 +168,7 @@ export async function getStreets(db: ScopedDb, zip?: string, territoryType?: Ter
   return await db.building.groupBy({ by: 'street', where: selectors })
 }
 
-export async function getAvailableStreets(db: ScopedDb, zip?: string, territoryType?: TerritoryKind) {
+export async function getAvailableStreets(db: TransactionClient, zip?: string, territoryType?: TerritoryKind) {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {
@@ -184,7 +188,7 @@ export async function getAvailableStreets(db: ScopedDb, zip?: string, territoryT
 }
 
 export async function getEntrances(
-  db: ScopedDb,
+  db: TransactionClient,
   zip?: string,
   street?: string,
   territoryType?: TerritoryKind,
@@ -219,7 +223,7 @@ export async function getEntrances(
 }
 
 export async function getAvailableEntrances(
-  db: ScopedDb,
+  db: TransactionClient,
   zip?: string,
   street?: string,
   territoryType?: TerritoryKind,
@@ -253,14 +257,14 @@ export async function getAvailableEntrances(
   return buildings.map(building => building.entrance).filter(entrance => entrance != null)
 }
 
-export async function getEntrance(db: ScopedDb, entranceId: number): Promise<Entrance | null> {
+export async function getEntrance(db: TransactionClient, entranceId: number): Promise<Entrance | null> {
   return await db.buildingEntrance.findUnique({
     where: { id: entranceId },
     include: { buildings: true },
   })
 }
 
-export async function getBuilding(db: ScopedDb, buildingId: number): Promise<Building | null> {
+export async function getBuilding(db: TransactionClient, buildingId: number): Promise<Building | null> {
   return await db.building.findUnique({
     where: { id: buildingId },
     include: { entrance: { include: { buildings: true } } },

--- a/app/features/territories/server/create-building.server.ts
+++ b/app/features/territories/server/create-building.server.ts
@@ -1,10 +1,10 @@
 import type { DetailedBuilding } from '~/features/territories/model/detailed-building.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 import { getTerritoryPolygon } from './get-territory-polygon.server'
 
 export async function createBuilding(
-  db: ScopedDb,
+  db: TransactionClient,
   {
     address,
     coordinates = {},

--- a/app/features/territories/server/delayed-working-territories.server.ts
+++ b/app/features/territories/server/delayed-working-territories.server.ts
@@ -1,6 +1,6 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function countDelayedWorkingTerritories(db: ScopedDb) {
+export async function countDelayedWorkingTerritories(db: TransactionClient) {
   return await db.territory.count({
     where: {
       attributions: {

--- a/app/features/territories/server/edit-building.server.ts
+++ b/app/features/territories/server/edit-building.server.ts
@@ -2,11 +2,11 @@ import type { Building } from '~/database/generated/client'
 
 import { getTerritoryPolygon } from '~/features/territories/server/get-territory-polygon.server'
 
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 
 export async function editBuilding(
-  db: ScopedDb,
+  db: TransactionClient,
   buildingId: number,
   {
     address,

--- a/app/features/territories/server/fetch-attributions-by-group.server.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.ts
@@ -1,4 +1,4 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 export interface AttributionsByGroup {
   groupName: string
@@ -6,7 +6,7 @@ export interface AttributionsByGroup {
 }
 
 // Compte les attributions actives (en cours) regroupées par groupe de prédication
-export async function fetchActiveAttributionsByGroup(db: ScopedDb): Promise<AttributionsByGroup[]> {
+export async function fetchActiveAttributionsByGroup(db: TransactionClient): Promise<AttributionsByGroup[]> {
   const attributions = await db.attribution.findMany({
     where: { endDate: null },
     select: {

--- a/app/features/territories/server/fetch-attributions-for-stats.server.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from '~/database/generated/client'
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import type { StatsAttribution } from './stats-attribution.type'
 import type { StatsFilterParams } from './stats-filter-params.type'
 
@@ -12,7 +12,10 @@ function buildDateOverlapWhere(startDate: Date, endDate: Date): Prisma.Attributi
   }
 }
 
-export async function fetchAttributionsForStats(db: ScopedDb, params: StatsFilterParams): Promise<StatsAttribution[]> {
+export async function fetchAttributionsForStats(
+  db: TransactionClient,
+  params: StatsFilterParams,
+): Promise<StatsAttribution[]> {
   const attributions = await db.attribution.findMany({
     where: {
       territory: {

--- a/app/features/territories/server/fetch-open-data.server.ts
+++ b/app/features/territories/server/fetch-open-data.server.ts
@@ -1,9 +1,9 @@
 import { Readable } from 'node:stream'
 import type { ReadableStream } from 'node:stream/web'
 import { parse } from 'csv'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function fetchOpenData(db: ScopedDb) {
+export async function fetchOpenData(db: TransactionClient) {
   const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
   if (!banoUrl?.value || banoUrl.value === '') {
     return new Readable().pipe(parse({ delimiter: ',' }))

--- a/app/features/territories/server/fetch-territory-counts.server.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.ts
@@ -1,12 +1,12 @@
 import type { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import type { TerritoryCountByType } from './territory-count-by-type.type'
 
 export type { TerritoryCountByType } from './territory-count-by-type.type'
 export { getTotalTerritoryCount } from './territory-count-by-type.type'
 
 export async function fetchTerritoryCounts(
-  db: ScopedDb,
+  db: TransactionClient,
   territoryKinds?: TerritoryKind[],
 ): Promise<TerritoryCountByType[]> {
   const groups = await db.territory.groupBy({

--- a/app/features/territories/server/get-building-details.server.ts
+++ b/app/features/territories/server/get-building-details.server.ts
@@ -1,7 +1,7 @@
 import type { DetailedBuilding } from '~/features/territories/model/detailed-building.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getBuildingDetails(db: ScopedDb, buildingId: number): Promise<DetailedBuilding | null> {
+export async function getBuildingDetails(db: TransactionClient, buildingId: number): Promise<DetailedBuilding | null> {
   return await db.building.findUnique({
     where: { id: buildingId },
     include: {

--- a/app/features/territories/server/get-buildings.server.ts
+++ b/app/features/territories/server/get-buildings.server.ts
@@ -1,8 +1,8 @@
 import type { Building, Prisma } from '~/database/generated/client'
 
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getBuildings(db: ScopedDb, zip: string, street: string): Promise<Building[]> {
+export async function getBuildings(db: TransactionClient, zip: string, street: string): Promise<Building[]> {
   const selectors: Prisma.BuildingWhereInput = { active: true }
 
   if (zip != null) {

--- a/app/features/territories/server/get-territory-polygon.server.ts
+++ b/app/features/territories/server/get-territory-polygon.server.ts
@@ -1,6 +1,6 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getTerritoryPolygon(db: ScopedDb): Promise<[number, number][]> {
+export async function getTerritoryPolygon(db: TransactionClient): Promise<[number, number][]> {
   const territory = await db.setting.findFirst({
     where: { key: 'territory' },
   })

--- a/app/features/territories/server/handle-sync-work.server.ts
+++ b/app/features/territories/server/handle-sync-work.server.ts
@@ -1,6 +1,6 @@
 import type { Job } from 'bullmq'
 import { resolveCongregation } from '~/shared/libs/congregation.server'
-import { congregationContext, createScopedDb } from '~/shared/libs/db.server'
+import { withScope } from '~/shared/libs/db.server'
 import { createLogger } from '~/shared/libs/logger.server'
 import { importOpenData } from './import-open-data.server'
 import { sendMailAfterDataSync } from './send-mail-after-data-sync.server'
@@ -11,21 +11,19 @@ const logger = createLogger('sync-worker')
 export async function handleSyncWork(job: Job<SyncJobData>): Promise<void> {
   const { userEmail, userName, congregationId } = job.data
 
-  // Set congregation context for tenant-scoped queries during the job
   const congregation = await resolveCongregation(congregationId)
-  congregationContext.enterWith({ congregationId, congregation })
-
-  const db = createScopedDb(congregationId)
 
   try {
     await job.updateProgress(0)
     logger.info(`Starting sync job ${job.id}`, { userEmail, congregationId })
 
-    await importOpenData(db, congregationId, (percent: number) => {
-      logger.info(`Sync job ${job.id} progress: ${percent}%`, { userEmail })
-      if (percent < 99) {
-        job.updateProgress(percent)
-      }
+    await withScope(congregationId, async db => {
+      await importOpenData(db, congregationId, (percent: number) => {
+        logger.info(`Sync job ${job.id} progress: ${percent}%`, { userEmail })
+        if (percent < 99) {
+          job.updateProgress(percent)
+        }
+      })
     })
 
     await sendMailAfterDataSync(userEmail, userName, congregation)

--- a/app/features/territories/server/import-open-data.server.ts
+++ b/app/features/territories/server/import-open-data.server.ts
@@ -1,12 +1,12 @@
 import { getAllowedZips } from '~/features/territories/server/settings'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { pointInPolygon } from '~/shared/libs/point-in-polygon.server'
 
 import { fetchOpenData } from './fetch-open-data.server'
 import { getTerritoryPolygon } from './get-territory-polygon.server'
 
 export async function importOpenData(
-  db: ScopedDb,
+  db: TransactionClient,
   congregationId: number,
   progressCallback: (percent: number) => void = () => {},
 ) {

--- a/app/features/territories/server/resting-territories.server.ts
+++ b/app/features/territories/server/resting-territories.server.ts
@@ -1,12 +1,12 @@
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import {
   RESTING_PERIOD_FOR_CAMPAIGN,
   RESTING_PERIOD_FOR_DOORS_TO_DOORS,
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countRestingTerritories(db: ScopedDb) {
+export async function countRestingTerritories(db: TransactionClient) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()

--- a/app/features/territories/server/set-building-notes.server.ts
+++ b/app/features/territories/server/set-building-notes.server.ts
@@ -1,9 +1,9 @@
 import type { Building } from '~/database/generated/client'
 
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 export function setBuildingNotes(
-  db: ScopedDb,
+  db: TransactionClient,
   buildingId: number,
   { notes, importantNotes }: { notes: string; importantNotes: string },
 ): Promise<Building> {

--- a/app/features/territories/server/set-building-prospection-data.server.ts
+++ b/app/features/territories/server/set-building-prospection-data.server.ts
@@ -1,7 +1,11 @@
 import type { Building, Prisma } from '~/database/generated/client'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
-export function setBuildingProspectionData(db: ScopedDb, buildingId: number, formData: FormData): Promise<Building> {
+export function setBuildingProspectionData(
+  db: TransactionClient,
+  buildingId: number,
+  formData: FormData,
+): Promise<Building> {
   const data: Prisma.BuildingUpdateInput = {}
 
   data.homes = formData.get('homes') ? Number(formData.get('homes')) : null

--- a/app/features/territories/server/settings.ts
+++ b/app/features/territories/server/settings.ts
@@ -1,4 +1,4 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 export function parseTerritoryPolygon(text: string): [number, number][] {
   return text.split(',').map(coord =>
@@ -22,7 +22,7 @@ export function serializeZips(zips: string[]) {
   return zips.join(', ')
 }
 
-export async function getAllowedZips(db: ScopedDb): Promise<string[]> {
+export async function getAllowedZips(db: TransactionClient): Promise<string[]> {
   const zips = await db.setting.findFirst({
     where: { key: 'zips' },
   })

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -27,17 +27,17 @@ describe('getTerritoriesExportData', () => {
     const fakeTerritories = [{ id: 1, attributions: [] }]
     vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories as never)
 
-    const result = await getTerritoriesExportData(db as any, 2025)
+    const result = await getTerritoriesExportData(db as never, 2025)
     expect(result).toEqual(fakeTerritories)
   })
 
   it("retourne un tableau vide quand il n'y a pas de territoires", async () => {
-    const result = await getTerritoriesExportData(db as any, 2025)
+    const result = await getTerritoriesExportData(db as never, 2025)
     expect(result).toEqual([])
   })
 
   it("passe l'année théocratique aux fonctions de date", async () => {
-    await getTerritoriesExportData(db as any, 2024)
+    await getTerritoriesExportData(db as never, 2024)
 
     // Vérifier que les fonctions de date ont été utilisées (via le résultat)
     expect(vi.mocked(getBeginingDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
@@ -45,7 +45,7 @@ describe('getTerritoriesExportData', () => {
   })
 
   it('inclut les attributions anciennes encore actives (sans date de fin)', async () => {
-    await getTerritoriesExportData(db as any, 2025)
+    await getTerritoriesExportData(db as never, 2025)
 
     const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as Record<string, unknown>
     const attrWhere = (call.include as { attributions: { where: Record<string, unknown> } }).attributions.where

--- a/app/features/territories/server/territories-export-data.server.ts
+++ b/app/features/territories/server/territories-export-data.server.ts
@@ -1,7 +1,7 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } from './theocratic-year.server'
 
-export async function getTerritoriesExportData(db: ScopedDb, theocraticYear?: number) {
+export async function getTerritoriesExportData(db: TransactionClient, theocraticYear?: number) {
   const startDate = getBeginingDateOfTheocraticYear(theocraticYear)
   const endDate = getEndDateOfTheocraticYear(theocraticYear)
 

--- a/app/features/territories/server/territories-never-worked.server.ts
+++ b/app/features/territories/server/territories-never-worked.server.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '~/database/generated/client'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import type { StatsFilterParams } from './stats-filter-params.type'
 
 export interface NeverWorkedTerritory {
@@ -8,7 +8,7 @@ export interface NeverWorkedTerritory {
 }
 
 export async function getTerritoriesNeverWorked(
-  db: ScopedDb,
+  db: TransactionClient,
   params: StatsFilterParams,
 ): Promise<NeverWorkedTerritory[]> {
   const dateOverlap: Prisma.AttributionWhereInput = {

--- a/app/features/territories/server/territories.ts
+++ b/app/features/territories/server/territories.ts
@@ -1,9 +1,9 @@
 import type { Prisma } from '~/database/generated/client'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import { paginationFromUrl } from '~/shared/libs/pagination.server'
 
 export async function findTerritoriesWithDetailsPaginated(
-  db: ScopedDb,
+  db: TransactionClient,
   selectors: Prisma.TerritoryWhereInput,
   url: URL,
 ) {
@@ -23,7 +23,11 @@ export async function findTerritoriesWithDetailsPaginated(
   return { territories, pagination }
 }
 
-export async function findAvailableTerritoriesPaginated(db: ScopedDb, selectors: Prisma.TerritoryWhereInput, url: URL) {
+export async function findAvailableTerritoriesPaginated(
+  db: TransactionClient,
+  selectors: Prisma.TerritoryWhereInput,
+  url: URL,
+) {
   const total = await db.territory.count({ where: selectors })
   const pagination = paginationFromUrl(url, total)
 

--- a/app/features/territories/server/territory-coverage-total.server.test.ts
+++ b/app/features/territories/server/territory-coverage-total.server.test.ts
@@ -48,7 +48,7 @@ describe('computeTerritoryCoverageTotal', () => {
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(3)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverageTotal(db as any, undefined, undefined, startDate)
+    const result = await computeTerritoryCoverageTotal(db as never, undefined, undefined, startDate)
     expect(result).toBe(30)
   })
 
@@ -57,7 +57,7 @@ describe('computeTerritoryCoverageTotal', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverageTotal(db as any, undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverageTotal(db as never, undefined, undefined, startDate, endDate)
     expect(result).toBe(70)
   })
 })

--- a/app/features/territories/server/territory-coverage-total.server.ts
+++ b/app/features/territories/server/territory-coverage-total.server.ts
@@ -1,10 +1,10 @@
 import type { Prisma } from '~/database/generated/client'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverageTotal(
-  db: ScopedDb,
+  db: TransactionClient,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,

--- a/app/features/territories/server/territory-coverage.server.test.ts
+++ b/app/features/territories/server/territory-coverage.server.test.ts
@@ -55,7 +55,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(5)
 
     const result = await computeTerritoryCoverage(
-      db as any,
+      db as never,
       [TerritoryKind.Phone, TerritoryKind.Classical],
       [TerritoryAttributionKind.Phone],
     )
@@ -78,7 +78,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(4)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverage(db as any, undefined, undefined, startDate)
+    const result = await computeTerritoryCoverage(db as never, undefined, undefined, startDate)
     expect(result).toBe(40)
   })
 
@@ -87,7 +87,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(6)
 
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(db as any, undefined, undefined, undefined, endDate)
+    const result = await computeTerritoryCoverage(db as never, undefined, undefined, undefined, endDate)
     expect(result).toBe(60)
   })
 
@@ -97,7 +97,7 @@ describe('computeTerritoryCoverage', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(db as any, undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverage(db as never, undefined, undefined, startDate, endDate)
     expect(result).toBe(80)
   })
 })

--- a/app/features/territories/server/territory-coverage.server.ts
+++ b/app/features/territories/server/territory-coverage.server.ts
@@ -1,10 +1,10 @@
 import type { Prisma } from '~/database/generated/client'
 import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverage(
-  db: ScopedDb,
+  db: TransactionClient,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,

--- a/app/features/territories/server/update-buildings-in-entrance.server.test.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.test.ts
@@ -8,7 +8,6 @@ vi.mock('~/shared/libs/db.server', () => ({
       createMany: vi.fn(),
       deleteMany: vi.fn(),
     },
-    $transaction: vi.fn(),
   },
 }))
 
@@ -24,6 +23,8 @@ const { db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
+  vi.mocked(db.buildingEntrance.update).mockResolvedValue({} as never)
+  vi.mocked(db.buildingEntrance.createMany).mockResolvedValue({} as never)
   vi.mocked(db.buildingEntrance.deleteMany).mockResolvedValue({ count: 0 } as never)
 })
 
@@ -33,12 +34,12 @@ describe('updateBuildingsInEntrance', () => {
 
     const sentinel = Symbol('sentinel')
     let result: unknown = sentinel
-    result = await updateBuildingsInEntrance(db, 999, [1, 2], 1)
+    result = await updateBuildingsInEntrance(db as never, 999, [1, 2], 1)
     expect(result).toBeUndefined()
     expect(result).not.toBe(sentinel)
   })
 
-  it('exécute la transaction pour connecter/déconnecter les bâtiments', async () => {
+  it('connecte et déconnecte les bâtiments directement', async () => {
     vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue({
       id: 10,
       access: 1,
@@ -49,22 +50,11 @@ describe('updateBuildingsInEntrance', () => {
       buildings: [{ id: 1 }, { id: 2 }, { id: 3 }],
     } as never)
 
-    // $transaction exécute le callback
-    vi.mocked(db.$transaction).mockImplementation((async (fn: (tx: unknown) => Promise<void>) => {
-      const tx = {
-        buildingEntrance: {
-          update: vi.fn().mockResolvedValue({} as never),
-          createMany: vi.fn().mockResolvedValue({} as never),
-        },
-      }
-      await fn(tx)
-    }) as never)
-
     // buildingIds [1, 4] → ajouter 4, déconnecter 2 et 3
-    await updateBuildingsInEntrance(db, 10, [1, 4], 1)
+    await updateBuildingsInEntrance(db as never, 10, [1, 4], 1)
 
-    // La transaction a été exécutée
-    expect(vi.mocked(db.$transaction).mock.calls).toHaveLength(1)
+    // update a été appelé pour connecter/déconnecter
+    expect(vi.mocked(db.buildingEntrance.update).mock.calls).toHaveLength(1)
   })
 
   it('nettoie les entrées vides après la mise à jour', async () => {
@@ -78,23 +68,13 @@ describe('updateBuildingsInEntrance', () => {
       buildings: [{ id: 1 }],
     } as never)
 
-    vi.mocked(db.$transaction).mockImplementation((async (fn: (tx: unknown) => Promise<void>) => {
-      const tx = {
-        buildingEntrance: {
-          update: vi.fn().mockResolvedValue({} as never),
-          createMany: vi.fn().mockResolvedValue({} as never),
-        },
-      }
-      await fn(tx)
-    }) as never)
-
-    await updateBuildingsInEntrance(db, 10, [1], 1)
+    await updateBuildingsInEntrance(db as never, 10, [1], 1)
 
     // deleteMany est toujours appelé pour nettoyer les entrées vides
     expect(vi.mocked(db.buildingEntrance.deleteMany).mock.calls).toHaveLength(1)
   })
 
-  it('gère les erreurs de transaction sans planter', async () => {
+  it('gère les erreurs sans planter', async () => {
     vi.mocked(db.buildingEntrance.findUnique).mockResolvedValue({
       id: 10,
       access: 1,
@@ -105,9 +85,9 @@ describe('updateBuildingsInEntrance', () => {
       buildings: [{ id: 1 }],
     } as never)
 
-    vi.mocked(db.$transaction).mockRejectedValue(new Error('Transaction failed'))
+    vi.mocked(db.buildingEntrance.update).mockRejectedValue(new Error('Update failed'))
 
     // Ne doit pas lancer d'erreur
-    await expect(updateBuildingsInEntrance(db, 10, [1, 2], 1)).resolves.toBeUndefined()
+    await expect(updateBuildingsInEntrance(db as never, 10, [1, 2], 1)).resolves.toBeUndefined()
   })
 })

--- a/app/features/territories/server/update-buildings-in-entrance.server.ts
+++ b/app/features/territories/server/update-buildings-in-entrance.server.ts
@@ -1,8 +1,8 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 import logger from '~/shared/libs/logger.server'
 
 export async function updateBuildingsInEntrance(
-  db: ScopedDb,
+  db: TransactionClient,
   entranceId: number,
   buildingIds: number[],
   congregationId: number,
@@ -33,36 +33,34 @@ export async function updateBuildingsInEntrance(
   }
 
   try {
-    await db.$transaction(async tx => {
-      // Update current entrance.
-      await tx.buildingEntrance.update({
-        where: { id: entrance.id },
-        data: {
-          buildings: {
-            connect: newBuildingIds.map(buildingId => ({ id: buildingId })),
-            disconnect: disconnectBuildingIds.map(buildingId => ({ id: buildingId })),
-          },
+    // Update current entrance.
+    await db.buildingEntrance.update({
+      where: { id: entrance.id },
+      data: {
+        buildings: {
+          connect: newBuildingIds.map(buildingId => ({ id: buildingId })),
+          disconnect: disconnectBuildingIds.map(buildingId => ({ id: buildingId })),
         },
-      })
-
-      // Create new entrance if needed.
-      if (disconnectBuildingIds.length > 0) {
-        await tx.buildingEntrance.createMany({
-          data: disconnectBuildingIds.map(disconnectBuildingId => ({
-            buildingId: disconnectBuildingId,
-            access: entrance.access,
-            isMailboxOpen: entrance.isMailboxOpen,
-            // biome-ignore lint/style/useNamingConvention: prisma model
-            isPMR: entrance.isPMR,
-            isOpenEarly: entrance.isOpenEarly,
-            buildings: {
-              connect: { id: disconnectBuildingId },
-            },
-            congregationId,
-          })),
-        })
-      }
+      },
     })
+
+    // Create new entrance if needed.
+    if (disconnectBuildingIds.length > 0) {
+      await db.buildingEntrance.createMany({
+        data: disconnectBuildingIds.map(disconnectBuildingId => ({
+          buildingId: disconnectBuildingId,
+          access: entrance.access,
+          isMailboxOpen: entrance.isMailboxOpen,
+          // biome-ignore lint/style/useNamingConvention: prisma model
+          isPMR: entrance.isPMR,
+          isOpenEarly: entrance.isOpenEarly,
+          buildings: {
+            connect: { id: disconnectBuildingId },
+          },
+          congregationId,
+        })),
+      })
+    }
 
     logger.info(`Update of entrance ${entranceId} with buildings ${buildingIds.join(', ')} succeed.`)
   } catch (error) {

--- a/app/shared/libs/auth.server.test.ts
+++ b/app/shared/libs/auth.server.test.ts
@@ -10,15 +10,9 @@ vi.mock('~/features/authorization/server/verify-role.server', () => ({
   verifyRole: vi.fn(),
 }))
 
-vi.mock('~/shared/libs/db.server', () => ({
-  restoreCongregationContext: vi.fn(),
-  createScopedDb: vi.fn(() => 'mocked-scoped-db'),
-}))
-
 const { authenticateAndAuthorize } = await import('./auth.server')
 const { verifySession } = await import('~/features/authentication/server/session.server')
 const { verifyRole } = await import('~/features/authorization/server/verify-role.server')
-const { restoreCongregationContext, createScopedDb } = await import('~/shared/libs/db.server')
 
 function makeRequest() {
   return new Request('http://localhost/')
@@ -44,11 +38,10 @@ describe('authenticateAndAuthorize', () => {
     expect(result.session).toBe(fakeSessionResult.session)
   })
 
-  it('retourne un db scopé via createScopedDb', async () => {
+  it('retourne congregationId from currentUser', async () => {
     const result = await authenticateAndAuthorize(makeRequest())
 
-    expect(createScopedDb).toHaveBeenCalledWith(5)
-    expect(result.db).toBe('mocked-scoped-db')
+    expect(result.congregationId).toBe(5)
   })
 
   it('résout les permissions via verifyRole', async () => {
@@ -75,13 +68,5 @@ describe('authenticateAndAuthorize', () => {
 
     expect(verifyRole).not.toHaveBeenCalled()
     expect(result.can(Role.Admin)).toBe(false)
-  })
-
-  it('appelle restoreCongregationContext après la résolution des rôles', async () => {
-    vi.mocked(verifyRole).mockResolvedValue(true as never)
-
-    await authenticateAndAuthorize(makeRequest(), [Role.Admin])
-
-    expect(restoreCongregationContext).toHaveBeenCalledWith(5)
   })
 })

--- a/app/shared/libs/auth.server.ts
+++ b/app/shared/libs/auth.server.ts
@@ -2,16 +2,11 @@ import { verifySession } from '~/features/authentication/server/session.server'
 import type { Role } from '~/features/authorization/model/roles.type'
 import { verifyRole } from '~/features/authorization/server/verify-role.server'
 
-import { createScopedDb, restoreCongregationContext } from './db.server'
-
 /**
- * Authenticates the user, checks roles, and returns a tenant-scoped db client.
+ * Authenticates the user and checks roles.
  *
- * Combines verifySession + verifyRole into a single call. Returns a scoped `db`
- * client that reads congregationId from a closure (not AsyncLocalStorage), making
- * it immune to the Prisma 7 pg adapter breaking ALS propagation.
- *
- * Use this in all authenticated route loaders and actions.
+ * Returns congregationId for use with withScope() and explicit query scoping.
+ * RLS + compound unique indexes handle tenant isolation at the DB level.
  */
 export async function authenticateAndAuthorize(request: Request, roles: Role[] = []) {
   const { currentUser, congregation, session } = await verifySession(request)
@@ -19,14 +14,11 @@ export async function authenticateAndAuthorize(request: Request, roles: Role[] =
   const resolved = await Promise.all(roles.map(async role => [role, await verifyRole(request, role)] as const))
   const permissions = new Set(resolved.filter(([, granted]) => granted).map(([role]) => role))
 
-  // Also restore ALS for any code that still reads from it (e.g. legacy db import)
-  restoreCongregationContext(currentUser.congregationId)
-
   return {
     currentUser,
     congregation,
+    congregationId: currentUser.congregationId,
     session,
     can: (role: Role) => permissions.has(role),
-    db: createScopedDb(currentUser.congregationId),
   }
 }

--- a/app/shared/libs/congregation.server.test.ts
+++ b/app/shared/libs/congregation.server.test.ts
@@ -4,9 +4,6 @@ vi.mock('~/shared/libs/db.server', () => ({
   unscopedDb: {
     congregation: { findUnique: vi.fn(), findFirst: vi.fn() },
   },
-  congregationContext: {
-    getStore: vi.fn(),
-  },
 }))
 
 vi.mock('react-router', () => ({
@@ -16,14 +13,8 @@ vi.mock('react-router', () => ({
   }),
 }))
 
-const {
-  resolveCongregation,
-  resolveCongregationFromRequest,
-  getCongregationFromContext,
-  requireCongregation,
-  getPlatformName,
-} = await import('./congregation.server')
-const { unscopedDb: db, congregationContext } = await import('~/shared/libs/db.server')
+const { resolveCongregation, resolveCongregationFromRequest, getPlatformName } = await import('./congregation.server')
+const { unscopedDb: db } = await import('~/shared/libs/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
@@ -147,50 +138,6 @@ describe('resolveCongregation', () => {
     const result = await resolveCongregation(1)
     expect(result.suspendedAt).toBe(suspendedDate)
     expect(result.suspendedReason).toBe('Impayé')
-  })
-})
-
-describe('getCongregationFromContext', () => {
-  it("retourne null quand le contexte n'est pas défini", () => {
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
-
-    expect(getCongregationFromContext()).toBeNull()
-  })
-
-  it('retourne la congrégation du contexte', () => {
-    const fakeCongregation = { id: 1, name: 'Test' }
-    vi.mocked(congregationContext.getStore).mockReturnValue({
-      congregationId: 1,
-      congregation: fakeCongregation,
-    } as never)
-
-    expect(getCongregationFromContext()).toBe(fakeCongregation)
-  })
-
-  it('retourne null quand le contexte existe mais sans congrégation', () => {
-    vi.mocked(congregationContext.getStore).mockReturnValue({
-      congregationId: 1,
-    })
-
-    expect(getCongregationFromContext()).toBeNull()
-  })
-})
-
-describe('requireCongregation', () => {
-  it("lance une erreur quand le contexte n'est pas défini", () => {
-    vi.mocked(congregationContext.getStore).mockReturnValue(undefined as never)
-
-    expect(() => requireCongregation()).toThrow('Congregation context is required but not set')
-  })
-
-  it('retourne la congrégation quand le contexte est défini', () => {
-    const fakeCongregation = { id: 1, name: 'Test' }
-    vi.mocked(congregationContext.getStore).mockReturnValue({
-      congregationId: 1,
-      congregation: fakeCongregation,
-    } as never)
-
-    expect(requireCongregation()).toBe(fakeCongregation)
   })
 })
 

--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
 
-import { congregationContext, unscopedDb } from '~/shared/libs/db.server'
+import { unscopedDb } from '~/shared/libs/db.server'
 
 const DEFAULT_PLATFORM_NAME = 'Unitae'
 const DEFAULT_EMAIL_FROM = 'Unitae <noreply@unitae.app>'
@@ -21,19 +21,6 @@ export type CongregationInfo = {
   suspendedAt: Date | null
   suspendedReason: string | null
   trialEndsAt: Date | null
-}
-
-export function getCongregationFromContext(): CongregationInfo | null {
-  const ctx = congregationContext.getStore()
-  return ctx?.congregation ?? null
-}
-
-export function requireCongregation(): CongregationInfo {
-  const congregation = getCongregationFromContext()
-  if (!congregation) {
-    throw new Error('Congregation context is required but not set')
-  }
-  return congregation
 }
 
 export async function resolveCongregation(congregationId: number): Promise<CongregationInfo> {

--- a/app/shared/libs/db.server.ts
+++ b/app/shared/libs/db.server.ts
@@ -1,139 +1,27 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '~/database/generated/client'
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+const db = new PrismaClient({ adapter })
 
-// Unscoped client for global operations (UserRole, setup, login, health checks)
-const unscopedDb = new PrismaClient({ adapter })
-
-// Congregation context carried per-request via AsyncLocalStorage
-type CongregationContext = {
-  congregationId: number
-  congregation?: import('~/shared/libs/congregation.server').CongregationInfo
-}
-export const congregationContext = new AsyncLocalStorage<CongregationContext>()
+// Unscoped = same client, no SET LOCAL → RLS allows all rows (for login, setup, health, platform admin)
+const unscopedDb = db
 
 /**
- * Restores the congregation context in AsyncLocalStorage.
+ * Runs a callback inside a PostgreSQL transaction with tenant-scoped RLS.
  *
- * The Prisma 7 pg adapter breaks AsyncLocalStorage propagation after async queries.
- * Call this after verifySession/verifyRole to ensure subsequent db queries are scoped.
+ * Uses SET LOCAL to set the congregation_id session variable, which is
+ * automatically unset when the transaction ends. This prevents leaking
+ * congregation context across requests via the connection pool.
  */
-export function restoreCongregationContext(congregationId: number) {
-  congregationContext.enterWith({ congregationId })
-}
-
-const SCOPED_MODELS = new Set<string>([
-  'User',
-  'Territory',
-  'Building',
-  'BuildingEntrance',
-  'Attribution',
-  'PublisherGroup',
-  'PublisherActivity',
-  'BoardSection',
-  'BoardDocument',
-  'Event',
-  'EventKind',
-  'Setting',
-])
-
-const READ_OPERATIONS = new Set([
-  'findMany',
-  'findFirst',
-  'findUnique',
-  'findFirstOrThrow',
-  'findUniqueOrThrow',
-  'count',
-  'aggregate',
-  'groupBy',
-])
-
-const WRITE_OPERATIONS = new Set(['create', 'createMany', 'createManyAndReturn'])
-const UPDATE_OPERATIONS = new Set(['update', 'updateMany', 'upsert', 'delete', 'deleteMany'])
-
-// Tenant-scoped client — auto-injects congregationId on all scoped models
-const db = unscopedDb.$extends({
-  query: {
-    async $allOperations({ model, operation, args, query }) {
-      if (!model || !SCOPED_MODELS.has(model)) return query(args)
-
-      const ctx = congregationContext.getStore()
-      if (!ctx) {
-        throw new Error(
-          `Congregation context is required for ${model}.${operation} but was not set. ` +
-            'Use unscopedDb for global operations or ensure verifySession() was called.',
-        )
-      }
-
-      const { congregationId } = ctx
-
-      if (READ_OPERATIONS.has(operation)) {
-        args.where = { ...args.where, congregationId }
-      }
-
-      if (WRITE_OPERATIONS.has(operation)) {
-        if (Array.isArray(args.data)) {
-          args.data = args.data.map((d: Record<string, unknown>) => ({ ...d, congregationId }))
-        } else if (args.data) {
-          args.data = { ...args.data, congregationId }
-        }
-      }
-
-      if (UPDATE_OPERATIONS.has(operation)) {
-        args.where = { ...args.where, congregationId }
-        if (operation === 'upsert' && args.create) {
-          args.create = { ...args.create, congregationId }
-        }
-      }
-
-      const result = await query(args)
-
-      // Restore ALS context after query — the Prisma 7 pg adapter can break
-      // AsyncLocalStorage propagation during async operations.
-      congregationContext.enterWith(ctx)
-
-      return result
-    },
-  },
-})
-
-/**
- * Creates a tenant-scoped Prisma client that reads congregationId from a closure
- * instead of AsyncLocalStorage. This is immune to the Prisma 7 pg adapter breaking
- * ALS propagation after async queries.
- */
-function scopeQueries(congregationId: number) {
-  return unscopedDb.$extends({
-    query: {
-      $allOperations({ model, operation, args, query }) {
-        if (!model || !SCOPED_MODELS.has(model)) return query(args)
-
-        if (READ_OPERATIONS.has(operation)) {
-          args.where = { ...args.where, congregationId }
-        }
-
-        if (WRITE_OPERATIONS.has(operation)) {
-          if (Array.isArray(args.data)) {
-            args.data = args.data.map((d: Record<string, unknown>) => ({ ...d, congregationId }))
-          } else if (args.data) {
-            args.data = { ...args.data, congregationId }
-          }
-        }
-
-        if (UPDATE_OPERATIONS.has(operation)) {
-          args.where = { ...args.where, congregationId }
-          if (operation === 'upsert' && args.create) {
-            args.create = { ...args.create, congregationId }
-          }
-        }
-
-        return query(args)
-      },
-    },
+function withScope<T>(congregationId: number, fn: (tx: TransactionClient) => Promise<T>): Promise<T> {
+  return db.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+    return fn(tx)
   })
 }
 
-export type ScopedDb = ReturnType<typeof scopeQueries>
-export { db, scopeQueries as createScopedDb, unscopedDb }
+type TransactionClient = Parameters<Parameters<typeof db.$transaction>[0]>[0]
+
+export type { TransactionClient }
+export { db, unscopedDb, withScope }

--- a/app/shared/libs/limits.server.test.ts
+++ b/app/shared/libs/limits.server.test.ts
@@ -25,22 +25,22 @@ function makeLimits(overrides: Partial<ConstructorParameters<typeof LimitService
 describe('LimitService', () => {
   describe('isLimited', () => {
     it('retourne false quand la limite est null (illimité)', () => {
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: null }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: null }))
       expect(service.isLimited('publishers')).toBe(false)
     })
 
     it('retourne true quand la limite est définie', () => {
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       expect(service.isLimited('publishers')).toBe(true)
     })
 
     it('retourne true même quand la limite est 0', () => {
-      const service = new LimitService(db as any, makeLimits({ maxTerritories: 0 }))
+      const service = new LimitService(db as never, makeLimits({ maxTerritories: 0 }))
       expect(service.isLimited('territories')).toBe(true)
     })
 
     it('vérifie chaque type de limite indépendamment', () => {
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10, maxTerritories: null }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10, maxTerritories: null }))
       expect(service.isLimited('publishers')).toBe(true)
       expect(service.isLimited('territories')).toBe(false)
     })
@@ -48,46 +48,46 @@ describe('LimitService', () => {
 
   describe('isStorageLimited', () => {
     it('retourne false quand maxStorageBytes est null', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: null }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: null }))
       expect(service.isStorageLimited()).toBe(false)
     })
 
     it('retourne true quand maxStorageBytes est défini', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.isStorageLimited()).toBe(true)
     })
   })
 
   describe('checkStorageLimit', () => {
     it("retourne false quand le stockage n'est pas limité", () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: null }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: null }))
       expect(service.checkStorageLimit(500n, 100n)).toBe(false)
     })
 
     it('retourne false quand le total est sous la limite', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 100n)).toBe(false)
     })
 
     it('retourne false quand le total est exactement à la limite', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 500n)).toBe(false)
     })
 
     it('retourne true quand le total dépasse la limite', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       expect(service.checkStorageLimit(500n, 501n)).toBe(true)
     })
   })
 
   describe('errorIfStorageOverLimit', () => {
     it("ne lance pas d'erreur quand sous la limite", () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       expect(() => service.errorIfStorageOverLimit(100n, 100n)).not.toThrow()
     })
 
     it('lance LimitError quand la limite est dépassée', () => {
-      const service = new LimitService(db as any, makeLimits({ maxStorageBytes: 1000n }))
+      const service = new LimitService(db as never, makeLimits({ maxStorageBytes: 1000n }))
       try {
         service.errorIfStorageOverLimit(900n, 200n)
         expect.unreachable('devrait lancer une erreur')
@@ -104,7 +104,7 @@ describe('LimitService', () => {
     })
 
     it("retourne false quand la ressource n'est pas limitée", async () => {
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: null }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: null }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(false)
     })
@@ -112,7 +112,7 @@ describe('LimitService', () => {
     it('retourne false quand le count est sous la limite', async () => {
       vi.mocked(db.user.count).mockResolvedValue(5)
 
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(false)
     })
@@ -120,7 +120,7 @@ describe('LimitService', () => {
     it('retourne true quand le count atteint la limite', async () => {
       vi.mocked(db.user.count).mockResolvedValue(10)
 
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(true)
     })
@@ -128,7 +128,7 @@ describe('LimitService', () => {
     it('retourne true quand le count dépasse la limite', async () => {
       vi.mocked(db.user.count).mockResolvedValue(15)
 
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       const result = await service.checkWouldGoOverLimit('publishers')
       expect(result).toBe(true)
     })
@@ -136,7 +136,7 @@ describe('LimitService', () => {
     it('vérifie les territoires via db.territory.count', async () => {
       vi.mocked(db.territory.count).mockResolvedValue(3)
 
-      const service = new LimitService(db as any, makeLimits({ maxTerritories: 5 }))
+      const service = new LimitService(db as never, makeLimits({ maxTerritories: 5 }))
       const result = await service.checkWouldGoOverLimit('territories')
       expect(result).toBe(false)
     })
@@ -144,7 +144,7 @@ describe('LimitService', () => {
     it('vérifie les documents via db.boardDocument.count', async () => {
       vi.mocked(db.boardDocument.count).mockResolvedValue(20)
 
-      const service = new LimitService(db as any, makeLimits({ maxBoardDocuments: 20 }))
+      const service = new LimitService(db as never, makeLimits({ maxBoardDocuments: 20 }))
       const result = await service.checkWouldGoOverLimit('boardDocuments')
       expect(result).toBe(true)
     })
@@ -158,14 +158,14 @@ describe('LimitService', () => {
     it("ne lance pas d'erreur quand sous la limite", async () => {
       vi.mocked(db.user.count).mockResolvedValue(5)
 
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       await expect(service.errorIfWouldGoOverLimit('publishers')).resolves.toBeUndefined()
     })
 
     it('lance LimitError quand la limite est atteinte', async () => {
       vi.mocked(db.user.count).mockResolvedValue(10)
 
-      const service = new LimitService(db as any, makeLimits({ maxPublishers: 10 }))
+      const service = new LimitService(db as never, makeLimits({ maxPublishers: 10 }))
       try {
         await service.errorIfWouldGoOverLimit('publishers')
         expect.unreachable('devrait lancer une erreur')

--- a/app/shared/libs/limits.server.ts
+++ b/app/shared/libs/limits.server.ts
@@ -1,4 +1,4 @@
-import type { ScopedDb } from '~/shared/libs/db.server'
+import type { TransactionClient } from '~/shared/libs/db.server'
 
 const LIMIT_COLUMN_MAP = {
   publishers: 'maxPublishers',
@@ -28,7 +28,7 @@ export class LimitError extends Error {
 
 export class LimitService {
   constructor(
-    private db: ScopedDb,
+    private db: TransactionClient,
     private limits: CongregationLimits,
   ) {}
 

--- a/package.json
+++ b/package.json
@@ -1,98 +1,98 @@
 {
-  "name": "unitae",
-  "license": "AGPL-3.0-only",
-  "private": true,
-  "sideEffects": false,
-  "type": "module",
-  "scripts": {
-    "build": "react-router build",
-    "build:format": "biome check --write",
-    "build:db": "prisma generate",
-    "start": "react-router-serve ./build/server/index.js",
-    "db:migrate": "pnpm prisma migrate deploy",
-    "db:seed": "pnpm prisma db seed",
-    "start:dev": "react-router dev",
-    "start:emails": "email dev",
-    "start:worker": "pnpm tsx ./workers/sync-worker.server.ts",
-    "test:lint": "biome lint",
-    "test:typecheck": "react-router typegen && tsc",
-    "test:unit": "vitest run",
-    "test:unit:watch": "vitest",
-    "test:unit:coverage": "vitest run --coverage"
-  },
-  "dependencies": {
-    "@aws-sdk/client-s3": "^3.1024.0",
-    "@mjackson/form-data-parser": "^0.9.1",
-    "@prisma/adapter-pg": "^7.6.0",
-    "@prisma/client": "7.6.0",
-    "@radix-ui/react-slot": "^1.2.4",
-    "@react-email/components": "^1.0.11",
-    "@react-pdf/renderer": "^4.3.3",
-    "@react-router/node": "^7.14.0",
-    "@react-router/serve": "^7.14.0",
-    "@vis.gl/react-google-maps": "^1.8.2",
-    "bullmq": "^5.73.0",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "csv": "^6.5.1",
-    "dotenv": "^17.4.0",
-    "exceljs": "^4.4.0",
-    "ioredis": "^5.10.1",
-    "isbot": "^5.1.37",
-    "jszip": "^3.10.1",
-    "lucide-react": "^1.7.0",
-    "next-themes": "^0.4.6",
-    "radix-ui": "^1.4.3",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-router": "^7.14.0",
-    "recharts": "^3.8.1",
-    "resend": "^6.10.0",
-    "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0",
-    "tsx": "^4.21.0",
-    "winston": "^3.19.0"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.4.10",
-    "@react-router/dev": "^7.14.0",
-    "@tailwindcss/vite": "^4.2.2",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
-    "@vitest/coverage-v8": "^4.1.3",
-    "prisma": "^7.6.0",
-    "react-email": "5.2.10",
-    "shadcn": "^4.2.0",
-    "tailwindcss": "^4.2.2",
-    "ts-node": "^10.9.2",
-    "typescript": "^6.0.2",
-    "vite": "^8.0.5",
-    "vitest": "^4.1.3"
-  },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "esbuild": "^0.25.8"
+    "name": "unitae",
+    "license": "AGPL-3.0-only",
+    "private": true,
+    "sideEffects": false,
+    "type": "module",
+    "scripts": {
+        "build": "react-router build",
+        "build:format": "biome check --write",
+        "build:db": "prisma generate",
+        "start": "react-router-serve ./build/server/index.js",
+        "db:migrate": "pnpm prisma migrate deploy",
+        "db:seed": "pnpm prisma db seed",
+        "start:dev": "react-router dev",
+        "start:emails": "email dev",
+        "start:worker": "pnpm tsx ./workers/sync-worker.server.ts",
+        "test:lint": "biome lint",
+        "test:typecheck": "react-router typegen && tsc",
+        "test:unit": "vitest run",
+        "test:unit:watch": "vitest",
+        "test:unit:coverage": "vitest run --coverage"
     },
-    "onlyBuiltDependencies": [
-      "@prisma/engines",
-      "better-sqlite3",
-      "prisma"
-    ]
-  },
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": ">=24.11.0",
-      "onFail": "error"
+    "dependencies": {
+        "@aws-sdk/client-s3": "^3.1024.0",
+        "@mjackson/form-data-parser": "^0.9.1",
+        "@prisma/adapter-pg": "^7.6.0",
+        "@prisma/client": "7.6.0",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@react-email/components": "^1.0.11",
+        "@react-pdf/renderer": "^4.3.3",
+        "@react-router/node": "^7.14.0",
+        "@react-router/serve": "^7.14.0",
+        "@vis.gl/react-google-maps": "^1.8.2",
+        "bullmq": "^5.73.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "csv": "^6.5.1",
+        "dotenv": "^17.4.0",
+        "exceljs": "^4.4.0",
+        "ioredis": "^5.10.1",
+        "isbot": "^5.1.37",
+        "jszip": "^3.10.1",
+        "lucide-react": "^1.7.0",
+        "next-themes": "^0.4.6",
+        "radix-ui": "^1.4.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "react-router": "^7.14.0",
+        "recharts": "^3.8.1",
+        "resend": "^6.10.0",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.5.0",
+        "tsx": "^4.21.0",
+        "winston": "^3.19.0"
     },
-    "packageManager": {
-      "name": "pnpm",
-      "version": "10.26.1",
-      "onFail": "warn"
-    }
-  },
-  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
+    "devDependencies": {
+        "@biomejs/biome": "2.4.10",
+        "@react-router/dev": "^7.14.0",
+        "@tailwindcss/vite": "^4.2.2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitest/coverage-v8": "^4.1.3",
+        "prisma": "^7.6.0",
+        "react-email": "5.2.10",
+        "shadcn": "^4.2.0",
+        "tailwindcss": "^4.2.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^6.0.2",
+        "vite": "^8.0.5",
+        "vitest": "^4.1.3"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "pnpm": {
+        "overrides": {
+            "esbuild": "^0.25.8"
+        },
+        "onlyBuiltDependencies": [
+            "@prisma/engines",
+            "better-sqlite3",
+            "prisma"
+        ]
+    },
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": ">=24.11.0",
+            "onFail": "error"
+        },
+        "packageManager": {
+            "name": "pnpm",
+            "version": "10.26.1",
+            "onFail": "warn"
+        }
+    },
+    "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa"
 }


### PR DESCRIPTION
## Summary

- Replace unreliable Prisma `$extends` client extension with two independent layers of multi-tenant data isolation
- Add **PostgreSQL Row-Level Security (RLS)** on all 13 scoped tables as a DB-level safety net
- Add **compound unique indexes** (`@@unique([id, congregationId])`) so TypeScript enforces `congregationId` at compile time for `findUnique`/`update`/`delete`
- Remove AsyncLocalStorage, `ScopedDb` type, and `0 as number` placeholder pattern
- All routes now use `withScope(congregationId, fn)` with `$transaction` + `SET LOCAL` for connection-pool-safe RLS

## Context

Multi-tenant data isolation was broken: users could see and update data from all congregations. The Prisma extension approach failed across multiple fix attempts due to:
- Prisma 7 PrismaPg adapter breaking AsyncLocalStorage propagation
- `findUnique` silently ignoring `congregationId` injected into non-unique where clauses
- Uncertainty whether `$allOperations` hook even fires with the pg adapter

## Test plan

- [x] `pnpm test:typecheck` passes
- [x] `pnpm test:lint` passes (0 errors, 0 warnings)
- [x] `pnpm test:unit` passes (315/315 tests)
- [ ] Run `pnpm prisma migrate deploy` against dev database
- [ ] Manual multi-tenant test: log in as user from congregation A, verify only congregation A data is visible
- [ ] RLS verification via psql: `SET app.congregation_id = '1'; SELECT count(*) FROM "User";`