### PR TITLE
fix: make seed multi-tenant aware

### DIFF
--- a/app/database/seed.ts
+++ b/app/database/seed.ts
@@ -150,40 +150,41 @@ async function main() {
     },
   })
 
-  // Create or get default congregation
-  const defaultCongregation = await prisma.congregation.upsert({
-    where: { slug: 'ma-congregation' },
-    update: {},
-    create: {
-      name: 'Ma Congrégation',
-      slug: 'ma-congregation',
-      domain: 'ma-congregation.example.com',
-    },
-  })
+  // Single-tenant installations: pre-create a default congregation with its
+  // EventKind and programme templates. In multi-tenant mode, congregations
+  // are created through the /register flow (registerCongregation), which
+  // already seeds templates for each new tenant.
+  if (process.env.MULTI_TENANT !== 'true') {
+    const seedLocale = 'fr'
 
-  const seedLocale = 'fr'
+    const defaultCongregation = await prisma.congregation.upsert({
+      where: { slug: 'ma-congregation' },
+      update: {},
+      create: {
+        name: 'Ma Congrégation',
+        slug: 'ma-congregation',
+        domain: 'ma-congregation.example.com',
+      },
+    })
 
-  await prisma.eventKind.upsert({
-    where: {
-      // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
-      key_congregationId: { key: EventKind.Off, congregationId: defaultCongregation.id },
-    },
-    update: {
-      name: m.seed_event_kind_absence({}, { locale: seedLocale }),
-      color: '#cfcfcf',
-    },
-    create: {
-      name: m.seed_event_kind_absence({}, { locale: seedLocale }),
-      color: '#cfcfcf',
-      key: EventKind.Off,
-      congregationId: defaultCongregation.id,
-    },
-  })
+    await prisma.eventKind.upsert({
+      where: {
+        // biome-ignore lint/style/useNamingConvention: Prisma compound unique key
+        key_congregationId: { key: EventKind.Off, congregationId: defaultCongregation.id },
+      },
+      update: {
+        name: m.seed_event_kind_absence({}, { locale: seedLocale }),
+        color: '#cfcfcf',
+      },
+      create: {
+        name: m.seed_event_kind_absence({}, { locale: seedLocale }),
+        color: '#cfcfcf',
+        key: EventKind.Off,
+        congregationId: defaultCongregation.id,
+      },
+    })
 
-  // Seed default programme templates for all congregations
-  const allCongregations = await prisma.congregation.findMany({ select: { id: true } })
-  for (const congregation of allCongregations) {
-    await seedDefaultTemplates(prisma, congregation.id, seedLocale)
+    await seedDefaultTemplates(prisma, defaultCongregation.id, seedLocale)
   }
 }
 


### PR DESCRIPTION
## Summary

- In multi-tenant mode (`MULTI_TENANT=true`), the seed now only creates the 14 global `UserRole` rows. The default congregation and its data are skipped — each tenant gets its `Off` EventKind and 3 programme templates when created through `/register` or `/setup`.
- In single-tenant mode (default), the seed continues to pre-create the default "Ma Congrégation" with everything it needs.
- Removes the retroactive `allCongregations` loop that seeded templates for every existing congregation — no longer needed since `registerCongregation` and `setupFirstUser` both call `seedDefaultTemplates` natively.

## Test plan

- [ ] `MULTI_TENANT=true pnpm prisma db seed` → only 14 UserRoles created, no Congregation
- [ ] `pnpm prisma db seed` (default) → UserRoles + default congregation + EventKind + 3 templates
- [ ] Register a new congregation via `/register` → templates + EventKind auto-created
- [ ] Setup first user via `/setup` → same