### PR TITLE
docs: update PDF export and display board programme documentation

### DIFF
--- a/docs/product/display-board.md
+++ b/docs/product/display-board.md
@@ -113,7 +113,7 @@ Available types (appear only when the related feature has data):
 
 - **Groupes de prédication** — Live list of publisher groups with responsible, deputy, and members
 - **Pionniers** — List of publishers registered as regular pioneers, special pioneers, or missionaries
-- **Programmes** — One entry per programme template (e.g., "Réunion de semaine"). Shows all events from the start of the current month with their assigned parts, grouped by section. An optional "Afficher les services" toggle adds service role assignments.
+- **Programmes** — Configurable live schedule documents. Each programme document stores a `dynamicConfig` JSON with per-template parts/services selection and a groupBy preference (date or template). Multiple programme documents can be created with different configurations. The view shows events from the start of the current month with a clean layout: colored section bars, dot leaders between part names and assignees, and per-template content filtering. Legacy documents without `dynamicConfig` fall back to a single template via `dynamicRef` and a `showServices` flag.
 
 Dynamic documents support the same visibility, highlighting, ordering, and section placement controls as PDF documents. They appear alongside PDFs in the same sections on the board. On the board view, each dynamic document card shows a **preview summary** (group count, pioneer count, or next event date) to provide context at a glance.
 

--- a/docs/product/events.md
+++ b/docs/product/events.md
@@ -51,7 +51,7 @@ Parts and service roles are stored inline on each event (with name, section, ord
 
 ## PDF Export
 
-Events can be exported to PDF from the programme list. The export supports filtering by template and date range. Parallel parts (sharing the same order) are rendered with their track label appended to the part name.
+Events can be exported to PDF from the programme list. The export form provides per-template content selection: each template row has checkboxes for parts and services, allowing mixed exports (e.g., midweek parts + weekend services only). Additional options include an editable document title, a date range filter, and grouping by date (chronological) or by template type. The PDF uses a workbook-inspired single-column layout with colored section bars, dot leaders between part names and assignees, and topic replacing part name when available. Parallel parts (same order, different tracks) render as sub-rows with track labels. A legacy URL format (`?templateId=...&contentType=...`) is preserved for backwards compatibility.
 
 ## Assignments
 


### PR DESCRIPTION
## Summary

- Updated PDF export section in `docs/product/events.md` to reflect new per-template content selection, editable title, groupBy option, and workbook-inspired layout
- Updated programme dynamic documents section in `docs/product/display-board.md` to describe `dynamicConfig` JSON, multi-template support, and clean layout with dot leaders

## Test plan

- [ ] Review documentation accuracy against implemented features in feat/export-program branch