### PR TITLE
feat: dedicated Docker images for runtime, worker, and migrate

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -58,6 +58,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: worker
+          push: true
+          tags: ghcr.io/unitae/unitae/worker:latest
+          cache-from: type=gha
+
       - name: Build and push migrate image
         uses: docker/build-push-action@v6
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,24 @@
-FROM node:22-slim AS base
-RUN apt-get update && apt-get install -y openssl poppler-utils && rm -rf /var/lib/apt/lists/*
+# syntax=docker/dockerfile:1
+
+# ── Base: Alpine + openssl + tini + pnpm ─────────────────────
+FROM node:22-alpine AS base
+RUN apk add --no-cache openssl tini
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV COREPACK_HOME="/corepack"
 RUN corepack enable && corepack prepare pnpm@10.26.1 --activate
 WORKDIR /app
 
+# ── Base-worker: adds poppler-utils for PDF thumbnails ───────
+FROM base AS base-worker
+RUN apk add --no-cache poppler-utils
+
+# ── Deps: install all dependencies (dev + prod) ─────────────
 FROM base AS deps
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
+# ── Build: generate Prisma client + React Router build ───────
 FROM deps AS build
 COPY app/database ./app/database
 COPY prisma.config.ts ./
@@ -17,21 +26,58 @@ RUN pnpm prisma generate
 COPY . .
 RUN pnpm run build
 
-FROM base AS runtime
-ENV NODE_ENV=production
-ENV PORT="8080"
-RUN groupadd --gid 1001 unitae && \
-    useradd --uid 1001 --gid unitae --shell /bin/sh --create-home unitae
-COPY --from=build --chown=unitae:unitae /app .
+# ── Prod-deps: prune to production dependencies only ─────────
+FROM deps AS prod-deps
 RUN pnpm prune --prod
-USER unitae
-EXPOSE 8080
-CMD ["pnpm", "start"]
 
-FROM base AS migrate
+# ── Runtime: web server ──────────────────────────────────────
+FROM base AS runtime
+LABEL org.opencontainers.image.title="unitae" \
+      org.opencontainers.image.description="Unitae web server" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
 ENV NODE_ENV=production
-RUN groupadd --gid 1001 unitae && \
-    useradd --uid 1001 --gid unitae --shell /bin/sh --create-home unitae
-COPY --from=build --chown=unitae:unitae /app .
-USER unitae
-CMD ["pnpm", "prisma", "migrate", "deploy"]
+ENV PORT=8080
+RUN addgroup -g 1001 -S unitae && \
+    adduser -u 1001 -S unitae -G unitae -s /sbin/nologin -H
+COPY --from=build --chown=1001:1001 /app/build ./build
+COPY --from=build --chown=1001:1001 /app/package.json ./
+COPY --from=prod-deps --chown=1001:1001 /app/node_modules ./node_modules
+USER 1001
+EXPOSE 8080
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node_modules/.bin/react-router-serve", "./build/server/index.js"]
+
+# ── Worker: background job processor ─────────────────────────
+FROM base-worker AS worker
+LABEL org.opencontainers.image.title="unitae-worker" \
+      org.opencontainers.image.description="Unitae background job processor" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+ENV NODE_ENV=production
+RUN addgroup -g 1001 -S unitae && \
+    adduser -u 1001 -S unitae -G unitae -s /sbin/nologin -H
+COPY --from=build --chown=1001:1001 /app/app ./app
+COPY --from=build --chown=1001:1001 /app/package.json ./
+COPY --from=build --chown=1001:1001 /app/tsconfig.json ./
+COPY --from=build --chown=1001:1001 /app/prisma.config.ts ./
+COPY --from=prod-deps --chown=1001:1001 /app/node_modules ./node_modules
+USER 1001
+EXPOSE 9090
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node_modules/.bin/tsx", "./app/workers/worker.server.ts"]
+
+# ── Migrate: database migration runner (one-shot job) ────────
+FROM base AS migrate
+LABEL org.opencontainers.image.title="unitae-migrate" \
+      org.opencontainers.image.description="Unitae database migration runner" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+ENV NODE_ENV=production
+RUN addgroup -g 1001 -S unitae && \
+    adduser -u 1001 -S unitae -G unitae -s /sbin/nologin -H
+COPY --from=build --chown=1001:1001 /app/app/database/schema.prisma ./app/database/schema.prisma
+COPY --from=build --chown=1001:1001 /app/app/database/migrations ./app/database/migrations
+COPY --from=build --chown=1001:1001 /app/prisma.config.ts ./
+COPY --from=build --chown=1001:1001 /app/package.json ./
+COPY --from=deps --chown=1001:1001 /app/node_modules ./node_modules
+USER 1001
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node_modules/.bin/prisma", "migrate", "deploy"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,9 +39,8 @@ services:
         condition: service_healthy
 
   worker:
-    image: ${UNITAE_IMAGE:-ghcr.io/unitae/unitae:latest}
+    image: ${UNITAE_WORKER_IMAGE:-ghcr.io/unitae/unitae/worker:latest}
     restart: unless-stopped
-    command: pnpm start:worker
     env_file: .env
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

- Splits the monolithic Dockerfile into three optimized production targets: `runtime` (web), `worker` (background jobs), and `migrate` (one-shot DB migration)
- Switches from `node:22-slim` to `node:22-alpine` (~50 MB smaller base, no native addons needed)
- Adds `tini` as PID 1 for proper signal forwarding and zombie reaping
- Replaces `pnpm start` / `pnpm start:worker` with direct binary invocation — eliminates process wrapper overhead
- Each image copies only what it needs: runtime gets `build/`, worker gets `app/` source, migrate gets schema + migrations

## Image comparison

| Image | Contains | Excludes |
|-------|----------|----------|
| `unitae:runtime` | `build/`, prod `node_modules` | `app/` source, `poppler-utils` |
| `unitae/worker` | `app/` source, `tsx`, `poppler-utils`, prod `node_modules` | `build/` directory, client assets |
| `unitae/migrate` | schema, migrations, full `node_modules` (prisma CLI is a devDep) | `build/`, app source |

## Security hardening

- Alpine base (smaller attack surface)
- `tini` as PID 1 (signal forwarding + zombie reaping)
- Non-root UID 1001, no login shell (`/sbin/nologin`), no home directory
- `poppler-utils` only in worker image (not in runtime)
- OCI labels on all images
- Direct binary CMD (no shell interpretation)

## Test plan

- [x] All three targets build successfully
- [x] Runtime image does NOT have `pdftoppm` (`which pdftoppm` fails)
- [x] Worker image has `pdftoppm` at `/usr/bin/pdftoppm`
- [x] All images run as UID 1001 (non-root)
- [x] `tini` present at `/sbin/tini`
- [ ] CI pipeline builds and pushes all three images
- [ ] Runtime serves `/health` on port 8080
- [ ] Worker health check responds on port 9090
- [ ] Migrate job applies pending migrations