### PR TITLE
fix: error boundary alignment, auth route, and client PDF crash

### DIFF
--- a/app/features/authentication/authentication.routes.ts
+++ b/app/features/authentication/authentication.routes.ts
@@ -9,7 +9,6 @@ export const authenticationRoutes = [
   route('verify-email/:token', 'features/authentication/routes/verify-email-confirm.tsx'),
   ...prefix('password', [
     route(':userHash/reset', 'features/authentication/routes/password-reset.tsx'),
-    route(':userId/invalidate', 'features/authentication/routes/password-invalidation.tsx'),
     route('forgot', 'features/authentication/routes/password-forgot.tsx'),
   ]),
 ] satisfies RouteConfig

--- a/app/features/territories/ui/TerritoryDocument.tsx
+++ b/app/features/territories/ui/TerritoryDocument.tsx
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { Document, Font, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
 import { formatAccessSequence } from '~/features/territories/model/access-format'
 import { shopKindLabels as getShopKindLabels, type ShopKind } from '~/features/territories/model/shop-kind.type'
@@ -8,15 +7,13 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import * as m from '~/paraglide/messages'
 import type { Entrance } from '~/shared/types/entrance'
 
-const fontsDir = path.join(process.cwd(), 'public', 'fonts')
-
 Font.register({
   family: 'Fira Sans',
   fonts: [
-    { src: path.join(fontsDir, 'FiraSans-Regular.ttf') },
-    { src: path.join(fontsDir, 'FiraSans-Bold.ttf'), fontWeight: 'bold' },
-    { src: path.join(fontsDir, 'FiraSans-Italic.ttf'), fontStyle: 'italic' },
-    { src: path.join(fontsDir, 'FiraSans-BoldItalic.ttf'), fontWeight: 'bold', fontStyle: 'italic' },
+    { src: '/fonts/FiraSans-Regular.ttf' },
+    { src: '/fonts/FiraSans-Bold.ttf', fontWeight: 'bold' },
+    { src: '/fonts/FiraSans-Italic.ttf', fontStyle: 'italic' },
+    { src: '/fonts/FiraSans-BoldItalic.ttf', fontWeight: 'bold', fontStyle: 'italic' },
   ],
 })
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -83,7 +83,7 @@ export function ErrorBoundary() {
     return (
       <div className="flex min-h-screen items-center justify-center px-4">
         <Card className="max-w-md text-center">
-          <CardHeader className="items-center gap-3">
+          <CardHeader className="items-center justify-items-center gap-3">
             <div className="flex size-12 items-center justify-center rounded-full bg-muted">
               <Icon className="size-6 text-muted-foreground" />
             </div>
@@ -118,7 +118,7 @@ export function ErrorBoundary() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <Card className="max-w-md text-center">
-        <CardHeader className="items-center gap-3">
+        <CardHeader className="items-center justify-items-center gap-3">
           <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="size-6 text-destructive" />
           </div>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -18,6 +18,7 @@ export default [
   ...authenticationRoutes,
   route('', 'routes/_authenticated-layout.tsx', [
     index('features/dashboard/routes/index.tsx'),
+    route('password/:userId/invalidate', 'features/authentication/routes/password-invalidation.tsx'),
     route('me', 'features/authentication/routes/user/_layout.tsx', [
       route('profile', 'features/authentication/routes/user/profile.tsx'),
       route('consents', 'features/authentication/routes/user/consents.tsx'),

--- a/app/shared/ui/RouteErrorBoundary.tsx
+++ b/app/shared/ui/RouteErrorBoundary.tsx
@@ -17,7 +17,7 @@ export function RouteErrorBoundary() {
     return (
       <div className="flex items-center justify-center py-20">
         <Card className="max-w-md text-center">
-          <CardHeader className="items-center gap-3">
+          <CardHeader className="items-center justify-items-center gap-3">
             <div className="flex size-12 items-center justify-center rounded-full bg-muted">
               <Icon className="size-6 text-muted-foreground" />
             </div>
@@ -52,7 +52,7 @@ export function RouteErrorBoundary() {
   return (
     <div className="flex items-center justify-center py-20">
       <Card className="max-w-md text-center">
-        <CardHeader className="items-center gap-3">
+        <CardHeader className="items-center justify-items-center gap-3">
           <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="size-6 text-destructive" />
           </div>


### PR DESCRIPTION
## Summary

- **Error boundary icon alignment**: Added `justify-items-center` to `CardHeader` in both `ErrorBoundary` (root) and `RouteErrorBoundary` to center icons in the CSS Grid layout
- **Password invalidation route**: Moved `/password/:userId/invalidate` from unauthenticated `authenticationRoutes` into the authenticated layout so `requireAuth` middleware runs and `userContext`/`permissionsContext` are available
- **Client-side PDF crash**: Replaced `node:path` and `process.cwd()` in `TerritoryDocument.tsx` with public URL paths (`/fonts/...`) to prevent `ReferenceError: process is not defined` in the client bundle

## Test plan

- [ ] Verify error boundary pages show centered icons (trigger a 404 or 500)
- [ ] Verify password invalidation works from Settings > Users > Edit > Reset password
- [ ] Verify territory list and territory view pages load via client-side navigation (not just direct URL)
- [ ] Verify PDF download still works on territory pages