### PR TITLE
feat: make default email sender configurable via EMAIL_FROM

### DIFF
--- a/app/shared/libs/congregation.server.ts
+++ b/app/shared/libs/congregation.server.ts
@@ -3,7 +3,7 @@ import { redirect } from 'react-router'
 import { unscopedDb } from '~/shared/libs/db.server'
 
 const DEFAULT_PLATFORM_NAME = 'Unitae'
-const DEFAULT_EMAIL_FROM = 'Unitae <noreply@unitae.app>'
+const DEFAULT_EMAIL_FROM = process.env.EMAIL_FROM ?? 'Unitae <noreply@unitae.app>'
 
 export type CongregationInfo = {
   id: number

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -42,6 +42,7 @@ Redis is used for the BullMQ job queue and login rate limiting.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `RESEND_API_KEY` | — | [Resend](https://resend.com/) API key for sending emails. Without this, the app works but cannot send password reset emails or notifications |
+| `EMAIL_FROM` | `Unitae <noreply@unitae.app>` | Default sender address for outgoing emails. Must match a verified domain in your Resend account |
 
 ## File Storage
 


### PR DESCRIPTION
## Summary
- Add `EMAIL_FROM` environment variable to override the default sender address (`Unitae <noreply@unitae.app>`)
- Self-hosted users can now set their own verified Resend domain as the sender
- Per-congregation `emailFromAddress` (set via control plane) still takes priority when present
- Document the new variable in the self-hosting environment variables guide

## Test plan
- [ ] Without `EMAIL_FROM` set, emails are sent from `Unitae <noreply@unitae.app>` (unchanged default)
- [ ] With `EMAIL_FROM="My App <noreply@mydomain.com>"`, emails use that sender address
- [ ] A congregation with `emailFromAddress` set in the DB still uses its own sender (env var does not override)