### PR TITLE
docs: update product docs for board and programme features

### DIFF
--- a/docs/product/display-board.md
+++ b/docs/product/display-board.md
@@ -26,6 +26,14 @@ Documents are stored in the configured file storage backend (local filesystem or
 
 **Required role**: `BoardUploader`, `BoardValidator`, or `Admin`
 
+### File Replacement
+
+Existing documents can have their PDF file replaced from the edit page. The previous file is automatically saved as a version — see "Version History" below.
+
+### Version History
+
+When a document's file is replaced, the previous version is preserved. Access version history from the edit page (clock icon). Previous versions can be downloaded or restored. Restoring a version saves the current file as a new version first.
+
 ### Visibility Scheduling
 
 Control when a document appears on the board:
@@ -43,9 +51,36 @@ Important documents can be featured on the board using the *Mettre en avant le d
 
 **Required role**: `BoardValidator` or `Admin`
 
+## In-App PDF Viewer
+
+Clicking a document opens an in-app viewer page that keeps the sidebar and navigation visible:
+
+- **Desktop / iOS** — Uses the browser's native PDF embed with a clean toolbar-less view
+- **Android** — Lazy-loads a PDF.js canvas renderer (~500 KB, loaded on demand) for inline viewing
+
+The viewer includes a back button to the board and a download button. Document viewing is tracked server-side when the page loads.
+
 ## View Tracking
 
 The system tracks which members have viewed each document. This gives administrators visibility into document reach without requiring explicit acknowledgment from members.
+
+## Dynamic Documents
+
+In addition to uploaded PDFs, the board can display **live data** from other Unitae features. Board validators add dynamic documents from a catalog via the "Ajouter un document dynamique" button.
+
+Available types (appear only when the related feature has data):
+
+- **Groupes de prédication** — Live list of publisher groups with responsible, deputy, and members
+- **Pionniers** — List of publishers registered as regular pioneers, special pioneers, or missionaries
+- **Programmes** — One entry per programme template (e.g., "Réunion de semaine"). Shows all events from the start of the current month with their assigned parts, grouped by section. An optional "Afficher les services" toggle adds service role assignments.
+
+Dynamic documents support the same visibility, highlighting, ordering, and section placement controls as PDF documents. They appear alongside PDFs in the same sections on the board.
+
+### Unread Detection
+
+For PDFs, the unread badge disappears once a member opens the document. For dynamic documents, the badge **reappears when the underlying data changes** — e.g., when a new publisher is added to a group or a programme assignment is updated. This ensures members are notified of fresh content.
+
+**Required role**: `BoardValidator` or `Admin` to add/configure. Any authenticated user can view.
 
 ## Permissions
 
@@ -54,8 +89,7 @@ The system tracks which members have viewed each document. This gives administra
 | `BoardUploader` | Upload documents to the board |
 | `BoardValidator` | Upload, edit, delete documents. Manage sections. Set visibility and highlighting |
 | `Admin` | Everything |
-
-Any authenticated user can view the board and its visible documents.
+| Any authenticated user | View the board, its visible documents, and dynamic documents |
 
 See [Roles and Permissions](roles-and-permissions.md) for the full list of roles across all features.
 

--- a/docs/product/events.md
+++ b/docs/product/events.md
@@ -10,6 +10,7 @@ Programme templates (*Modèles de programme*) define the recurring structure of 
 - **Clé unique** — An internal identifier
 - **Jour de la semaine** — The recurring weekday (null for one-time events like the Memorial)
 - **Parties** — Ordered list of programme parts (spiritual content), each with a name, section grouping, order, optional duration, and a variable flag
+- **Piste / Salle** (`track`) — Optional label for parts happening simultaneously. Parts sharing the same order number with different tracks run in parallel (e.g., an adult class in the main hall while children have a separate activity). Leave empty for normal sequential parts
 - **Rôles de service** — Service attributions needed during the event (Sono, Estrade, Accueil, Nettoyage)
 - **Responsable** — An optional user designated as manager for this template's programmes
 
@@ -36,17 +37,21 @@ Each event has:
 - **Programme spirituel** — Ordered list of parts with speaker/reader assignments and topics
 - **Services** — List of service role assignments
 
-Events are accessible at **Programmes** in the sidebar.
+Events are accessible at **Programmes** in the sidebar. The list shows all events from the start of the current month onward, so events planned several months ahead are visible.
 
 ### Event Structure Editing
 
 Each event's structure (parts and service roles) can be edited independently from its template:
 
-- **Add/remove parts** — Custom parts can be added to any event, even template-based ones
+- **Add/remove parts** — Custom parts can be added to any event, even template-based ones. Custom parts can also specify a **track** to run in parallel with other parts at the same order position
 - **Add/remove service roles** — Same flexibility for service attributions
 - **Apply a template** — Freeform events can retroactively adopt a template's structure
 
 Parts and service roles are stored inline on each event (with name, section, order, duration), so editing one event's structure does not affect the template or other events.
+
+## PDF Export
+
+Events can be exported to PDF from the programme list. The export supports filtering by template and date range. Parallel parts (sharing the same order) are rendered with their track label appended to the part name.
 
 ## Assignments
 

--- a/docs/product/feature-overview.md
+++ b/docs/product/feature-overview.md
@@ -2,12 +2,16 @@
 
 ## Virtual Display Board
 
-The display board is a digital notice board where congregation administrators can share PDF documents with all members.
+The display board is a digital notice board where congregation administrators can share PDF documents and live data views with all members.
 
 - **Sections** — Organize documents into named sections with custom ordering
 - **Visibility scheduling** — Set *Visible à partir du* and *Visible jusqu'au* dates to control when documents appear
 - **Highlighting** — Pin important documents to the top of the board
 - **View tracking** — See which members have viewed each document
+- **Dynamic documents** — Live views of publisher groups, pioneer lists, and meeting programmes alongside uploaded PDFs
+- **In-app PDF viewer** — Embedded viewer with native rendering on desktop and PDF.js fallback on Android
+- **File replacement & versioning** — Replace a document's PDF while preserving previous versions
+- **Thumbnails** — Auto-generated first-page preview thumbnails for PDF documents
 
 See [Display Board](display-board.md) for details.
 
@@ -41,7 +45,8 @@ See [Publishers](publishers.md) for details.
 Manage congregation meeting programmes, event scheduling, and publisher assignments.
 
 - **Programme templates** — Define meeting structures (parts + service roles) with recurring weekdays. Ships with midweek, weekend, and memorial defaults
-- **Event generation** — Auto-generate events from templates for 2 months, or create one-time events from templates or freeform
+- **Parallel parts (tracks)** — Mark template parts to run simultaneously in different rooms/groups (e.g., "Main hall" vs "Children"). Parts with the same order and different tracks render side-by-side in the board viewer and PDF export
+- **Event generation** — Auto-generate events from templates, or create one-time events from templates or freeform. Events are listed from the start of the current month onward
 - **Publisher assignments** — Assign speakers, readers, and service roles with a dynamic info card showing availability, conflicts, and rotation history
 - **Conflict detection** — Days-off conflicts block assignments in real time and retroactively flag existing ones
 - **Per-template responsibility** — Delegate programme management to specific elders without granting full ProgramManager role


### PR DESCRIPTION
## Summary

Updates product documentation to cover all features added in recent PRs.

**Display Board** (`docs/product/display-board.md`):
- File replacement & version history
- In-app PDF viewer (native embed on desktop/iOS, PDF.js on Android)
- Dynamic documents (publisher groups, pioneers, programme views)
- Unread detection for dynamic content
- Updated permissions table

**Events & Programmes** (`docs/product/events.md`):
- Parallel parts via track field
- Updated event listing scope (from start of current month)
- PDF export section
- Track on custom event parts

**Feature Overview** (`docs/product/feature-overview.md`):
- Added dynamic docs, in-app viewer, versioning, thumbnails to board section
- Added parallel parts and updated event generation to events section