### PR TITLE
fix: add explicit congregationId to all findMany queries on scoped models

### DIFF
--- a/app/features/board/server/notifications.tsx
+++ b/app/features/board/server/notifications.tsx
@@ -13,6 +13,7 @@ export async function sendNewDocumentNotificationEmail(
 ) {
   const users = await db.user.findMany({
     where: {
+      congregationId: congregation.id,
       congregationRoles: {
         some: {
           role: { key: Role.BoardValidator },

--- a/app/features/events/routes/days-off/list.tsx
+++ b/app/features/events/routes/days-off/list.tsx
@@ -18,7 +18,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { currentUser, session, congregationId } = await authenticateAndAuthorize(request)
 
   return withScope(congregationId, async db => {
-    const events = await getNextDaysOffs(db, currentUser.id)
+    const events = await getNextDaysOffs(db, currentUser.id, congregationId)
 
     logger.info(`Loading personal Days Off list. User ID: ${currentUser.id}`)
 

--- a/app/features/events/server/days-off.server.ts
+++ b/app/features/events/server/days-off.server.ts
@@ -1,9 +1,10 @@
 import { EventKind } from '~/features/events/model/event-kind.type'
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export function getNextDaysOffs(db: TransactionClient, userId: number) {
+export function getNextDaysOffs(db: TransactionClient, userId: number, congregationId: number) {
   return db.event.findMany({
     where: {
+      congregationId,
       createdBy: { id: userId },
       kind: {
         key: EventKind.Off,
@@ -32,7 +33,7 @@ export async function createDayOff(
     return null
   }
 
-  const eventKind = await db.eventKind.findFirst({ where: { key: EventKind.Off } })
+  const eventKind = await db.eventKind.findFirst({ where: { key: EventKind.Off, congregationId } })
 
   return await db.event.create({
     data: {

--- a/app/features/events/server/event-kind.server.test.ts
+++ b/app/features/events/server/event-kind.server.test.ts
@@ -21,14 +21,14 @@ describe('getAllEventType', () => {
     ]
     vi.mocked(db.eventKind.findMany).mockResolvedValue(fakeEventKinds as never)
 
-    const result = await getAllEventType(db)
+    const result = await getAllEventType(db, 1)
     expect(result).toEqual(fakeEventKinds)
   })
 
   it("retourne un tableau vide quand il n'y a pas de types", async () => {
     vi.mocked(db.eventKind.findMany).mockResolvedValue([] as never)
 
-    const result = await getAllEventType(db)
+    const result = await getAllEventType(db, 1)
     expect(result).toEqual([])
   })
 })

--- a/app/features/events/server/event-kind.server.ts
+++ b/app/features/events/server/event-kind.server.ts
@@ -1,5 +1,5 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getAllEventType(db: TransactionClient) {
-  return await db.eventKind.findMany()
+export async function getAllEventType(db: TransactionClient, congregationId: number) {
+  return await db.eventKind.findMany({ where: { congregationId } })
 }

--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -28,7 +28,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   })
 
   return withScope(congregationId, async db => {
-    const file = await generatePublishersYearlyActivityXlsx(db, Number(params.year))
+    const file = await generatePublishersYearlyActivityXlsx(db, congregationId, Number(params.year))
 
     return new Response(file, {
       status: 200,

--- a/app/features/publishers/routes/activity/new.tsx
+++ b/app/features/publishers/routes/activity/new.tsx
@@ -38,7 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const year = Number(searchParams.get('year') ?? timeRange.getFullYear())
 
   return withScope(congregationId, async db => {
-    const publishers = await getPublishers(db, { groupId: groupFilter })
+    const publishers = await getPublishers(db, congregationId, { groupId: groupFilter })
 
     const activity = await db.publisherActivity.findFirst({
       where: {

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -29,7 +29,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   return withScope(congregationId, async db => {
     const today = new Date()
-    const file = await renderActivityPdfZip(db, Number(params.year))
+    const file = await renderActivityPdfZip(db, congregationId, Number(params.year))
 
     return new Response(file, {
       status: 200,

--- a/app/features/publishers/routes/activity/publisher-list.tsx
+++ b/app/features/publishers/routes/activity/publisher-list.tsx
@@ -44,7 +44,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const year = Number(searchParams.get('year') ?? timeRange.getFullYear())
 
   return withScope(congregationId, async db => {
-    const users = await getPublisherWithActivities(db, month, year)
+    const users = await getPublisherWithActivities(db, congregationId, month, year)
 
     return {
       firstMonth: {
@@ -55,7 +55,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         month,
         year,
       },
-      stats: await getPublisherStats(db, month, year),
+      stats: await getPublisherStats(db, congregationId, month, year),
       publishers: users
         .map(sanitizeUser)
         .map(({ activities, ...member }) => ({

--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -24,6 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return withScope(congregationId, async db => {
     const brothers = await db.user.findMany({
       where: {
+        congregationId,
         // biome-ignore lint/style/useNamingConvention: Prisma OR operator
         OR: [{ isHelder: true }, { isServant: true }],
       },

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -36,8 +36,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
     if (result == null) throw redirect('/congregation/publishers')
 
-    const showAuxiliaryPioneer = await getBoolSetting(db, CongregationSettingKey.AuxiliaryPioneerProfileActivated)
-    const groups = await db.publisherGroup.findMany()
+    const showAuxiliaryPioneer = await getBoolSetting(db, CongregationSettingKey.AuxiliaryPioneerProfileActivated, congregationId)
+    const groups = await db.publisherGroup.findMany({ where: { congregationId } })
     const { email, password, ...user } = result
     return {
       user: {

--- a/app/features/publishers/routes/publishers/group-list.tsx
+++ b/app/features/publishers/routes/publishers/group-list.tsx
@@ -38,6 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   return withScope(congregationId, async db => {
     const groups = await db.publisherGroup.findMany({
+      where: { congregationId },
       include: {
         responsible: true,
         deputy: true,

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -23,6 +23,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   return withScope(congregationId, async db => {
     const brothers = await db.user.findMany({
       where: {
+        congregationId,
         // biome-ignore lint/style/useNamingConvention: Prisma OR operator
         OR: [{ isHelder: true }, { isServant: true }],
         responsibleFor: {

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -25,7 +25,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const groups = await db.publisherGroup.findMany()
+    const groups = await db.publisherGroup.findMany({ where: { congregationId } })
 
     return { groups, hideAuxiliaryPioneer: false }
   })

--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -40,7 +40,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   )
 
   return withScope(congregationId, async db => {
-    const users = await getPublishersWithGroup(db)
+    const users = await getPublishersWithGroup(db, congregationId)
 
     return {
       users: users.map(user => ({

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
@@ -40,7 +40,7 @@ async function readWorkbook(buffer: excelJs.Buffer) {
 
 describe('generatePublishersYearlyActivityXlsx', () => {
   it('génère 12 feuilles pour une année théocratique', async () => {
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
 
     expect(workbook.worksheets).toHaveLength(12)
@@ -51,7 +51,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.Normal, { isPublisher: true, hours: 0, studies: 1 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
     const firstSheet = workbook.worksheets[0]
     const dataRow = firstSheet.getRow(2)
@@ -64,7 +64,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierPermanant, { hours: 50 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -76,7 +76,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -88,7 +88,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.PionnierSpecial, { hours: 130 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 
@@ -100,7 +100,7 @@ describe('generatePublishersYearlyActivityXlsx', () => {
       makeActivity(PublisherType.Missionnaire, { hours: 120 }),
     ] as never)
 
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 2025)
+    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
     const workbook = await readWorkbook(buffer)
     const dataRow = workbook.worksheets[0].getRow(2)
 

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
@@ -4,7 +4,7 @@ import type { TransactionClient } from '~/shared/libs/db.server'
 import { PublisherType, publisherTypeReportsHours } from '~/shared/types/publisher-type'
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
-export async function generatePublishersYearlyActivityXlsx(db: TransactionClient, year: number) {
+export async function generatePublishersYearlyActivityXlsx(db: TransactionClient, congregationId: number, year: number) {
   const months = Array.from({ length: 12 }, (_, i) => (i + 8 > 11 ? i - 4 : i + 8))
   const workbook = new excelJs.Workbook()
 
@@ -13,7 +13,7 @@ export async function generatePublishersYearlyActivityXlsx(db: TransactionClient
     const date = new Date(yearMonth, month, 1)
     const monthName = date.toLocaleString('fr', { month: 'long' })
     const sheetName = `${monthName} ${yearMonth}`.toUpperCase()
-    const activities = await getPublishersMonthlyActivity(db, month, yearMonth)
+    const activities = await getPublishersMonthlyActivity(db, congregationId, month, yearMonth)
 
     const worksheet = workbook.addWorksheet(sheetName)
     worksheet.columns = [
@@ -92,11 +92,12 @@ export async function generatePublishersYearlyActivityXlsx(db: TransactionClient
   return await workbook.xlsx.writeBuffer()
 }
 
-function getPublishersMonthlyActivity(db: TransactionClient, month: number, year: number) {
+function getPublishersMonthlyActivity(db: TransactionClient, congregationId: number, month: number, year: number) {
   return db.publisherActivity.findMany({
     where: {
       month,
       year,
+      congregationId,
     },
     include: {
       publisher: {

--- a/app/features/publishers/server/get-publisher-stats.server.test.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.test.ts
@@ -32,7 +32,7 @@ describe('getPublisherStats', () => {
       makeFigure(PublisherType.PionnierAuxiliaires, 7, 350, 3),
     ])
 
-    const result = await getPublisherStats(db, 3, 2025)
+    const result = await getPublisherStats(db, 1, 3, 2025)
 
     // all: total
     expect(result.all.count).toBe(25)
@@ -58,7 +58,7 @@ describe('getPublisherStats', () => {
     vi.mocked(db.user.count).mockResolvedValue(0)
     vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([])
 
-    const result = await getPublisherStats(db, 1, 2025)
+    const result = await getPublisherStats(db, 1, 1, 2025)
 
     expect(result.all.count).toBe(0)
     expect(result.all.active).toBe(0)
@@ -74,7 +74,7 @@ describe('getPublisherStats', () => {
     vi.mocked(db.user.count).mockResolvedValue(10)
     vi.mocked(db.publisherActivity.groupBy).mockResolvedValue([makeFigure(PublisherType.Normal, 10, 0, 2)])
 
-    const result = await getPublisherStats(db, 6, 2025)
+    const result = await getPublisherStats(db, 1, 6, 2025)
 
     expect(result.all.active).toBe(10)
     expect(result.all.hours).toBe(0) // pas de pionniers
@@ -89,7 +89,7 @@ describe('getPublisherStats', () => {
       makeFigure(PublisherType.PionnierPermanant, 2, 50, 0),
     ])
 
-    const result = await getPublisherStats(db, 1, 2025)
+    const result = await getPublisherStats(db, 1, 1, 2025)
 
     // all.hours n'inclut que les pionniers permanents et auxiliaires
     expect(result.all.hours).toBe(50)

--- a/app/features/publishers/server/get-publisher-stats.server.ts
+++ b/app/features/publishers/server/get-publisher-stats.server.ts
@@ -1,9 +1,10 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 
-export async function getPublisherStats(db: TransactionClient, month: number, year: number) {
+export async function getPublisherStats(db: TransactionClient, congregationId: number, month: number, year: number) {
   const publishers = await db.user.count({
     where: {
+      congregationId,
       activities: {
         some: {
           year,
@@ -12,7 +13,7 @@ export async function getPublisherStats(db: TransactionClient, month: number, ye
       },
     },
   })
-  const figureMap = await getFiguresMap(db, month, year)
+  const figureMap = await getFiguresMap(db, congregationId, month, year)
 
   return {
     all: getAllStats(publishers, figureMap),
@@ -22,7 +23,7 @@ export async function getPublisherStats(db: TransactionClient, month: number, ye
   }
 }
 
-async function getFiguresMap(db: TransactionClient, month: number, year: number) {
+async function getFiguresMap(db: TransactionClient, congregationId: number, month: number, year: number) {
   const figures = await db.publisherActivity.groupBy({
     _count: {
       _all: true,
@@ -35,6 +36,7 @@ async function getFiguresMap(db: TransactionClient, month: number, year: number)
       year,
       month,
       isPublisher: true,
+      congregationId,
     },
     by: 'type',
   })

--- a/app/features/publishers/server/get-publisher-with-activities.server.test.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.test.ts
@@ -18,14 +18,14 @@ describe('getPublisherWithActivities', () => {
     const fakeResult = [{ id: 1, isPublisher: true, activities: [{ month: 3, year: 2025 }] }]
     vi.mocked(db.user.findMany).mockResolvedValue(fakeResult as never)
 
-    const result = await getPublisherWithActivities(db, 3, 2025)
+    const result = await getPublisherWithActivities(db, 1, 3, 2025)
     expect(result).toEqual(fakeResult)
   })
 
   it("retourne un tableau vide quand il n'y a pas de résultats", async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    const result = await getPublisherWithActivities(db, 1, 2025)
+    const result = await getPublisherWithActivities(db, 1, 1, 2025)
     expect(result).toEqual([])
   })
 })

--- a/app/features/publishers/server/get-publisher-with-activities.server.ts
+++ b/app/features/publishers/server/get-publisher-with-activities.server.ts
@@ -1,8 +1,14 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export function getPublisherWithActivities(db: TransactionClient, selectedMonth: number, selectedYear: number) {
+export function getPublisherWithActivities(
+  db: TransactionClient,
+  congregationId: number,
+  selectedMonth: number,
+  selectedYear: number,
+) {
   return db.user.findMany({
     where: {
+      congregationId,
       // biome-ignore lint/style/useNamingConvention: prisma keywords
       OR: [
         {

--- a/app/features/publishers/server/groups.ts
+++ b/app/features/publishers/server/groups.ts
@@ -1,8 +1,8 @@
 import { sanitizeUser } from '~/features/authentication/server/sanitize-user.server'
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getGroups(db: TransactionClient) {
-  return await db.publisherGroup.findMany()
+export async function getGroups(db: TransactionClient, congregationId: number) {
+  return await db.publisherGroup.findMany({ where: { congregationId } })
 }
 
 export async function getGroup(db: TransactionClient, groupId: number) {

--- a/app/features/publishers/server/publishers.server.test.ts
+++ b/app/features/publishers/server/publishers.server.test.ts
@@ -21,21 +21,21 @@ describe('getPublishers', () => {
     ]
     vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
-    const result = await getPublishers(db)
+    const result = await getPublishers(db, 1)
     expect(result).toEqual(fakePublishers)
   })
 
   it("retourne un tableau vide quand il n'y a pas de proclamateurs", async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    const result = await getPublishers(db)
+    const result = await getPublishers(db, 1)
     expect(result).toEqual([])
   })
 
   it('accepte un filtre par groupId', async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1 }] as never)
 
-    const result = await getPublishers(db, { groupId: 3 })
+    const result = await getPublishers(db, 1, { groupId: 3 })
     expect(result).toHaveLength(1)
   })
 })
@@ -45,7 +45,7 @@ describe('getPublishersWithGroup', () => {
     const fakePublishers = [{ id: 1, publisherGroup: { name: 'Groupe 1' } }]
     vi.mocked(db.user.findMany).mockResolvedValue(fakePublishers as never)
 
-    const result = await getPublishersWithGroup(db)
+    const result = await getPublishersWithGroup(db, 1)
     expect(result).toEqual(fakePublishers)
   })
 })

--- a/app/features/publishers/server/publishers.ts
+++ b/app/features/publishers/server/publishers.ts
@@ -1,18 +1,23 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getPublishers(db: TransactionClient, options?: { groupId?: number | null }) {
+export async function getPublishers(
+  db: TransactionClient,
+  congregationId: number,
+  options?: { groupId?: number | null },
+) {
   return await db.user.findMany({
     where: {
       isPublisher: true,
+      congregationId,
       ...(options?.groupId != null ? { publisherGroupId: options.groupId } : {}),
     },
     orderBy: [{ lastname: 'asc' }, { firstname: 'asc' }],
   })
 }
 
-export async function getPublishersWithGroup(db: TransactionClient) {
+export async function getPublishersWithGroup(db: TransactionClient, congregationId: number) {
   return await db.user.findMany({
-    where: { isPublisher: true },
+    where: { isPublisher: true, congregationId },
     include: { publisherGroup: true },
     orderBy: [{ lastname: 'asc' }, { firstname: 'asc' }],
   })

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -43,7 +43,7 @@ describe('renderActivityPdfZip', () => {
   it('filtre les activités de septembre à août (mois 8-11 puis 0-7)', async () => {
     vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 
-    await renderActivityPdfZip(db, 2025)
+    await renderActivityPdfZip(db, 1, 2025)
 
     const call = vi.mocked(db.user.findMany).mock.calls[0][0] as Record<string, unknown>
     const where = (call.where as { activities: { some: Record<string, unknown> } }).activities.some

--- a/app/features/publishers/server/render-activity-pdf-zip.server.tsx
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.tsx
@@ -4,10 +4,11 @@ import { sanitizeUser } from '~/features/authentication/server/sanitize-user.ser
 import { PublisherActivityDocument } from '~/features/publishers/ui/PublisherActivityDocument'
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function renderActivityPdfZip(db: TransactionClient, year: number) {
+export async function renderActivityPdfZip(db: TransactionClient, congregationId: number, year: number) {
   const yearBegining = new Date(year, 0, 1)
   const users = await db.user.findMany({
     where: {
+      congregationId,
       activities: {
         some: {
           // biome-ignore lint/style/useNamingConvention: Prisma syntax

--- a/app/features/settings/routes/congregation/event-kind-list.tsx
+++ b/app/features/settings/routes/congregation/event-kind-list.tsx
@@ -22,7 +22,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const kinds = await getAllEventType(db)
+    const kinds = await getAllEventType(db, congregationId)
 
     return {
       kinds,

--- a/app/features/settings/routes/congregation/settings.tsx
+++ b/app/features/settings/routes/congregation/settings.tsx
@@ -30,6 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const auxiliaryPioneerProfileActivated = await getBoolSetting(
       db,
       CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+      congregationId,
     )
 
     return {

--- a/app/features/settings/routes/territories/settings.tsx
+++ b/app/features/settings/routes/territories/settings.tsx
@@ -37,9 +37,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   return withScope(congregationId, async db => {
     const territory = await getTerritoryPolygon(db)
     const zips = await getAllowedZips(db)
-    const banoUrl = await getSetting(db, TerritorySettingKey.BanoUrl)
-    const prospectionValidity = await getSetting(db, TerritorySettingKey.ProspectionValidity)
-    const phoneTypeActivated = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const banoUrl = await getSetting(db, TerritorySettingKey.BanoUrl, congregationId)
+    const prospectionValidity = await getSetting(db, TerritorySettingKey.ProspectionValidity, congregationId)
+    const phoneTypeActivated = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     return {
       territory: serializeTerritoryPolygon(territory),

--- a/app/features/settings/server/settings.ts
+++ b/app/features/settings/server/settings.ts
@@ -4,14 +4,14 @@ import type { TerritorySettingKey } from '~/shared/types/territory-setting-key'
 
 type SettingKey = TerritorySettingKey | CongregationSettingKey
 
-export async function getSetting(db: TransactionClient, key: SettingKey): Promise<string | undefined> {
-  const setting = await db.setting.findFirst({ where: { key } })
+export async function getSetting(db: TransactionClient, key: SettingKey, congregationId: number): Promise<string | undefined> {
+  const setting = await db.setting.findFirst({ where: { key, congregationId } })
 
   return setting?.value
 }
 
-export async function getBoolSetting(db: TransactionClient, key: SettingKey): Promise<boolean | undefined> {
-  const settingValue = await getSetting(db, key)
+export async function getBoolSetting(db: TransactionClient, key: SettingKey, congregationId: number): Promise<boolean | undefined> {
+  const settingValue = await getSetting(db, key, congregationId)
 
   return settingValue === 'true'
 }
@@ -21,7 +21,7 @@ export async function setSetting(db: TransactionClient, key: SettingKey, value: 
     return
   }
 
-  const existing = await db.setting.findFirst({ where: { key } })
+  const existing = await db.setting.findFirst({ where: { key, congregationId } })
 
   if (existing) {
     await db.setting.update({

--- a/app/features/territories/routes/attributions/edit.tsx
+++ b/app/features/territories/routes/attributions/edit.tsx
@@ -33,7 +33,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     const attribution = await db.attribution.findUnique({
       where: {
@@ -47,7 +47,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       throw redirect('/territories/attributions')
     }
 
-    const users = await getPublishers(db)
+    const users = await getPublishers(db, congregationId)
 
     return { users, phoneTypeActive, attribution, entrances: attribution.territory.entrances.map(aggregateEntrance) }
   })

--- a/app/features/territories/routes/attributions/excel-export.tsx
+++ b/app/features/territories/routes/attributions/excel-export.tsx
@@ -28,7 +28,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   })
 
   return withScope(congregationId, async db => {
-    const exportData = await getTerritoriesExportData(db, Number(params.year))
+    const exportData = await getTerritoriesExportData(db, congregationId, Number(params.year))
     const file = await generateS13ExportExcel(exportData, params.year)
 
     return new Response(await file.xlsx.writeBuffer(), {

--- a/app/features/territories/routes/attributions/list.tsx
+++ b/app/features/territories/routes/attributions/list.tsx
@@ -59,16 +59,16 @@ export async function loader({ request }: Route.LoaderArgs) {
   )
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     const url = new URL(request.url)
     const selectors = computeFilters(url.searchParams)
     selectors.endDate = null
 
-    const { attributions, pagination } = await findActiveAttributionsPaginated(db, selectors, url)
+    const { attributions, pagination } = await findActiveAttributionsPaginated(db, selectors, url, congregationId)
 
     const messages = { success: session.get('success'), error: session.get('error') }
-    const groups = await getGroups(db)
+    const groups = await getGroups(db, congregationId)
     const theocraticYear = getCurrentTheocraticYear()
 
     return data(

--- a/app/features/territories/routes/attributions/new.tsx
+++ b/app/features/territories/routes/attributions/new.tsx
@@ -33,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     const territory = await db.territory.findUnique({
       where: {
@@ -50,6 +50,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const users = await db.user.findMany({
       where: {
         isPublisher: true,
+        congregationId,
       },
       orderBy: [
         {

--- a/app/features/territories/routes/attributions/pdf-export.tsx
+++ b/app/features/territories/routes/attributions/pdf-export.tsx
@@ -29,7 +29,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   })
 
   return withScope(congregationId, async db => {
-    const territories = await getTerritoriesExportData(db, Number(params.year))
+    const territories = await getTerritoriesExportData(db, congregationId, Number(params.year))
     const file = await pdf(
       <TerritoryAttributionDocument year={Number(params.year)} territories={territories} />,
     ).toBlob()

--- a/app/features/territories/routes/attributions/territories.tsx
+++ b/app/features/territories/routes/attributions/territories.tsx
@@ -43,10 +43,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     const selectors = await computeFilters(url.searchParams)
     selectors.attributions = { none: { endDate: null } }
 
-    const { territories, pagination } = await findAvailableTerritoriesPaginated(db, selectors, url)
+    const { territories, pagination } = await findAvailableTerritoriesPaginated(db, selectors, url, congregationId)
 
     const messages = { success: session.get('success'), error: session.get('error') }
-    const zips = await getZips(db)
+    const zips = await getZips(db, congregationId)
 
     return data(
       {

--- a/app/features/territories/routes/prospection/_layout.tsx
+++ b/app/features/territories/routes/prospection/_layout.tsx
@@ -34,7 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
+    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity, congregationId)) ?? '0')
     const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
     if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
     const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
@@ -42,14 +42,15 @@ export async function loader({ request }: Route.LoaderArgs) {
     const warningDate = new Date()
     warningDate.setMonth(warningDate.getMonth() - 3)
 
-    const totalBuildings = await db.building.count()
-    const totalActiveBuildings = await db.building.count({ where: { active: true } })
-    const totalRemovedBuildings = await db.building.count({ where: { inOpenData: false, active: true } })
+    const totalBuildings = await db.building.count({ where: { congregationId } })
+    const totalActiveBuildings = await db.building.count({ where: { active: true, congregationId } })
+    const totalRemovedBuildings = await db.building.count({ where: { inOpenData: false, active: true, congregationId } })
     const totalCreatedBuildings = await db.building.count({
-      where: { inOpenData: true, active: true, prospectionDate: null },
+      where: { inOpenData: true, active: true, prospectionDate: null, congregationId },
     })
     const totalStaleBuildings = await db.building.count({
       where: {
+        congregationId,
         // biome-ignore lint/style/useNamingConvention: OR is a keywork for prisma ORM
         OR: [
           {
@@ -107,7 +108,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })
     const banoUrl = await db.setting.findFirst({ where: { key: 'bano-url' } })
     const messages = { success: session.get('success'), error: session.get('error') }
-    const zips = await getZips(db)
+    const zips = await getZips(db, congregationId)
 
     return data(
       {

--- a/app/features/territories/routes/prospection/active-building-list.tsx
+++ b/app/features/territories/routes/prospection/active-building-list.tsx
@@ -32,7 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   return withScope(congregationId, async db => {
     const url = new URL(request.url)
     const staleDate = await getProspectionStaleDate(db)
-    const { buildings, pagination } = await findBuildingsPaginated(db, { active: true }, url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, { active: true }, url, congregationId)
 
     return {
       buildings,

--- a/app/features/territories/routes/prospection/building-list.tsx
+++ b/app/features/territories/routes/prospection/building-list.tsx
@@ -34,7 +34,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const url = new URL(request.url)
     const selectors = computeFilters(url.searchParams)
     const staleDate = await getProspectionStaleDate(db)
-    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url, congregationId)
 
     return {
       buildings,

--- a/app/features/territories/routes/prospection/edit-building-prospection.tsx
+++ b/app/features/territories/routes/prospection/edit-building-prospection.tsx
@@ -47,7 +47,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       throw redirect('/territories/buildings', { status: 404 })
     }
 
-    const buildings = await getBuildings(db, building.zip, building.street)
+    const buildings = await getBuildings(db, congregationId, building.zip, building.street)
     const messages = {
       success: session.get('success'),
       error: session.get('error'),

--- a/app/features/territories/routes/prospection/missing-building-list.tsx
+++ b/app/features/territories/routes/prospection/missing-building-list.tsx
@@ -35,7 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
     const selectors = { inOpenData: false, active: true }
     const url = new URL(request.url)
-    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url, congregationId)
 
     return {
       buildings,

--- a/app/features/territories/routes/prospection/need-check-building-list.tsx
+++ b/app/features/territories/routes/prospection/need-check-building-list.tsx
@@ -35,7 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity)) ?? '0')
+    const prospectionValidity = Number((await getSetting(db, TerritorySettingKey.ProspectionValidity, congregationId)) ?? '0')
     const staleDate = prospectionValidity > 0 ? new Date() : new Date(0)
     if (prospectionValidity > 0) staleDate.setMonth(staleDate.getMonth() - prospectionValidity)
     const inactiveStaleDate = prospectionValidity > 0 ? new Date() : new Date(0)
@@ -99,7 +99,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
 
     const url = new URL(request.url)
-    const { buildings, pagination } = await findBuildingsWithEntrancePaginated(db, selector, url)
+    const { buildings, pagination } = await findBuildingsWithEntrancePaginated(db, selector, url, congregationId)
 
     return {
       buildings,

--- a/app/features/territories/routes/prospection/new-building-list.tsx
+++ b/app/features/territories/routes/prospection/new-building-list.tsx
@@ -35,7 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
     const selectors = { inOpenData: true, active: true, prospectionDate: null }
     const url = new URL(request.url)
-    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url)
+    const { buildings, pagination } = await findBuildingsPaginated(db, selectors, url, congregationId)
 
     return {
       buildings,

--- a/app/features/territories/routes/split-tool/_layout.tsx
+++ b/app/features/territories/routes/split-tool/_layout.tsx
@@ -26,10 +26,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
     const totalBuildingsForDoors = await db.building.count({
       where: {
         active: true,
+        congregationId,
         entrance: {
           territories: {
             none: { type: TerritoryKind.Classical },
@@ -58,6 +59,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const totalBuildingsForPhone = await db.building.count({
       where: {
         active: true,
+        congregationId,
         entrance: {
           territories: {
             none: { type: TerritoryKind.Classical },
@@ -81,6 +83,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const totalBuildingsForCommerce = await db.building.count({
       where: {
         active: true,
+        congregationId,
         entrance: {
           territories: {
             none: { type: TerritoryKind.Commerces },
@@ -96,6 +99,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const totalBuildingsForCampus = await db.building.count({
       where: {
         active: true,
+        congregationId,
         entrance: {
           territories: {
             none: { type: TerritoryKind.Univ },
@@ -111,6 +115,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const totalBuildingsForHotel = await db.building.count({
       where: {
         active: true,
+        congregationId,
         entrance: {
           territories: {
             none: { type: TerritoryKind.Hotel },
@@ -125,7 +130,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })
 
     const messages = { success: session.get('success'), error: session.get('error') }
-    const zips = await getZips(db)
+    const zips = await getZips(db, congregationId)
 
     return data(
       {

--- a/app/features/territories/routes/split-tool/commerces.tsx
+++ b/app/features/territories/routes/split-tool/commerces.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       hasShops: true,
       entrance: { territories: { none: { type: TerritoryKind.Commerces } } },
     }
-    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url, congregationId)
 
     return {
       entrances,

--- a/app/features/territories/routes/split-tool/create.tsx
+++ b/app/features/territories/routes/split-tool/create.tsx
@@ -33,7 +33,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   return withScope(congregationId, async db => {
     const count = await db.territory.count({
-      where: { type: String(type) },
+      where: { type: String(type), congregationId },
     })
 
     let prefix = 'D'

--- a/app/features/territories/routes/split-tool/hotels.tsx
+++ b/app/features/territories/routes/split-tool/hotels.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       hasHotel: true,
       entrance: { territories: { none: { type: TerritoryKind.Hotel } } },
     }
-    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url, congregationId)
 
     return {
       entrances,

--- a/app/features/territories/routes/split-tool/list.tsx
+++ b/app/features/territories/routes/split-tool/list.tsx
@@ -32,7 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     const url = new URL(request.url)
     const filters = computeFilters(url.searchParams)
@@ -57,7 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       },
     }
 
-    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url, congregationId)
 
     return {
       entrances,

--- a/app/features/territories/routes/split-tool/phones.tsx
+++ b/app/features/territories/routes/split-tool/phones.tsx
@@ -32,7 +32,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
     if (!phoneTypeActive) {
       throw redirect('/territories/buildings/split-territories')
     }
@@ -57,7 +57,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ],
       entrance: { territories: { none: { type: TerritoryKind.Phone } } },
     }
-    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url, congregationId)
 
     return {
       entrances,

--- a/app/features/territories/routes/split-tool/university.tsx
+++ b/app/features/territories/routes/split-tool/university.tsx
@@ -42,7 +42,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       hasCampus: true,
       entrance: { territories: { none: { type: TerritoryKind.Univ } } },
     }
-    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url)
+    const { entrances, pagination } = await findEntrancesPaginated(db, selectors, url, congregationId)
 
     return {
       entrances,

--- a/app/features/territories/routes/stats/index.tsx
+++ b/app/features/territories/routes/stats/index.tsx
@@ -88,12 +88,13 @@ export async function loader({ request }: Route.LoaderArgs) {
       attributionsByGroup,
       groups,
     ] = await Promise.all([
-      countActiveWorkingTerritories(db),
-      countDelayedWorkingTerritories(db),
-      countRestingTerritories(db),
-      countAvailableTerritories(db),
+      countActiveWorkingTerritories(db, congregationId),
+      countDelayedWorkingTerritories(db, congregationId),
+      countRestingTerritories(db, congregationId),
+      countAvailableTerritories(db, congregationId),
       computeTerritoryCoverage(
         db,
+        congregationId,
         filterParams.territoryKind,
         filterParams.attributionKind,
         filterParams.startDate,
@@ -101,6 +102,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ),
       computeTerritoryCoverageTotal(
         db,
+        congregationId,
         filterParams.territoryKind,
         filterParams.attributionKind.length > 0
           ? filterParams.attributionKind
@@ -108,13 +110,13 @@ export async function loader({ request }: Route.LoaderArgs) {
         filterParams.startDate,
         filterParams.endDate,
       ),
-      fetchAttributionsForStats(db, filterParams),
-      fetchAttributionsForStats(db, prevParams),
-      fetchTerritoryCounts(db, filterParams.territoryKind),
-      fetchTerritoryCounts(db),
-      getTerritoriesNeverWorked(db, filterParams),
-      fetchActiveAttributionsByGroup(db),
-      getGroups(db),
+      fetchAttributionsForStats(db, filterParams, congregationId),
+      fetchAttributionsForStats(db, prevParams, congregationId),
+      fetchTerritoryCounts(db, congregationId, filterParams.territoryKind),
+      fetchTerritoryCounts(db, congregationId),
+      getTerritoriesNeverWorked(db, filterParams, congregationId),
+      fetchActiveAttributionsByGroup(db, congregationId),
+      getGroups(db, congregationId),
     ])
 
     const workingTerritoriesCount = activeWorkingTerritoriesCount + delayedWorkingTerritoriesCount

--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -59,12 +59,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         status: 404,
       })
     }
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
-    const zips = await getAvailableZips(db, territory.type as TerritoryKind)
+    const zips = await getAvailableZips(db, congregationId, territory.type as TerritoryKind)
     const url = new URL(request.url)
     const entrances = await getAvailableEntrances(
       db,
+      congregationId,
       String(url.searchParams.get('zip')),
       String(url.searchParams.get('street')),
       territory.type as TerritoryKind,
@@ -82,7 +83,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       }
     }
 
-    const streets = await getAvailableStreets(db, String(url.searchParams.get('zip')), territory.type as TerritoryKind)
+    const streets = await getAvailableStreets(db, congregationId, String(url.searchParams.get('zip')), territory.type as TerritoryKind)
     if (!url.searchParams.has('street')) {
       return {
         territory,

--- a/app/features/territories/routes/territory/list.tsx
+++ b/app/features/territories/routes/territory/list.tsx
@@ -45,17 +45,17 @@ export async function loader({ request }: Route.LoaderArgs) {
   const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     const url = new URL(request.url)
     const selectors = await computeFilters(url.searchParams)
-    const { territories, pagination } = await findTerritoriesWithDetailsPaginated(db, selectors, url)
+    const { territories, pagination } = await findTerritoriesWithDetailsPaginated(db, selectors, url, congregationId)
 
     const messages = {
       success: session.get('success'),
       error: session.get('error'),
     }
-    const zips = await getZips(db)
+    const zips = await getZips(db, congregationId)
 
     return data(
       {

--- a/app/features/territories/routes/territory/new.tsx
+++ b/app/features/territories/routes/territory/new.tsx
@@ -35,16 +35,17 @@ export async function loader({ request }: Route.LoaderArgs) {
   const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
 
   return withScope(congregationId, async db => {
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
     const url = new URL(request.url)
     const zips = await db.building.groupBy({
       by: ['zip'],
-      where: { active: true },
+      where: { active: true, congregationId },
     })
 
     const buildings = await db.building.findMany({
       where: {
         active: true,
+        congregationId,
         street: String(url.searchParams.get('street')),
         zip: String(url.searchParams.get('zip')),
       },
@@ -60,7 +61,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
     const streets = await db.building.groupBy({
       by: ['street'],
-      where: { active: true, zip: String(url.searchParams.get('zip')) },
+      where: { active: true, congregationId, zip: String(url.searchParams.get('zip')) },
     })
 
     if (!url.searchParams.has('street')) {

--- a/app/features/territories/routes/territory/view.tsx
+++ b/app/features/territories/routes/territory/view.tsx
@@ -55,7 +55,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
     const apiKey = getOptionalEnv('GOOGLE_MAPS_API_KEY')
     const mapId = getOptionalEnv('GOOGLE_MAPS_MAP_ID')
-    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive)
+    const phoneTypeActive = await getBoolSetting(db, TerritorySettingKey.TerritoryTypePhoneActive, congregationId)
 
     return {
       territory,

--- a/app/features/territories/server/active-working-territories.server.test.ts
+++ b/app/features/territories/server/active-working-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countActiveWorkingTerritories', () => {
   it('retourne le nombre de territoires en cours de travail', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
 
-    const result = await countActiveWorkingTerritories(db)
+    const result = await countActiveWorkingTerritories(db, 1)
     expect(result).toBe(5)
   })
 
   it("retourne 0 quand aucun territoire n'est actif", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countActiveWorkingTerritories(db)
+    const result = await countActiveWorkingTerritories(db, 1)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/active-working-territories.server.ts
+++ b/app/features/territories/server/active-working-territories.server.ts
@@ -1,8 +1,9 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function countActiveWorkingTerritories(db: TransactionClient) {
+export async function countActiveWorkingTerritories(db: TransactionClient, congregationId: number) {
   return await db.territory.count({
     where: {
+      congregationId,
       attributions: {
         some: {
           endDate: null,

--- a/app/features/territories/server/attributions.ts
+++ b/app/features/territories/server/attributions.ts
@@ -6,14 +6,15 @@ export async function findActiveAttributionsPaginated(
   db: TransactionClient,
   selectors: Prisma.AttributionWhereInput,
   url: URL,
+  congregationId: number,
 ) {
-  const total = await db.attribution.count({ where: selectors })
+  const total = await db.attribution.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, total)
 
   const attributions = await db.attribution.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     include: { territory: true, publisher: true },
     orderBy: [{ startDate: 'asc' }],
   })

--- a/app/features/territories/server/available-territories.server.test.ts
+++ b/app/features/territories/server/available-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countAvailableTerritories', () => {
   it('retourne le nombre de territoires disponibles', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(12)
 
-    const result = await countAvailableTerritories(db)
+    const result = await countAvailableTerritories(db, 1)
     expect(result).toBe(12)
   })
 
   it("retourne 0 quand aucun territoire n'est disponible", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countAvailableTerritories(db)
+    const result = await countAvailableTerritories(db, 1)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/available-territories.server.ts
+++ b/app/features/territories/server/available-territories.server.ts
@@ -6,7 +6,7 @@ import {
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countAvailableTerritories(db: TransactionClient) {
+export async function countAvailableTerritories(db: TransactionClient, congregationId: number) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()
@@ -16,6 +16,7 @@ export async function countAvailableTerritories(db: TransactionClient) {
   endRestPeriodForPhone.setTime(endRestPeriodForPhone.getTime() - RESTING_PERIOD_FOR_PHONE)
   return await db.territory.count({
     where: {
+      congregationId,
       attributions: {
         every: {
           // biome-ignore lint/style/useNamingConvention: Prisma does not support snake_case

--- a/app/features/territories/server/buildings.ts
+++ b/app/features/territories/server/buildings.ts
@@ -27,14 +27,19 @@ function sortEntrancesByAddress(entrances: Entrance[]) {
   return entrances
 }
 
-export async function findBuildingsPaginated(db: TransactionClient, selectors: Prisma.BuildingWhereInput, url: URL) {
-  const totalBuildings = await db.building.count({ where: selectors })
+export async function findBuildingsPaginated(
+  db: TransactionClient,
+  selectors: Prisma.BuildingWhereInput,
+  url: URL,
+  congregationId: number,
+) {
+  const totalBuildings = await db.building.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, totalBuildings)
 
   const buildings = await db.building.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     orderBy: [{ zip: 'asc' }, { street: 'asc' }, { number: 'asc' }],
   })
 
@@ -47,14 +52,15 @@ export async function findBuildingsWithEntrancePaginated(
   db: TransactionClient,
   selectors: Prisma.BuildingWhereInput,
   url: URL,
+  congregationId: number,
 ) {
-  const totalBuildings = await db.building.count({ where: selectors })
+  const totalBuildings = await db.building.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, totalBuildings)
 
   const buildings = await db.building.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     include: { entrance: true },
     orderBy: [{ zip: 'asc' }, { street: 'asc' }, { number: 'asc' }],
   })
@@ -64,14 +70,19 @@ export async function findBuildingsWithEntrancePaginated(
   return { buildings, pagination }
 }
 
-export async function findEntrancesPaginated(db: TransactionClient, selectors: Prisma.BuildingWhereInput, url: URL) {
-  const totalBuildings = await db.building.count({ where: selectors })
+export async function findEntrancesPaginated(
+  db: TransactionClient,
+  selectors: Prisma.BuildingWhereInput,
+  url: URL,
+  congregationId: number,
+) {
+  const totalBuildings = await db.building.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, totalBuildings)
 
   const buildings = await db.building.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     select: { entrance: { include: { buildings: true } } },
     distinct: ['entranceId'],
     orderBy: [{ zip: 'asc' }, { street: 'asc' }, { number: 'asc' }],
@@ -116,8 +127,8 @@ export function aggregateEntrance(entrance: Entrance): AggregatedEntrance {
   }
 }
 
-export async function getZips(db: TransactionClient, territoryType?: TerritoryKind) {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+export async function getZips(db: TransactionClient, congregationId: number, territoryType?: TerritoryKind) {
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (territoryType != null) {
     selectors.entrance = {
@@ -132,8 +143,8 @@ export async function getZips(db: TransactionClient, territoryType?: TerritoryKi
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getAvailableZips(db: TransactionClient, territoryType?: TerritoryKind) {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+export async function getAvailableZips(db: TransactionClient, congregationId: number, territoryType?: TerritoryKind) {
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (territoryType != null) {
     selectors.entrance = {
@@ -148,8 +159,8 @@ export async function getAvailableZips(db: TransactionClient, territoryType?: Te
   return await db.building.groupBy({ by: 'zip', where: selectors })
 }
 
-export async function getStreets(db: TransactionClient, zip?: string, territoryType?: TerritoryKind) {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+export async function getStreets(db: TransactionClient, congregationId: number, zip?: string, territoryType?: TerritoryKind) {
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (zip != null) {
     selectors.zip = zip
@@ -168,8 +179,8 @@ export async function getStreets(db: TransactionClient, zip?: string, territoryT
   return await db.building.groupBy({ by: 'street', where: selectors })
 }
 
-export async function getAvailableStreets(db: TransactionClient, zip?: string, territoryType?: TerritoryKind) {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+export async function getAvailableStreets(db: TransactionClient, congregationId: number, zip?: string, territoryType?: TerritoryKind) {
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (zip != null) {
     selectors.zip = zip
@@ -189,11 +200,12 @@ export async function getAvailableStreets(db: TransactionClient, zip?: string, t
 
 export async function getEntrances(
   db: TransactionClient,
+  congregationId: number,
   zip?: string,
   street?: string,
   territoryType?: TerritoryKind,
 ): Promise<Entrance[]> {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (zip != null) {
     selectors.zip = zip
@@ -224,11 +236,12 @@ export async function getEntrances(
 
 export async function getAvailableEntrances(
   db: TransactionClient,
+  congregationId: number,
   zip?: string,
   street?: string,
   territoryType?: TerritoryKind,
 ): Promise<Entrance[]> {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (zip != null) {
     selectors.zip = zip

--- a/app/features/territories/server/delayed-working-territories.server.test.ts
+++ b/app/features/territories/server/delayed-working-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countDelayedWorkingTerritories', () => {
   it('retourne le nombre de territoires en retard', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(3)
 
-    const result = await countDelayedWorkingTerritories(db)
+    const result = await countDelayedWorkingTerritories(db, 1)
     expect(result).toBe(3)
   })
 
   it("retourne 0 quand aucun territoire n'est en retard", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countDelayedWorkingTerritories(db)
+    const result = await countDelayedWorkingTerritories(db, 1)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/delayed-working-territories.server.ts
+++ b/app/features/territories/server/delayed-working-territories.server.ts
@@ -1,8 +1,9 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function countDelayedWorkingTerritories(db: TransactionClient) {
+export async function countDelayedWorkingTerritories(db: TransactionClient, congregationId: number) {
   return await db.territory.count({
     where: {
+      congregationId,
       attributions: {
         some: {
           endDate: null,

--- a/app/features/territories/server/fetch-attributions-by-group.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.test.ts
@@ -21,7 +21,7 @@ describe('fetchActiveAttributionsByGroup', () => {
       { publisher: { publisherGroup: { name: 'Groupe B' } } },
     ] as never)
 
-    const result = await fetchActiveAttributionsByGroup(db)
+    const result = await fetchActiveAttributionsByGroup(db, 1)
 
     expect(result).toEqual([
       { groupName: 'Groupe A', count: 2 },
@@ -35,7 +35,7 @@ describe('fetchActiveAttributionsByGroup', () => {
       { publisher: { publisherGroup: { name: 'Groupe A' } } },
     ] as never)
 
-    const result = await fetchActiveAttributionsByGroup(db)
+    const result = await fetchActiveAttributionsByGroup(db, 1)
 
     expect(result).toEqual([
       { groupName: 'Sans groupe', count: 1 },
@@ -46,7 +46,7 @@ describe('fetchActiveAttributionsByGroup', () => {
   it("retourne un tableau vide quand il n'y a aucune attribution active", async () => {
     vi.mocked(db.attribution.findMany).mockResolvedValue([])
 
-    const result = await fetchActiveAttributionsByGroup(db)
+    const result = await fetchActiveAttributionsByGroup(db, 1)
     expect(result).toEqual([])
   })
 })

--- a/app/features/territories/server/fetch-attributions-by-group.server.ts
+++ b/app/features/territories/server/fetch-attributions-by-group.server.ts
@@ -6,9 +6,12 @@ export interface AttributionsByGroup {
 }
 
 // Compte les attributions actives (en cours) regroupées par groupe de prédication
-export async function fetchActiveAttributionsByGroup(db: TransactionClient): Promise<AttributionsByGroup[]> {
+export async function fetchActiveAttributionsByGroup(
+  db: TransactionClient,
+  congregationId: number,
+): Promise<AttributionsByGroup[]> {
   const attributions = await db.attribution.findMany({
-    where: { endDate: null },
+    where: { endDate: null, congregationId },
     select: {
       publisher: {
         select: {

--- a/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.test.ts
@@ -34,7 +34,7 @@ describe('fetchAttributionsForStats', () => {
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
-    })
+    }, 1)
 
     expect(result).toEqual([
       {
@@ -58,7 +58,7 @@ describe('fetchAttributionsForStats', () => {
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
-    })
+    }, 1)
 
     expect(result).toEqual([])
   })
@@ -72,7 +72,7 @@ describe('fetchAttributionsForStats', () => {
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
       groupId: 42,
-    })
+    }, 1)
 
     expect(result).toEqual([])
   })

--- a/app/features/territories/server/fetch-attributions-for-stats.server.ts
+++ b/app/features/territories/server/fetch-attributions-for-stats.server.ts
@@ -15,9 +15,11 @@ function buildDateOverlapWhere(startDate: Date, endDate: Date): Prisma.Attributi
 export async function fetchAttributionsForStats(
   db: TransactionClient,
   params: StatsFilterParams,
+  congregationId: number,
 ): Promise<StatsAttribution[]> {
   const attributions = await db.attribution.findMany({
     where: {
+      congregationId,
       territory: {
         type: { in: params.territoryKind },
       },

--- a/app/features/territories/server/fetch-territory-counts.server.test.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.test.ts
@@ -22,7 +22,7 @@ describe('fetchTerritoryCounts', () => {
       { type: 'commerces', _count: { id: 5 } },
     ] as never)
 
-    const result = await fetchTerritoryCounts(db, [TerritoryKind.Classical, TerritoryKind.Commerces])
+    const result = await fetchTerritoryCounts(db, 1, [TerritoryKind.Classical, TerritoryKind.Commerces])
 
     expect(result).toEqual([
       { type: TerritoryKind.Classical, count: 30 },
@@ -33,7 +33,7 @@ describe('fetchTerritoryCounts', () => {
   it('fonctionne sans filtre de types', async () => {
     vi.mocked(db.territory.groupBy).mockResolvedValue([{ type: 'doors-to-doors', _count: { id: 20 } }] as never)
 
-    const result = await fetchTerritoryCounts(db)
+    const result = await fetchTerritoryCounts(db, 1)
 
     expect(result).toEqual([{ type: TerritoryKind.Classical, count: 20 }])
   })

--- a/app/features/territories/server/fetch-territory-counts.server.ts
+++ b/app/features/territories/server/fetch-territory-counts.server.ts
@@ -7,12 +7,16 @@ export { getTotalTerritoryCount } from './territory-count-by-type.type'
 
 export async function fetchTerritoryCounts(
   db: TransactionClient,
+  congregationId: number,
   territoryKinds?: TerritoryKind[],
 ): Promise<TerritoryCountByType[]> {
   const groups = await db.territory.groupBy({
     by: ['type'],
     _count: { id: true },
-    ...(territoryKinds != null && territoryKinds.length > 0 ? { where: { type: { in: territoryKinds } } } : {}),
+    where: {
+      congregationId,
+      ...(territoryKinds != null && territoryKinds.length > 0 ? { type: { in: territoryKinds } } : {}),
+    },
   })
 
   return groups.map(g => ({

--- a/app/features/territories/server/get-buildings.server.test.ts
+++ b/app/features/territories/server/get-buildings.server.test.ts
@@ -18,14 +18,14 @@ describe('getBuildings', () => {
     const fakeBuildings = [{ id: 1, zip: '75001', street: 'Rue Test' }]
     vi.mocked(db.building.findMany).mockResolvedValue(fakeBuildings as never)
 
-    const result = await getBuildings(db, '75001', 'Rue Test')
+    const result = await getBuildings(db, 1, '75001', 'Rue Test')
     expect(result).toEqual(fakeBuildings)
   })
 
   it('retourne un tableau vide quand aucun bâtiment ne correspond', async () => {
     vi.mocked(db.building.findMany).mockResolvedValue([] as never)
 
-    const result = await getBuildings(db, '00000', 'Rue Inexistante')
+    const result = await getBuildings(db, 1, '00000', 'Rue Inexistante')
     expect(result).toEqual([])
   })
 })

--- a/app/features/territories/server/get-buildings.server.ts
+++ b/app/features/territories/server/get-buildings.server.ts
@@ -2,8 +2,13 @@ import type { Building, Prisma } from '~/database/generated/client'
 
 import type { TransactionClient } from '~/shared/libs/db.server'
 
-export async function getBuildings(db: TransactionClient, zip: string, street: string): Promise<Building[]> {
-  const selectors: Prisma.BuildingWhereInput = { active: true }
+export async function getBuildings(
+  db: TransactionClient,
+  congregationId: number,
+  zip: string,
+  street: string,
+): Promise<Building[]> {
+  const selectors: Prisma.BuildingWhereInput = { active: true, congregationId }
 
   if (zip != null) {
     selectors.zip = zip

--- a/app/features/territories/server/import-open-data.server.ts
+++ b/app/features/territories/server/import-open-data.server.ts
@@ -15,6 +15,7 @@ export async function importOpenData(
   await db.building.updateMany({
     where: {
       inOpenData: true,
+      congregationId,
     },
     data: {
       inOpenData: false,

--- a/app/features/territories/server/resting-territories.server.test.ts
+++ b/app/features/territories/server/resting-territories.server.test.ts
@@ -23,14 +23,14 @@ describe('countRestingTerritories', () => {
   it('retourne le nombre de territoires au repos', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(7)
 
-    const result = await countRestingTerritories(db)
+    const result = await countRestingTerritories(db, 1)
     expect(result).toBe(7)
   })
 
   it('retourne 0 quand aucun territoire ne se repose', async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await countRestingTerritories(db)
+    const result = await countRestingTerritories(db, 1)
     expect(result).toBe(0)
   })
 })

--- a/app/features/territories/server/resting-territories.server.ts
+++ b/app/features/territories/server/resting-territories.server.ts
@@ -6,7 +6,7 @@ import {
   RESTING_PERIOD_FOR_PHONE,
 } from './resting-periods.server'
 
-export async function countRestingTerritories(db: TransactionClient) {
+export async function countRestingTerritories(db: TransactionClient, congregationId: number) {
   const endRestPeriodForDoorsToDoors = new Date()
   const endRestPeriodForCampaign = new Date()
   const endRestPeriodForPhone = new Date()
@@ -17,6 +17,7 @@ export async function countRestingTerritories(db: TransactionClient) {
 
   return await db.territory.count({
     where: {
+      congregationId,
       attributions: {
         some: {
           // biome-ignore lint/style/useNamingConvention: Prisma does not support snake_case

--- a/app/features/territories/server/territories-export-data.server.test.ts
+++ b/app/features/territories/server/territories-export-data.server.test.ts
@@ -27,17 +27,17 @@ describe('getTerritoriesExportData', () => {
     const fakeTerritories = [{ id: 1, attributions: [] }]
     vi.mocked(db.territory.findMany).mockResolvedValue(fakeTerritories as never)
 
-    const result = await getTerritoriesExportData(db as never, 2025)
+    const result = await getTerritoriesExportData(db as never, 1, 2025)
     expect(result).toEqual(fakeTerritories)
   })
 
   it("retourne un tableau vide quand il n'y a pas de territoires", async () => {
-    const result = await getTerritoriesExportData(db as never, 2025)
+    const result = await getTerritoriesExportData(db as never, 1, 2025)
     expect(result).toEqual([])
   })
 
   it("passe l'année théocratique aux fonctions de date", async () => {
-    await getTerritoriesExportData(db as never, 2024)
+    await getTerritoriesExportData(db as never, 1, 2024)
 
     // Vérifier que les fonctions de date ont été utilisées (via le résultat)
     expect(vi.mocked(getBeginingDateOfTheocraticYear).mock.calls[0][0]).toBe(2024)
@@ -45,7 +45,7 @@ describe('getTerritoriesExportData', () => {
   })
 
   it('inclut les attributions anciennes encore actives (sans date de fin)', async () => {
-    await getTerritoriesExportData(db as never, 2025)
+    await getTerritoriesExportData(db as never, 1, 2025)
 
     const call = vi.mocked(db.territory.findMany).mock.calls[0][0] as Record<string, unknown>
     const attrWhere = (call.include as { attributions: { where: Record<string, unknown> } }).attributions.where

--- a/app/features/territories/server/territories-export-data.server.ts
+++ b/app/features/territories/server/territories-export-data.server.ts
@@ -1,7 +1,7 @@
 import type { TransactionClient } from '~/shared/libs/db.server'
 import { getBeginingDateOfTheocraticYear, getEndDateOfTheocraticYear } from './theocratic-year.server'
 
-export async function getTerritoriesExportData(db: TransactionClient, theocraticYear?: number) {
+export async function getTerritoriesExportData(db: TransactionClient, congregationId: number, theocraticYear?: number) {
   const startDate = getBeginingDateOfTheocraticYear(theocraticYear)
   const endDate = getEndDateOfTheocraticYear(theocraticYear)
 
@@ -11,6 +11,7 @@ export async function getTerritoriesExportData(db: TransactionClient, theocratic
   endDatePreviousYear.setFullYear(endDatePreviousYear.getFullYear() - 1)
 
   return await db.territory.findMany({
+    where: { congregationId },
     include: {
       attributions: {
         orderBy: { startDate: 'desc' },

--- a/app/features/territories/server/territories-never-worked.server.test.ts
+++ b/app/features/territories/server/territories-never-worked.server.test.ts
@@ -27,7 +27,7 @@ describe('getTerritoriesNeverWorked', () => {
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
-    })
+    }, 1)
 
     expect(result).toEqual([
       { id: 5, number: 'T-5' },
@@ -43,7 +43,7 @@ describe('getTerritoriesNeverWorked', () => {
       attributionKind: [TerritoryAttributionKind.Default],
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
-    })
+    }, 1)
 
     expect(result).toEqual([])
   })
@@ -57,7 +57,7 @@ describe('getTerritoriesNeverWorked', () => {
       startDate: new Date(2025, 8, 1),
       endDate: new Date(2026, 7, 31),
       groupId: 7,
-    })
+    }, 1)
 
     expect(result).toEqual([{ id: 3, number: 'T-3' }])
   })

--- a/app/features/territories/server/territories-never-worked.server.ts
+++ b/app/features/territories/server/territories-never-worked.server.ts
@@ -10,6 +10,7 @@ export interface NeverWorkedTerritory {
 export async function getTerritoriesNeverWorked(
   db: TransactionClient,
   params: StatsFilterParams,
+  congregationId: number,
 ): Promise<NeverWorkedTerritory[]> {
   const dateOverlap: Prisma.AttributionWhereInput = {
     startDate: { lte: params.endDate },
@@ -19,6 +20,7 @@ export async function getTerritoriesNeverWorked(
 
   const territories = await db.territory.findMany({
     where: {
+      congregationId,
       type: { in: params.territoryKind },
       attributions: {
         none: {

--- a/app/features/territories/server/territories.server.test.ts
+++ b/app/features/territories/server/territories.server.test.ts
@@ -18,7 +18,7 @@ describe('findTerritoriesWithDetailsPaginated', () => {
     vi.mocked(db.territory.count).mockResolvedValue(50 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 1 }, { id: 2 }] as never)
 
-    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/?page=1&pageSize=25'))
+    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/?page=1&pageSize=25'), 1)
 
     expect(result.territories).toHaveLength(2)
     expect(result.pagination.total).toBe(50)
@@ -29,7 +29,7 @@ describe('findTerritoriesWithDetailsPaginated', () => {
     vi.mocked(db.territory.count).mockResolvedValue(0 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([] as never)
 
-    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/'))
+    const result = await findTerritoriesWithDetailsPaginated(db, {}, new URL('http://localhost/'), 1)
 
     expect(result.territories).toEqual([])
     expect(result.pagination.total).toBe(0)
@@ -41,7 +41,7 @@ describe('findAvailableTerritoriesPaginated', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10 as never)
     vi.mocked(db.territory.findMany).mockResolvedValue([{ id: 3 }] as never)
 
-    const result = await findAvailableTerritoriesPaginated(db, {}, new URL('http://localhost/'))
+    const result = await findAvailableTerritoriesPaginated(db, {}, new URL('http://localhost/'), 1)
 
     expect(result.territories).toHaveLength(1)
     expect(result.pagination.total).toBe(10)

--- a/app/features/territories/server/territories.ts
+++ b/app/features/territories/server/territories.ts
@@ -6,14 +6,15 @@ export async function findTerritoriesWithDetailsPaginated(
   db: TransactionClient,
   selectors: Prisma.TerritoryWhereInput,
   url: URL,
+  congregationId: number,
 ) {
-  const total = await db.territory.count({ where: selectors })
+  const total = await db.territory.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, total)
 
   const territories = await db.territory.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     include: {
       entrances: { include: { buildings: { where: { active: true } } } },
       attributions: { where: { endDate: null }, include: { publisher: true } },
@@ -27,14 +28,15 @@ export async function findAvailableTerritoriesPaginated(
   db: TransactionClient,
   selectors: Prisma.TerritoryWhereInput,
   url: URL,
+  congregationId: number,
 ) {
-  const total = await db.territory.count({ where: selectors })
+  const total = await db.territory.count({ where: { ...selectors, congregationId } })
   const pagination = paginationFromUrl(url, total)
 
   const territories = await db.territory.findMany({
     skip: pagination.offset,
     take: pagination.size,
-    where: selectors,
+    where: { ...selectors, congregationId },
     include: {
       entrances: { include: { buildings: true } },
       attributions: { orderBy: { endDate: 'desc' }, take: 1 },

--- a/app/features/territories/server/territory-coverage-total.server.test.ts
+++ b/app/features/territories/server/territory-coverage-total.server.test.ts
@@ -18,21 +18,21 @@ describe('computeTerritoryCoverageTotal', () => {
     // Premier appel: total, deuxième appel: territoires avec attributions
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(4)
 
-    const result = await computeTerritoryCoverageTotal(db)
+    const result = await computeTerritoryCoverageTotal(db, 1)
     expect(result).toBe(40)
   })
 
   it("retourne 0 quand il n'y a aucun territoire", async () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
 
-    const result = await computeTerritoryCoverageTotal(db)
+    const result = await computeTerritoryCoverageTotal(db, 1)
     expect(result).toBe(0)
   })
 
   it('retourne 100 quand tous les territoires ont des attributions', async () => {
     vi.mocked(db.territory.count).mockResolvedValueOnce(5).mockResolvedValueOnce(5)
 
-    const result = await computeTerritoryCoverageTotal(db)
+    const result = await computeTerritoryCoverageTotal(db, 1)
     expect(result).toBe(100)
   })
 
@@ -40,7 +40,7 @@ describe('computeTerritoryCoverageTotal', () => {
     // Chaque territoire ne peut être compté qu'une fois
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(10)
 
-    const result = await computeTerritoryCoverageTotal(db)
+    const result = await computeTerritoryCoverageTotal(db, 1)
     expect(result).toBe(100)
   })
 
@@ -48,7 +48,7 @@ describe('computeTerritoryCoverageTotal', () => {
     vi.mocked(db.territory.count).mockResolvedValueOnce(10).mockResolvedValueOnce(3)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverageTotal(db as never, undefined, undefined, startDate)
+    const result = await computeTerritoryCoverageTotal(db as never, 1, undefined, undefined, startDate)
     expect(result).toBe(30)
   })
 
@@ -57,7 +57,7 @@ describe('computeTerritoryCoverageTotal', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverageTotal(db as never, undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverageTotal(db as never, 1, undefined, undefined, startDate, endDate)
     expect(result).toBe(70)
   })
 })

--- a/app/features/territories/server/territory-coverage-total.server.ts
+++ b/app/features/territories/server/territory-coverage-total.server.ts
@@ -5,6 +5,7 @@ import type { TransactionClient } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverageTotal(
   db: TransactionClient,
+  congregationId: number,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,
@@ -28,12 +29,14 @@ export async function computeTerritoryCoverageTotal(
   // Count total territories of the specified kind
   const total = await db.territory.count({
     where: {
+      congregationId,
       type: { in: territoryKind },
     },
   })
 
   const count = await db.territory.count({
     where: {
+      congregationId,
       type: { in: territoryKind },
       attributions: {
         some: {

--- a/app/features/territories/server/territory-coverage.server.test.ts
+++ b/app/features/territories/server/territory-coverage.server.test.ts
@@ -22,7 +22,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10)
     vi.mocked(db.attribution.count).mockResolvedValue(3)
 
-    const result = await computeTerritoryCoverage(db)
+    const result = await computeTerritoryCoverage(db, 1)
     expect(result).toBe(30)
   })
 
@@ -30,7 +30,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(0)
     vi.mocked(db.attribution.count).mockResolvedValue(0)
 
-    const result = await computeTerritoryCoverage(db)
+    const result = await computeTerritoryCoverage(db, 1)
     expect(result).toBe(0)
   })
 
@@ -38,7 +38,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
     vi.mocked(db.attribution.count).mockResolvedValue(5)
 
-    const result = await computeTerritoryCoverage(db)
+    const result = await computeTerritoryCoverage(db, 1)
     expect(result).toBe(100)
   })
 
@@ -46,7 +46,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(5)
     vi.mocked(db.attribution.count).mockResolvedValue(10)
 
-    const result = await computeTerritoryCoverage(db)
+    const result = await computeTerritoryCoverage(db, 1)
     expect(result).toBe(200)
   })
 
@@ -56,6 +56,7 @@ describe('computeTerritoryCoverage', () => {
 
     const result = await computeTerritoryCoverage(
       db as never,
+      1,
       [TerritoryKind.Phone, TerritoryKind.Classical],
       [TerritoryAttributionKind.Phone],
     )
@@ -66,11 +67,11 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.territory.count).mockResolvedValue(10)
     vi.mocked(db.attribution.count).mockResolvedValue(2)
 
-    await computeTerritoryCoverage(db)
+    await computeTerritoryCoverage(db, 1)
 
     // On vérifie le résultat, pas l'appel au mock
     // Les valeurs par défaut sont testées implicitement via le résultat correct
-    expect(await computeTerritoryCoverage(db)).toBe(20)
+    expect(await computeTerritoryCoverage(db, 1)).toBe(20)
   })
 
   it('accepte un filtre startDate', async () => {
@@ -78,7 +79,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(4)
 
     const startDate = new Date(2025, 0, 1)
-    const result = await computeTerritoryCoverage(db as never, undefined, undefined, startDate)
+    const result = await computeTerritoryCoverage(db as never, 1, undefined, undefined, startDate)
     expect(result).toBe(40)
   })
 
@@ -87,7 +88,7 @@ describe('computeTerritoryCoverage', () => {
     vi.mocked(db.attribution.count).mockResolvedValue(6)
 
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(db as never, undefined, undefined, undefined, endDate)
+    const result = await computeTerritoryCoverage(db as never, 1, undefined, undefined, undefined, endDate)
     expect(result).toBe(60)
   })
 
@@ -97,7 +98,7 @@ describe('computeTerritoryCoverage', () => {
 
     const startDate = new Date(2025, 0, 1)
     const endDate = new Date(2025, 11, 31)
-    const result = await computeTerritoryCoverage(db as never, undefined, undefined, startDate, endDate)
+    const result = await computeTerritoryCoverage(db as never, 1, undefined, undefined, startDate, endDate)
     expect(result).toBe(80)
   })
 })

--- a/app/features/territories/server/territory-coverage.server.ts
+++ b/app/features/territories/server/territory-coverage.server.ts
@@ -5,6 +5,7 @@ import type { TransactionClient } from '~/shared/libs/db.server'
 
 export async function computeTerritoryCoverage(
   db: TransactionClient,
+  congregationId: number,
   territoryKind: TerritoryKind[] = [TerritoryKind.Classical],
   attributionKind: TerritoryAttributionKind[] = [TerritoryAttributionKind.Default],
   startDate?: Date,
@@ -29,12 +30,14 @@ export async function computeTerritoryCoverage(
   // Count total territories of the specified kind
   const total = await db.territory.count({
     where: {
+      congregationId,
       type: { in: territoryKind },
     },
   })
 
   const count = await db.attribution.count({
     where: {
+      congregationId,
       territory: {
         type: { in: territoryKind },
       },


### PR DESCRIPTION
## Summary

- Add explicit `congregationId` to every `findMany`, `count`, and `groupBy` query on scoped models
- RLS via `SET LOCAL` inside `$transaction` is not reliably propagated by PrismaPg adapter — confirmed in production (user list worked because it already had explicit `congregationId`, publisher list didn't)
- All query types now use explicit `congregationId`: `findUnique` (compound keys), `create` (in data), `findMany`/`count`/`groupBy` (in where)
- RLS remains as defense-in-depth safety net

## Context

Follow-up to #21. After deploying, user list was correctly scoped but publisher list still showed all congregations' data. Root cause: the publisher service functions relied solely on RLS (no explicit `congregationId` in where clause), and `SET LOCAL` doesn't reliably propagate to queries within the same `$transaction` when using PrismaPg.

## Test plan

- [x] `pnpm test:typecheck` passes
- [x] `pnpm test:lint` passes (0 errors, 0 warnings)
- [x] `pnpm test:unit` passes (326/326 tests)
- [ ] Verify publisher list only shows current congregation's publishers
- [ ] Verify territory list, board, events are all correctly scoped