### PR TITLE
feat: add non-superuser database role for RLS enforcement

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -136,6 +136,7 @@ jobs:
           --health-retries 5
     env:
       DATABASE_URL: postgresql://unitae:unitae@localhost:5432/unitae_test
+      DATABASE_APP_URL: postgresql://unitae_app:unitae_app@localhost:5432/unitae_test
       SESSION_SECRET: ci-test-secret-at-least-32-characters-long
       RESEND_API_KEY: re_test
       REDIS_HOST: localhost
@@ -161,6 +162,11 @@ jobs:
 
       - name: Generate Prisma client and Paraglide messages
         run: pnpm prisma generate && pnpm react-router typegen
+
+      - name: Create non-superuser app role for RLS
+        run: |
+          psql "$DATABASE_URL" -c "CREATE ROLE unitae_app LOGIN PASSWORD 'unitae_app' NOSUPERUSER;"
+          psql "$DATABASE_URL" -c "GRANT unitae_app TO unitae;"
 
       - name: Apply database migrations
         run: pnpm prisma migrate deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ docker compose -f docker/docker-compose.dev.yml up -d  # Start PostgreSQL + Redi
 ```
 ```ini
 DATABASE_URL="postgresql://unitae:unitae@localhost:5432/unitae_dev"
+DATABASE_APP_URL="postgresql://unitae_app:unitae_app@localhost:5432/unitae_dev"  # Optional — non-superuser for RLS enforcement
 RESEND_API_KEY="re_123"
 SESSION_SECRET="your-secret-key"
 REDIS_HOST="localhost"

--- a/app/database/migrations/20260425100000_add_app_database_role/migration.sql
+++ b/app/database/migrations/20260425100000_add_app_database_role/migration.sql
@@ -1,0 +1,24 @@
+-- CreateRole
+-- Create a non-superuser application role for RLS enforcement.
+-- Superusers bypass all RLS policies, so the app runtime must connect
+-- as a non-superuser for tenant isolation to actually work.
+-- The role is created with NOLOGIN — each environment sets the password separately.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'unitae_app') THEN
+    CREATE ROLE unitae_app NOLOGIN;
+  END IF;
+END
+$$;
+
+-- Grant schema usage and DML on all existing tables
+GRANT USAGE ON SCHEMA public TO unitae_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO unitae_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO unitae_app;
+
+-- Auto-grant on future tables/sequences created by the unitae superuser (migrations)
+ALTER DEFAULT PRIVILEGES FOR ROLE unitae IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO unitae_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE unitae IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO unitae_app;

--- a/app/shared/infra/db.server.ts
+++ b/app/shared/infra/db.server.ts
@@ -2,8 +2,9 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '~/database/generated/client'
 
 const poolMax = Number.parseInt(process.env.DATABASE_POOL_MAX ?? '10', 10)
+const connectionString = process.env.DATABASE_APP_URL ?? process.env.DATABASE_URL
 const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
   max: poolMax,
   connectionTimeoutMillis: 5000,
 })

--- a/app/shared/utils/env.server.ts
+++ b/app/shared/utils/env.server.ts
@@ -16,6 +16,10 @@ export function validateEnv() {
   requireEnv('DATABASE_URL')
   requireEnv('SESSION_SECRET')
 
+  if (!process.env.DATABASE_APP_URL) {
+    logger.warn('DATABASE_APP_URL is not set — RLS enforcement requires a non-superuser database role.')
+  }
+
   if (!process.env.CRON_SECRET) {
     logger.warn('CRON_SECRET is not set. Cron endpoints will reject all requests.')
   }

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
       POSTGRES_DB: unitae_dev
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U unitae -d unitae_dev']
       interval: 5s

--- a/docker/init-db/01-create-app-role.sql
+++ b/docker/init-db/01-create-app-role.sql
@@ -1,0 +1,16 @@
+-- Create the non-superuser app role used by the runtime.
+-- The unitae superuser remains for migrations; unitae_app is used by
+-- the web/worker processes so that RLS policies are enforced.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'unitae_app') THEN
+    CREATE ROLE unitae_app LOGIN PASSWORD 'unitae_app';
+  ELSE
+    ALTER ROLE unitae_app LOGIN PASSWORD 'unitae_app';
+  END IF;
+END
+$$;
+
+-- unitae must be able to grant privileges to unitae_app during migrations
+GRANT unitae_app TO unitae;

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,8 +38,9 @@ Set up a development environment and understand the codebase.
 1. [Development Setup](development/getting-started.md) — Clone, install, and run locally
 2. [Coding Conventions](development/coding-conventions.md) — Patterns, philosophy, and rules
 3. [Architecture](development/architecture.md) — System design, request flow, and data isolation
-4. [Background Processing](development/background-processing.md) — BullMQ worker architecture
-5. [CONTRIBUTING.md](../CONTRIBUTING.md) — How to submit a pull request
+4. [Row-Level Security](development/row-level-security.md) — How RLS enforces tenant isolation
+5. [Background Processing](development/background-processing.md) — BullMQ worker architecture
+6. [CONTRIBUTING.md](../CONTRIBUTING.md) — How to submit a pull request
 
 ### Reference
 

--- a/docs/development/row-level-security.md
+++ b/docs/development/row-level-security.md
@@ -1,0 +1,191 @@
+# Row-Level Security (RLS)
+
+Unitae uses **PostgreSQL Row-Level Security** to enforce tenant isolation at the database level. Each congregation's data is invisible to other congregations, even if application code has a bug.
+
+## How It Works
+
+### The Problem
+
+Unitae is multi-tenant: multiple congregations share the same PostgreSQL database. Every tenant-scoped table has a `congregationId` column. Without RLS, a bug in a query (missing `WHERE congregationId = ...`) could leak data across congregations.
+
+### The Solution
+
+RLS moves the isolation guarantee from the application layer down to the database engine. PostgreSQL itself filters rows before they reach the application.
+
+```
+┌──────────────────────────────────┐
+│          Application             │
+│                                  │
+│  SET LOCAL app.congregation_id   │──── sets context for the transaction
+│  SELECT * FROM "User"            │──── no WHERE needed, RLS filters
+│                                  │
+├──────────────────────────────────┤
+│          PostgreSQL              │
+│                                  │
+│  RLS policy checks every row:    │
+│  "congregationId" = current_setting('app.congregation_id')
+│                                  │
+│  Only matching rows are returned │
+└──────────────────────────────────┘
+```
+
+### Two Database Roles
+
+RLS policies are bypassed by PostgreSQL superusers. To make RLS effective, the application uses **two database roles**:
+
+| Role | Superuser | Used by | Purpose |
+|------|-----------|---------|---------|
+| `unitae` | Yes | Migrations, seed, backup | Schema changes (DDL), `pg_dump` |
+| `unitae_app` | No | Web server, worker | Runtime queries — RLS is enforced |
+
+The application reads `DATABASE_APP_URL` for the runtime connection. If not set, it falls back to `DATABASE_URL` (for backwards compatibility with single-role setups, but RLS will not be enforced if the role is a superuser).
+
+## RLS Policy
+
+Every tenant-scoped table has the same policy:
+
+```sql
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON "User" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+```
+
+**Behavior:**
+
+| `app.congregation_id` | Rows visible | When |
+|------------------------|-------------|------|
+| Not set / empty | All rows | Login, setup, health check, platform admin |
+| Set to a value | Only rows matching that congregation | Normal authenticated requests |
+
+The `true` parameter in `current_setting(...)` makes it return `NULL` instead of throwing an error when the variable is not set.
+
+## Tables with RLS
+
+**Tenant-scoped (RLS enforced):**
+
+Attribution, AuditLog, BoardDocument, BoardDynamicDocumentSettings, BoardSection, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, ConsentRecord, CongregationUserRole, DataDeletionRecord, Event, EventKind, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammeServiceRoleAssignment, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, PublisherActivity, PublisherGroup, Setting, Territory, User
+
+**Global (no RLS):**
+
+Congregation, UserRole, PasswordResetToken, EmailVerificationToken, BoardDocumentVersion, BoardDynamicDocumentView
+
+## Application Integration
+
+### Setting the Scope
+
+The `withScope` function in `app/shared/infra/db.server.ts` opens a transaction and sets the congregation context:
+
+```typescript
+function withScope<T>(congregationId: number, fn: (tx: TransactionClient) => Promise<T>): Promise<T> {
+  return db.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+    return fn(tx)
+  })
+}
+```
+
+`SET LOCAL` is transaction-scoped — it is automatically rolled back when the transaction ends. This prevents congregation context from leaking across requests through the connection pool.
+
+### In Route Loaders and Actions
+
+Authenticated routes use `withScopeFromContext`, which reads the congregation from the middleware context:
+
+```typescript
+export async function loader({ context }: Route.LoaderArgs) {
+  return withScopeFromContext(context, async db => {
+    // All queries here are automatically scoped by RLS
+    return getPublishers(db, congregationId)
+  })
+}
+```
+
+### Unscoped Access
+
+Some operations need to see all rows across congregations. These run **outside** `withScope`:
+
+- **Login** — must find the user by email regardless of congregation
+- **Setup / onboarding** — no congregation exists yet
+- **Health check** — system-level, no tenant context
+- **Platform admin** — cross-congregation management
+- **Password reset** — token lookup is global
+
+In these cases, use `db` or `unscopedDb` directly (they are the same instance). Since `app.congregation_id` is not set, the RLS policy allows all rows.
+
+## Development Setup
+
+The dev Docker Compose creates both roles automatically via an init script (`docker/init-db/01-create-app-role.sql`). To use the non-superuser role locally:
+
+1. Set `DATABASE_APP_URL` in your `.env`:
+
+   ```ini
+   DATABASE_URL="postgresql://unitae:unitae@localhost:5432/unitae_dev"
+   DATABASE_APP_URL="postgresql://unitae_app:unitae_app@localhost:5432/unitae_dev"
+   ```
+
+2. If your database volume already exists (created before the init script was added), reset it:
+
+   ```bash
+   docker compose -f docker/docker-compose.dev.yml down -v
+   docker compose -f docker/docker-compose.dev.yml up -d
+   pnpm prisma migrate deploy
+   pnpm prisma db seed
+   ```
+
+### Verifying RLS Works
+
+Connect as `unitae_app` and test scoped queries:
+
+```bash
+docker compose -f docker/docker-compose.dev.yml exec postgres \
+  psql -U unitae_app -d unitae_dev -c "
+    BEGIN;
+    SET LOCAL app.congregation_id = '1';
+    SELECT id, firstname, \"congregationId\" FROM \"User\";
+    COMMIT;
+  "
+```
+
+Only users from congregation 1 should appear. Without `SET LOCAL`, all users are visible.
+
+## Adding RLS to a New Table
+
+When creating a new tenant-scoped table with a `congregationId` column, add RLS in the same migration:
+
+```sql
+ALTER TABLE "NewTable" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "NewTable" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON "NewTable" FOR ALL
+  USING (
+    current_setting('app.congregation_id', true) IS NULL
+    OR current_setting('app.congregation_id', true) = ''
+    OR "congregationId" = current_setting('app.congregation_id', true)::int
+  );
+```
+
+The `unitae_app` role automatically gets DML privileges on new tables thanks to `ALTER DEFAULT PRIVILEGES` set up in the `20260425100000_add_app_database_role` migration.
+
+## Self-Hosting Considerations
+
+Self-hosted users deploying with a single database role (superuser) will see a warning at startup:
+
+```
+DATABASE_APP_URL is not set — RLS enforcement requires a non-superuser database role.
+```
+
+The application works correctly without `DATABASE_APP_URL` — tenant isolation still relies on `withScope` at the application level. However, for defense-in-depth, self-hosters should create a non-superuser role:
+
+```sql
+CREATE ROLE unitae_app LOGIN PASSWORD 'your-secure-password' NOSUPERUSER;
+GRANT USAGE ON SCHEMA public TO unitae_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO unitae_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO unitae_app;
+```
+
+Then set `DATABASE_APP_URL` in the environment to use this role for the runtime.

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -23,7 +23,8 @@ Complete reference for all configuration variables used by Unitae.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATABASE_URL` | — | PostgreSQL connection string (required) |
+| `DATABASE_URL` | — | PostgreSQL connection string (required). Used for migrations and seed |
+| `DATABASE_APP_URL` | — | Non-superuser connection string for the runtime. Enables RLS enforcement. Falls back to `DATABASE_URL` if not set. See [Row-Level Security](../development/row-level-security.md) |
 
 The database connection is configured in `prisma.config.ts`, not in `schema.prisma`.
 


### PR DESCRIPTION
## Summary

- PostgreSQL superusers bypass all RLS policies, making the 26 tenant isolation policies completely ineffective. This PR introduces a `unitae_app` non-superuser role for the app runtime so RLS actually enforces congregation-level data isolation.
- The superuser `unitae` is kept for migrations and backups. The app connects as `unitae_app` via a new `DATABASE_APP_URL` env var (falls back to `DATABASE_URL` for backwards compatibility).
- Includes a Prisma migration, Docker dev setup, CI workflow update, and technical documentation.

## What changed

| File | Change |
|------|--------|
| `app/database/migrations/.../migration.sql` | Creates `unitae_app` role with NOLOGIN, grants DML, sets up DEFAULT PRIVILEGES |
| `app/shared/infra/db.server.ts` | Uses `DATABASE_APP_URL ?? DATABASE_URL` |
| `app/shared/utils/env.server.ts` | Warns if `DATABASE_APP_URL` is not set |
| `docker/init-db/01-create-app-role.sql` | Dev init script — creates role with password |
| `docker/docker-compose.dev.yml` | Mounts init script |
| `.github/workflows/continuous-integration.yml` | Creates role + sets env for E2E |
| `docs/development/row-level-security.md` | Full RLS documentation |

## K8s changes (separate PR in unitae-platform)

Production K8s manifests need a follow-up PR to add `DATABASE_APP_URL` to secrets, mount a postgres init ConfigMap, and add a post-migrate Job to set the role password.

## Test plan

- [ ] Reset dev database (`docker compose down -v && up -d`), run migrations + seed, verify app starts with `DATABASE_APP_URL`
- [ ] Verify RLS: connect as `unitae_app`, `SET LOCAL app.congregation_id = '1'` — only congregation 1 data visible
- [ ] Verify unscoped access works (login, health check)
- [ ] CI E2E tests pass with the non-superuser role
- [ ] Typecheck passes
- [ ] Self-hosted fallback: app works with only `DATABASE_URL` (warning logged)