### PR TITLE
fix: close GDPR audit gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Unitae processes religious affiliation data (special category data under GDPR Ar
 - **Consent management** — Consent gate on first login, user-facing consent management page
 - **Privacy policy** — Built-in `/privacy` page covering all RGPD requirements
 - **Cookie consent** — Third-party services (Google Maps) only load after explicit consent
+- **Audit logging** — Structured audit trail for all GDPR-sensitive operations (login, data export, anonymization, consent, password changes)
+- **Log PII redaction** — Personal data automatically hashed in application logs
+- **Data retention** — Automated cleanup of expired tokens and old consent records via cron endpoint
 - **Deletion ledger** — Tracks anonymization operations for backup reconciliation
 - **Tenant isolation** — PostgreSQL Row-Level Security ensures strict data separation between congregations
 
-For the managed hosting service at [unitae.app](https://unitae.app), MindsersIT acts as data processor and provides a Data Processing Agreement (DPA) to each congregation. See [GDPR Checklist](docs/gdpr-checklist.md) for the full compliance status.
+For the managed hosting service at [unitae.app](https://unitae.app), MindsersIT acts as data processor and provides a Data Processing Agreement (DPA) to each congregation.
 
 Self-hosted instances are under the sole responsibility of the deploying entity — MindsersIT has no processor role since no data transits through its systems.
 
@@ -45,7 +48,6 @@ Full documentation is available in the [`docs/`](docs/README.md) folder:
 
 - [What is Unitae?](docs/product/what-is-unitae.md) — Product overview and background
 - [Feature Overview](docs/product/feature-overview.md) — What you can do with Unitae
-- [GDPR Checklist](docs/gdpr-checklist.md) — Data protection compliance status and roadmap
 - [Self-Hosting vs Managed Hosting](docs/managed-hosting/self-hosting-vs-managed.md) — Compare your options
 - [Environment Variables](docs/self-hosting/environment-variables.md) — Full configuration reference
 - [FAQ](docs/resources/faq.md) — Common questions answered

--- a/app/features/authentication/routes/password-forgot.tsx
+++ b/app/features/authentication/routes/password-forgot.tsx
@@ -3,6 +3,7 @@ import { data, Form, Link, redirect } from 'react-router'
 import { createPasswordResetToken } from '~/features/authentication/server/invalidate-user-password.server'
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
+import { audit, AuditAction } from '~/shared/libs/audit.server'
 import { getBrandingName, resolveCongregation, resolveCongregationFromRequest } from '~/shared/libs/congregation.server'
 import { unscopedDb as db } from '~/shared/libs/db.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
@@ -106,6 +107,14 @@ export async function action({ request }: Route.ActionArgs) {
       platformName={congregation.displayName}
     />,
   )
+
+  audit({
+    action: AuditAction.PasswordResetRequested,
+    congregationId: user.congregationId,
+    actorId: user.id,
+    entityType: 'User',
+    entityId: user.id,
+  })
 
   return redirect('/password/forgot', {
     headers: { 'Set-Cookie': await commitSession(session) },

--- a/app/features/authentication/routes/password-invalidation.tsx
+++ b/app/features/authentication/routes/password-invalidation.tsx
@@ -4,6 +4,7 @@ import { createPasswordResetToken } from '~/features/authentication/server/inval
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { commitSession } from '~/features/authentication/server/session.server'
 import { Role } from '~/features/authorization/model/roles.type'
+import { audit, AuditAction } from '~/shared/libs/audit.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { resolveCongregation } from '~/shared/libs/congregation.server'
 import { unscopedDb as db } from '~/shared/libs/db.server'
@@ -19,7 +20,7 @@ export function loader() {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { session, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
+  const { session, currentUser, can } = await authenticateAndAuthorize(request, [Role.SettingsUserManager])
   const canManageUser = can(Role.SettingsUserManager)
 
   if (!canManageUser) throw redirect('/')
@@ -42,6 +43,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       platformName={congregation.displayName}
     />,
   )
+  audit({
+    action: AuditAction.PasswordResetRequested,
+    congregationId: user.congregationId,
+    actorId: currentUser.id,
+    entityType: 'User',
+    entityId: user.id,
+  })
+
   session.flash('success', `Le mot de passe de ${user.email} a été réinitialisé`)
 
   return redirect(`/settings/users/${user.id}/edit`, {

--- a/app/features/authentication/routes/user/profile.tsx
+++ b/app/features/authentication/routes/user/profile.tsx
@@ -1,6 +1,7 @@
 import { Form, Link, redirect } from 'react-router'
 import { changeUserPassword } from '~/features/authentication/server/change-user-password.server'
 import { commitSession } from '~/features/authentication/server/session.server'
+import { audit, AuditAction } from '~/shared/libs/audit.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import logger from '~/shared/libs/logger.server'
 import { Alert, AlertDescription } from '~/shared/ui/alert'
@@ -142,12 +143,22 @@ export default function ProfilePage({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { session, currentUser } = await authenticateAndAuthorize(request)
+  const { session, currentUser, congregationId } = await authenticateAndAuthorize(request)
   const formData = await request.formData()
   const password = formData.get('password')
   const newPassword = formData.get('new_password')
 
   const isSuccess = await changeUserPassword(currentUser.id, String(password), String(newPassword))
+
+  if (isSuccess) {
+    audit({
+      action: AuditAction.PasswordChanged,
+      congregationId,
+      actorId: currentUser.id,
+      entityType: 'User',
+      entityId: currentUser.id,
+    })
+  }
 
   if (!isSuccess) {
     session.flash('error', 'Impossible modifier le mot de passe.')

--- a/app/features/settings/routes/users/new-user.tsx
+++ b/app/features/settings/routes/users/new-user.tsx
@@ -2,6 +2,7 @@ import { Form, redirect } from 'react-router'
 import { createPasswordResetToken } from '~/features/authentication/server/invalidate-user-password.server'
 import { sendResetUserPasswordEmail } from '~/features/authentication/server/send-reset-user-password-email.server'
 import { Role } from '~/features/authorization/model/roles.type'
+import { audit, AuditAction } from '~/shared/libs/audit.server'
 import { authenticateAndAuthorize } from '~/shared/libs/auth.server'
 import { withScope } from '~/shared/libs/db.server'
 import { LimitService } from '~/shared/libs/limits.server'
@@ -60,7 +61,7 @@ export default function SettingsLayout({ loaderData }: Route.ComponentProps) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const { congregation, congregationId } = await authenticateAndAuthorize(request)
+  const { currentUser, congregation, congregationId } = await authenticateAndAuthorize(request)
   const form = await request.formData()
   const firstname = String(form.get('firstname'))
   const lastname = String(form.get('lastname'))
@@ -108,6 +109,14 @@ export async function action({ request }: Route.ActionArgs) {
         platformName={congregation.displayName}
       />,
     )
+
+    audit({
+      action: AuditAction.UserCreated,
+      congregationId,
+      actorId: currentUser.id,
+      entityType: 'User',
+      entityId: user.id,
+    })
 
     return redirect('/settings/users')
   })

--- a/app/features/settings/server/anonymize-user.server.test.ts
+++ b/app/features/settings/server/anonymize-user.server.test.ts
@@ -4,6 +4,7 @@ const ANONYMIZED_EMAIL_PATTERN = /^deleted-.*@anonymized\.local$/
 
 const mockDb = {
   user: { findUnique: vi.fn(), update: vi.fn() },
+  publisherGroup: { updateMany: vi.fn() },
   congregationUserRole: { deleteMany: vi.fn() },
   passwordResetToken: { deleteMany: vi.fn() },
   dataDeletionRecord: { create: vi.fn() },
@@ -23,6 +24,7 @@ describe('anonymizeUser', () => {
       congregationId: 10,
     } as never)
     mockDb.user.update.mockResolvedValue({} as never)
+    mockDb.publisherGroup.updateMany.mockResolvedValue({ count: 0 } as never)
     mockDb.congregationUserRole.deleteMany.mockResolvedValue({ count: 2 } as never)
     mockDb.passwordResetToken.deleteMany.mockResolvedValue({ count: 0 } as never)
     mockDb.dataDeletionRecord.create.mockResolvedValue({} as never)
@@ -42,6 +44,7 @@ describe('anonymizeUser', () => {
     expect(updateCall.data.active).toBe(false)
     expect(updateCall.data.anonymizedAt).toBeInstanceOf(Date)
 
+    expect(mockDb.publisherGroup.updateMany).toHaveBeenCalledWith({ where: { deputyId: 1 }, data: { deputyId: null } })
     expect(mockDb.congregationUserRole.deleteMany).toHaveBeenCalledWith({ where: { userId: 1 } })
     expect(mockDb.passwordResetToken.deleteMany).toHaveBeenCalledWith({ where: { userId: 1 } })
 

--- a/app/features/settings/server/anonymize-user.server.ts
+++ b/app/features/settings/server/anonymize-user.server.ts
@@ -47,6 +47,14 @@ export async function anonymizeUser(db: TransactionClient, userId: number, reque
     },
   })
 
+  // Dissocier l'utilisateur du role d'adjoint de groupe (deputyId est nullable)
+  // Note: responsibleId est requis (non nullable) — le groupe pointe vers l'utilisateur
+  // anonymise ("Utilisateur supprime") ce qui est acceptable car le record est anonyme.
+  await db.publisherGroup.updateMany({
+    where: { deputyId: userId },
+    data: { deputyId: null },
+  })
+
   // Supprimer les roles de l'utilisateur
   await db.congregationUserRole.deleteMany({
     where: { userId },

--- a/app/features/settings/server/export-user-data.server.ts
+++ b/app/features/settings/server/export-user-data.server.ts
@@ -36,6 +36,7 @@ export async function exportUserData(db: TransactionClient, userId: number): Pro
       isServant: true,
       isAnointed: true,
       active: true,
+      platformAdmin: true,
       anonymizedAt: true,
       publisherGroupId: true,
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,7 @@ Start here to understand the product, its features, and how it works.
 2. [Feature Overview](product/feature-overview.md) — A glance at all features
 3. Deep dives: [Display Board](product/display-board.md) · [Territories](product/territories.md) · [Publishers](product/publishers.md) · [Events](product/events.md)
 4. [Roles and Permissions](product/roles-and-permissions.md) — The 14 roles and access control system
-5. [Security](product/security.md) — How your data is protected
-6. [GDPR Checklist](gdpr-checklist.md) — Data protection compliance status and roadmap
+5. [Security](product/security.md) — How your data is protected (includes GDPR & data protection)
 
 ### Use the managed hosting service
 

--- a/docs/product/feature-overview.md
+++ b/docs/product/feature-overview.md
@@ -66,9 +66,10 @@ Unitae manages religious affiliation data, which is special category data under 
 - **Consent management** — Users can view and withdraw their consents at any time from their profile
 - **Privacy policy** — Built-in `/privacy` page explaining data collection, purposes, legal basis, retention periods, sub-processors, and data subject rights
 - **Cookie consent** — Google Maps integration only loads after explicit user consent (ePrivacy Directive)
+- **Audit logging** — Structured audit trail for login, data export, anonymization, consent changes, user creation, and password operations
+- **Log PII redaction** — Email addresses and personal data fields are automatically hashed in application logs (SHA-256)
+- **Data retention** — Automated cleanup of expired password reset tokens and old withdrawn consent records via `/cron/retention` endpoint
 - **Deletion ledger** — All anonymization operations are recorded for backup reconciliation
-
-See [GDPR Checklist](../gdpr-checklist.md) for the full compliance status and roadmap.
 
 ## Coming Soon
 
@@ -77,5 +78,4 @@ Unitae is under active development. Planned features and improvements are tracke
 ## Related
 
 - [Security](security.md) — How data isolation and authentication protect your congregation
-- [GDPR Checklist](../gdpr-checklist.md) — Data protection compliance status
 - [Self-host Unitae](../self-hosting/getting-started.md) or [use managed hosting](../managed-hosting/getting-started.md) — Ready to get started?

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -66,13 +66,14 @@ Unitae processes religious affiliation data, classified as special category data
 - **User anonymization** — Replace personal data with non-identifiable values while preserving referential integrity (Article 17)
 - **Consent tracking** — Consent gate on first login, management page for users to withdraw consent
 - **Cookie consent** — Third-party services (Google Maps) only load after explicit consent
+- **Audit logging** — Structured audit trail for all GDPR-sensitive operations (login, data export, anonymization, consent changes, user creation, password operations)
+- **Log PII redaction** — Email addresses and personal data fields automatically hashed in application logs
+- **Data retention** — Automated cleanup of expired tokens and old consent records
 - **Deletion ledger** — Audit trail of all anonymization operations for backup reconciliation
 - **Privacy policy** — Built-in `/privacy` page covering all RGPD requirements
 - **Session invalidation** — Anonymized users are immediately logged out
 
 For the managed hosting service, MindsersIT acts as data processor under a Data Processing Agreement (DPA) with each congregation. Self-hosted instances are under the sole responsibility of the deploying entity.
-
-See [GDPR Checklist](../gdpr-checklist.md) for the full compliance status.
 
 ## Vulnerability Reporting
 


### PR DESCRIPTION
## Summary

Fixes gaps identified during a full GDPR compliance audit:

- **PublisherGroup FK handling**: clear `deputyId` when anonymizing a user to prevent orphaned references
- **User creation audit**: log `user.created` when admin creates a new user via `/settings/users/new`
- **Password change audit**: log `password.changed` when user changes their password from profile
- **Password reset audit**: log `password.reset.requested` for both self-service forgot password and admin-initiated reset
- **Data export completeness**: add `platformAdmin` field to user data export for full Art. 15 coverage

## Test plan
- [x] `pnpm test:typecheck` passes
- [x] `pnpm test:lint` passes (0 errors)
- [x] `pnpm test:unit` passes (342 tests)
- [ ] Manual: anonymize a user who is a group deputy, verify deputyId is cleared
- [ ] Manual: create a new user, verify AuditLog record with action `user.created`
- [ ] Manual: change password from profile, verify AuditLog record with action `password.changed`