### PR TITLE
feat: polish sidebar navigation — visual improvements, search, collapsible sections

### DIFF
--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -78,6 +78,7 @@
     "sidebar_my_absences": "My absences",
     "sidebar_my_territories": "My territories",
     "sidebar_logout": "Log out",
+    "sidebar_search": "Search…",
     "map_consent_title": "Google Maps",
     "map_consent_description": "Displaying the map requires loading Google Maps, which may set third-party cookies. By accepting, you consent to loading this external service.",
     "map_consent_accept": "Accept and show the map",

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -77,6 +77,7 @@
     "sidebar_my_profile": "My profile",
     "sidebar_my_absences": "My absences",
     "sidebar_my_territories": "My territories",
+    "sidebar_my_notifications": "My notifications",
     "sidebar_logout": "Log out",
     "sidebar_search": "Search…",
     "map_consent_title": "Google Maps",

--- a/app/messages/fr.json
+++ b/app/messages/fr.json
@@ -78,6 +78,7 @@
     "sidebar_my_absences": "Mes absences",
     "sidebar_my_territories": "Mes territoires",
     "sidebar_logout": "Déconnexion",
+    "sidebar_search": "Rechercher…",
     "map_consent_title": "Carte Google Maps",
     "map_consent_description": "L'affichage de la carte nécessite le chargement de Google Maps, qui peut déposer des cookies tiers. En acceptant, vous consentez au chargement de ce service externe.",
     "map_consent_accept": "Accepter et afficher la carte",

--- a/app/messages/fr.json
+++ b/app/messages/fr.json
@@ -77,6 +77,7 @@
     "sidebar_my_profile": "Mon profil",
     "sidebar_my_absences": "Mes absences",
     "sidebar_my_territories": "Mes territoires",
+    "sidebar_my_notifications": "Mes notifications",
     "sidebar_logout": "Déconnexion",
     "sidebar_search": "Rechercher…",
     "map_consent_title": "Carte Google Maps",

--- a/app/shared/ui/AppLayout.tsx
+++ b/app/shared/ui/AppLayout.tsx
@@ -37,9 +37,9 @@ export function AppLayout({ permissions, congregationName }: AppLayoutProps) {
       <SidebarInset>
         <NavigationProgress />
         <OfflineBanner />
-        <header className="flex items-center gap-2 p-2 md:p-3">
+        <div className="flex items-center p-2 md:group-has-data-[state=expanded]/sidebar-wrapper:hidden">
           <SidebarTrigger className="size-8 rounded-md" />
-        </header>
+        </div>
         <div className="flex-1 overflow-auto p-4 md:p-6">
           <Outlet />
         </div>

--- a/app/shared/ui/AppLayout.tsx
+++ b/app/shared/ui/AppLayout.tsx
@@ -29,14 +29,20 @@ export function AppLayout({ permissions, congregationName }: AppLayoutProps) {
 
   return (
     <SidebarProvider>
-      <AppSidebar permissions={permissions} congregationName={congregationName} />
+      <AppSidebar
+        permissions={permissions}
+        congregationName={congregationName}
+        onSearchClick={() => setCommandPaletteOpen(true)}
+      />
       <SidebarInset>
         <NavigationProgress />
         <OfflineBanner />
+        <header className="flex items-center gap-2 p-2 md:p-3">
+          <SidebarTrigger className="size-8 rounded-md" />
+        </header>
         <div className="flex-1 overflow-auto p-4 md:p-6">
           <Outlet />
         </div>
-        <SidebarTrigger className="fixed bottom-4 left-4 z-30 size-9 rounded-full border bg-background shadow-md max-sm:bottom-3 max-sm:left-3 max-sm:size-8 md:absolute" />
       </SidebarInset>
       <Toaster richColors position="top-right" />
       <CommandPalette permissions={permissions} open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -4,6 +4,7 @@ import {
   CalendarCheck,
   CalendarDays,
   CalendarOff,
+  ChevronDown,
   ClipboardList,
   FileText,
   FolderOpen,
@@ -14,6 +15,7 @@ import {
   Map as MapIcon,
   MapPin,
   PieChart,
+  Search,
   Settings,
   User,
   UserCog,
@@ -24,6 +26,7 @@ import {
 import { Form, NavLink } from 'react-router'
 
 import * as m from '~/paraglide/messages'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '~/shared/ui/collapsible'
 import {
   Sidebar,
   SidebarContent,
@@ -57,10 +60,11 @@ export interface AppSidebarPermissions {
 interface AppSidebarProps {
   permissions: AppSidebarPermissions
   congregationName?: string
+  onSearchClick?: () => void
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sidebar with many permission-based conditional sections
-export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
+export function AppSidebar({ permissions, congregationName, onSearchClick }: AppSidebarProps) {
   const showDocuments = permissions.canManageBoard
   const showAssemblee = permissions.canViewPublishers || permissions.canViewPrograms
   const showTerritories =
@@ -76,6 +80,15 @@ export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
           </span>
           <ThemeToggle />
         </div>
+        <button
+          type="button"
+          onClick={onSearchClick}
+          className="mx-2 mb-1 flex items-center gap-2 rounded-md border border-sidebar-border bg-sidebar px-2 py-1.5 text-muted-foreground text-sm hover:bg-sidebar-accent"
+        >
+          <Search className="size-4 shrink-0" />
+          <span className="flex-1 text-left">{m.command_palette_placeholder()}</span>
+          <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
+        </button>
       </SidebarHeader>
 
       <SidebarContent>
@@ -89,103 +102,148 @@ export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
         </SidebarGroup>
 
         {showDocuments && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{m.sidebar_documents()}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                <SidebarNavItem to="/board/sections" icon={FolderOpen} label={m.sidebar_sections()} />
-                <SidebarNavItem to="/board/documents" icon={FileText} label={m.sidebar_documents()} />
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger>
+                  {m.sidebar_documents()}
+                  <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarNavItem to="/board/sections" icon={FolderOpen} label={m.sidebar_sections()} />
+                    <SidebarNavItem to="/board/documents" icon={FileText} label={m.sidebar_documents()} />
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         )}
 
         {showAssemblee && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{m.sidebar_assembly()}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {permissions.canViewPublishers && (
-                  <SidebarNavItem to="/publishers" icon={Users} label={m.sidebar_publishers()} />
-                )}
-                {permissions.canViewPublishers && (
-                  <SidebarNavItem to="/groups" icon={UsersRound} label={m.sidebar_publisher_groups()} />
-                )}
-                {permissions.canViewPrograms && (
-                  <SidebarNavItem to="/programs" icon={CalendarDays} label={m.sidebar_programs()} end />
-                )}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger>
+                  {m.sidebar_assembly()}
+                  <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {permissions.canViewPublishers && (
+                      <SidebarNavItem to="/publishers" icon={Users} label={m.sidebar_publishers()} />
+                    )}
+                    {permissions.canViewPublishers && (
+                      <SidebarNavItem to="/groups" icon={UsersRound} label={m.sidebar_publisher_groups()} />
+                    )}
+                    {permissions.canViewPrograms && (
+                      <SidebarNavItem to="/programs" icon={CalendarDays} label={m.sidebar_programs()} end />
+                    )}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         )}
 
         {showTerritories && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{m.sidebar_territories()}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {permissions.canViewTerritories && (
-                  <SidebarNavItem
-                    to="/territories/attributions"
-                    icon={CalendarCheck}
-                    label={m.sidebar_attributions()}
-                  />
-                )}
-                {permissions.canViewTerritories && (
-                  <SidebarNavItem to="/territories" icon={MapIcon} label={m.sidebar_territories()} end />
-                )}
-                {permissions.canViewProspection && (
-                  <SidebarNavItem to="/territories/buildings" icon={Building2} label={m.sidebar_prospection()} />
-                )}
-                {permissions.canManageTerritories && (
-                  <SidebarNavItem to="/territories/stats" icon={PieChart} label={m.sidebar_statistics()} />
-                )}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger>
+                  {m.sidebar_territories()}
+                  <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {permissions.canViewTerritories && (
+                      <SidebarNavItem
+                        to="/territories/attributions"
+                        icon={CalendarCheck}
+                        label={m.sidebar_attributions()}
+                      />
+                    )}
+                    {permissions.canViewTerritories && (
+                      <SidebarNavItem to="/territories" icon={MapIcon} label={m.sidebar_territories()} end />
+                    )}
+                    {permissions.canViewProspection && (
+                      <SidebarNavItem to="/territories/buildings" icon={Building2} label={m.sidebar_prospection()} />
+                    )}
+                    {permissions.canManageTerritories && (
+                      <SidebarNavItem to="/territories/stats" icon={PieChart} label={m.sidebar_statistics()} />
+                    )}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         )}
 
         {showReglages && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{m.sidebar_settings()}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {permissions.canManageSettings && (
-                  <SidebarNavItem to="/settings/general" icon={Settings} label={m.sidebar_settings_general()} />
-                )}
-                {permissions.canManageUsers && (
-                  <SidebarNavItem to="/settings/users" icon={UserCog} label={m.sidebar_users()} />
-                )}
-                {permissions.canManageSettings && (
-                  <>
-                    <SidebarNavItem
-                      to="/settings/congregation"
-                      icon={Building2}
-                      label={m.sidebar_settings_assembly()}
-                    />
-                    <SidebarNavItem
-                      to="/settings/territories"
-                      icon={MapIcon}
-                      label={m.sidebar_settings_territories()}
-                    />
-                    <SidebarNavItem to="/settings/data" icon={HardDrive} label={m.sidebar_settings_data()} />
-                    <SidebarNavItem to="/settings/audit-log" icon={ClipboardList} label={m.sidebar_audit_log()} />
-                  </>
-                )}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger>
+                  {m.sidebar_settings()}
+                  <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {permissions.canManageSettings && (
+                      <SidebarNavItem to="/settings/general" icon={Settings} label={m.sidebar_settings_general()} />
+                    )}
+                    {permissions.canManageUsers && (
+                      <SidebarNavItem to="/settings/users" icon={UserCog} label={m.sidebar_users()} />
+                    )}
+                    {permissions.canManageSettings && (
+                      <>
+                        <SidebarNavItem
+                          to="/settings/congregation"
+                          icon={Building2}
+                          label={m.sidebar_settings_assembly()}
+                        />
+                        <SidebarNavItem
+                          to="/settings/territories"
+                          icon={MapIcon}
+                          label={m.sidebar_settings_territories()}
+                        />
+                        <SidebarNavItem to="/settings/data" icon={HardDrive} label={m.sidebar_settings_data()} />
+                        <SidebarNavItem to="/settings/audit-log" icon={ClipboardList} label={m.sidebar_audit_log()} />
+                      </>
+                    )}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         )}
 
         {permissions.isPlatformAdmin && (
-          <SidebarGroup>
-            <SidebarGroupLabel>{m.sidebar_platform()}</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                <SidebarNavItem to="/platform-admin" icon={UserRoundCog} label={m.sidebar_administration()} />
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
+          <Collapsible defaultOpen className="group/collapsible">
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger>
+                  {m.sidebar_platform()}
+                  <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    <SidebarNavItem to="/platform-admin" icon={UserRoundCog} label={m.sidebar_administration()} />
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
         )}
       </SidebarContent>
 

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -38,6 +38,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarTrigger,
   useSidebar,
 } from '~/shared/ui/sidebar'
 import { ThemeToggle } from '~/shared/ui/ThemeToggle'
@@ -78,7 +79,10 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
           <span className="truncate font-bold font-display text-foreground text-lg">
             {congregationName || 'Unitae'}
           </span>
-          <ThemeToggle />
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+            <SidebarTrigger className="size-7 rounded-md" />
+          </div>
         </div>
         <button
           type="button"

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -16,6 +16,7 @@ import {
   PieChart,
   Settings,
   User,
+  UserCog,
   UserRoundCog,
   Users,
   UsersRound,
@@ -69,10 +70,11 @@ export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
   return (
     <Sidebar>
       <SidebarHeader>
-        <div className="flex items-center gap-2 border-sidebar-border border-b px-3 py-4">
+        <div className="flex items-center justify-between gap-2 border-sidebar-border border-b px-3 py-4">
           <span className="truncate font-bold font-display text-foreground text-lg">
             {congregationName || 'Unitae'}
           </span>
+          <ThemeToggle />
         </div>
       </SidebarHeader>
 
@@ -152,7 +154,7 @@ export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
                   <SidebarNavItem to="/settings/general" icon={Settings} label={m.sidebar_settings_general()} />
                 )}
                 {permissions.canManageUsers && (
-                  <SidebarNavItem to="/settings/users" icon={Users} label={m.sidebar_users()} />
+                  <SidebarNavItem to="/settings/users" icon={UserCog} label={m.sidebar_users()} />
                 )}
                 {permissions.canManageSettings && (
                   <>
@@ -194,15 +196,12 @@ export function AppSidebar({ permissions, congregationName }: AppSidebarProps) {
           <SidebarNavItem to="/me/days-off" icon={CalendarOff} label={m.sidebar_my_absences()} />
           <SidebarNavItem to="/me/notifications" icon={Bell} label={m.notification_preferences_page_title()} />
           <SidebarMenuItem>
-            <div className="flex items-center justify-between">
-              <Form action="/logout" method="post">
-                <SidebarMenuButton type="submit" className="text-muted-foreground hover:text-destructive">
-                  <LogOut className="size-4" />
-                  <span>{m.sidebar_logout()}</span>
-                </SidebarMenuButton>
-              </Form>
-              <ThemeToggle />
-            </div>
+            <Form action="/logout" method="post">
+              <SidebarMenuButton type="submit" className="text-muted-foreground hover:text-destructive">
+                <LogOut className="size-4" />
+                <span>{m.sidebar_logout()}</span>
+              </SidebarMenuButton>
+            </Form>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -258,7 +258,7 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
           <SidebarNavItem to="/me/profile" icon={User} label={m.sidebar_my_profile()} />
           <SidebarNavItem to="/me/territories" icon={MapPin} label={m.sidebar_my_territories()} />
           <SidebarNavItem to="/me/days-off" icon={CalendarOff} label={m.sidebar_my_absences()} />
-          <SidebarNavItem to="/me/notifications" icon={Bell} label={m.notification_preferences_page_title()} />
+          <SidebarNavItem to="/me/notifications" icon={Bell} label={m.sidebar_my_notifications()} />
           <SidebarMenuItem>
             <Form action="/logout" method="post">
               <SidebarMenuButton type="submit" className="text-muted-foreground hover:text-destructive">

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -66,7 +66,6 @@ interface AppSidebarProps {
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sidebar with many permission-based conditional sections
 export function AppSidebar({ permissions, congregationName, onSearchClick }: AppSidebarProps) {
-  const showDocuments = permissions.canManageBoard
   const showAssemblee = permissions.canViewPublishers || permissions.canViewPrograms
   const showTerritories =
     permissions.canViewTerritories || permissions.canViewProspection || permissions.canManageTerritories
@@ -100,23 +99,26 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarNavItem to="/" icon={Home} label={m.sidebar_home()} end />
-              {permissions.canViewBoard && <SidebarNavItem to="/board" icon={LayoutGrid} label={m.sidebar_board()} />}
+              {permissions.canViewBoard && !permissions.canManageBoard && (
+                <SidebarNavItem to="/board" icon={LayoutGrid} label={m.sidebar_board()} />
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {showDocuments && (
+        {permissions.canManageBoard && (
           <Collapsible defaultOpen className="group/collapsible">
             <SidebarGroup>
               <SidebarGroupLabel asChild>
                 <CollapsibleTrigger>
-                  {m.sidebar_documents()}
+                  {m.sidebar_board()}
                   <ChevronDown className="ml-auto size-3 transition-transform duration-200 group-data-[state=closed]/collapsible:-rotate-90" />
                 </CollapsibleTrigger>
               </SidebarGroupLabel>
               <CollapsibleContent>
                 <SidebarGroupContent>
                   <SidebarMenu>
+                    <SidebarNavItem to="/board" icon={LayoutGrid} label={m.sidebar_board()} end />
                     <SidebarNavItem to="/board/sections" icon={FolderOpen} label={m.sidebar_sections()} />
                     <SidebarNavItem to="/board/documents" icon={FileText} label={m.sidebar_documents()} />
                   </SidebarMenu>

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -83,10 +83,10 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
         <button
           type="button"
           onClick={onSearchClick}
-          className="mx-2 mb-1 flex items-center gap-2 rounded-md border border-sidebar-border bg-sidebar px-2 py-1.5 text-muted-foreground text-sm hover:bg-sidebar-accent"
+          className="mx-2 mt-3 mb-1 flex items-center gap-2 rounded-md border border-sidebar-border px-2 py-1 text-muted-foreground text-xs hover:bg-sidebar-accent"
         >
-          <Search className="size-4 shrink-0" />
-          <span className="flex-1 text-left">{m.command_palette_placeholder()}</span>
+          <Search className="size-3.5 shrink-0" />
+          <span className="flex-1 truncate text-left">{m.sidebar_search()}</span>
           <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
         </button>
       </SidebarHeader>

--- a/app/shared/ui/CommandPalette.tsx
+++ b/app/shared/ui/CommandPalette.tsx
@@ -94,7 +94,7 @@ function getNavigationItems(permissions: AppSidebarPermissions): CommandItem[] {
   items.push({ id: 'my-absences', label: m.sidebar_my_absences(), icon: CalendarOff, to: '/me/days-off' })
   items.push({
     id: 'notifications',
-    label: m.notification_preferences_page_title(),
+    label: m.sidebar_my_notifications(),
     icon: Bell,
     to: '/me/notifications',
   })

--- a/app/shared/ui/collapsible.tsx
+++ b/app/shared/ui/collapsible.tsx
@@ -1,0 +1,7 @@
+import { Collapsible } from 'radix-ui'
+
+const CollapsibleRoot = Collapsible.Root
+const CollapsibleTrigger = Collapsible.Trigger
+const CollapsibleContent = Collapsible.Content
+
+export { CollapsibleRoot as Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/app/shared/ui/sidebar.tsx
+++ b/app/shared/ui/sidebar.tsx
@@ -344,7 +344,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        'flex min-h-0 flex-1 flex-col gap-3 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
         className,
       )}
       {...props}
@@ -375,7 +375,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'flex h-8 shrink-0 items-center rounded-md px-2 font-semibold text-[0.65rem] text-sidebar-foreground/50 uppercase tracking-wider outline-hidden ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-8 shrink-0 items-center rounded-md px-2 font-semibold text-xs text-sidebar-foreground/60 uppercase tracking-wider outline-hidden ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -441,7 +441,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button relative flex w-full items-center gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding,background-color,color] duration-150 group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-transparent data-[active=true]:font-medium data-[active=true]:text-sidebar-primary before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[3px] before:rounded-r before:bg-transparent before:transition-colors data-[active=true]:before:bg-sidebar-primary data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button relative flex w-full items-center gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding,background-color,color] duration-150 group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-primary/8 data-[active=true]:font-medium data-[active=true]:text-sidebar-primary data-[active=true]:[&>svg]:text-sidebar-primary aria-[current=page]:bg-sidebar-primary/8 aria-[current=page]:font-medium aria-[current=page]:text-sidebar-primary aria-[current=page]:[&>svg]:text-sidebar-primary before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[3px] before:rounded-r before:bg-transparent before:transition-colors data-[active=true]:before:bg-sidebar-primary aria-[current=page]:before:bg-sidebar-primary data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -42,13 +42,13 @@
   --color-chart-5: oklch(0.769 0.188 70.08);
 
   /* Sidebar */
-  --color-sidebar: oklch(0.985 0.001 106.423);
+  --color-sidebar: oklch(0.97 0.001 106.424); /* stone-100 — darker than page bg */
   --color-sidebar-foreground: oklch(0.216 0.006 56.043);
   --color-sidebar-primary: oklch(0.523 0.105 184.704);
   --color-sidebar-primary-foreground: oklch(0.985 0.001 106.423);
-  --color-sidebar-accent: oklch(0.97 0.001 106.424);
+  --color-sidebar-accent: oklch(0.923 0.003 48.717); /* stone-200 — visible hover on stone-100 */
   --color-sidebar-accent-foreground: oklch(0.216 0.006 56.043);
-  --color-sidebar-border: oklch(0.923 0.003 48.717); /* stone-200 */
+  --color-sidebar-border: oklch(0.869 0.005 56.366); /* stone-300 — distinct from accent */
   --color-sidebar-ring: oklch(0.523 0.105 184.704);
 }
 
@@ -73,7 +73,7 @@
   --color-input: oklch(0.374 0.01 67.558);
   --color-ring: oklch(0.648 0.116 184.117);
 
-  --color-sidebar: oklch(0.216 0.006 56.043);
+  --color-sidebar: oklch(0.180 0.005 56.043); /* darker than page bg */
   --color-sidebar-foreground: oklch(0.985 0.001 106.423);
   --color-sidebar-primary: oklch(0.648 0.116 184.117);
   --color-sidebar-primary-foreground: oklch(0.216 0.006 56.043);


### PR DESCRIPTION
## Summary
**Visual polish (commit 1):**
- Differentiate sidebar background from page background (stone-100 light, darker-than-stone-900 dark)
- Fix active state styling (was dead code) — add `aria-[current=page]` selectors for NavLink, giving active items teal bg fill + icon tint
- Stronger hover states, larger group labels, increased inter-group spacing
- Move theme toggle to header, clean up footer logout layout
- Use `UserCog` icon for settings/users to distinguish from publishers

**UX improvements (commit 2):**
- Add clickable search input in sidebar header ("Rechercher... ⌘K") that opens command palette
- Wrap all labeled sidebar groups in Radix Collapsible with chevron indicators
- Move sidebar toggle from floating bottom-left circle to inline header bar

## Test plan
- [ ] Sidebar bg is visibly distinct from page bg (both light and dark modes)
- [ ] Active nav item shows teal left bar + subtle teal background + teal icon
- [ ] Hover shows clear background change
- [ ] Group labels are readable
- [ ] Theme toggle in sidebar header next to congregation name
- [ ] Click search input in sidebar — command palette opens
- [ ] ⌘K keyboard shortcut still works
- [ ] Click section labels to collapse/expand with chevron rotation
- [ ] Sidebar toggle in top-left header bar (not floating at bottom)
- [ ] Mobile: hamburger in top-left opens sidebar sheet
- [ ] Home group (Accueil + Tableau) is not collapsible