### PR TITLE
fix: content directory permissions and cron docs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,7 @@ ENV NODE_ENV=production
 ENV UNITAE_WEB_PORT=8080
 RUN addgroup -g 1001 -S unitae && \
     adduser -u 1001 -S unitae -G unitae -s /sbin/nologin -H
+RUN mkdir -p /app/content/uploads && chown -R 1001:1001 /app/content
 COPY --from=build --chown=1001:1001 /app/build ./build
 COPY --from=build --chown=1001:1001 /app/package.json ./
 COPY --from=prod-deps --chown=1001:1001 /app/node_modules ./node_modules

--- a/docs/self-hosting/cron-jobs.md
+++ b/docs/self-hosting/cron-jobs.md
@@ -54,13 +54,13 @@ UNITAE_CRON_SECRET="your-secret-here"
 UNITAE_BASE_URL="http://localhost:8080"
 
 # Retention cleanup — daily at 3:00 AM
-0 3 * * * curl -s -H "Authorization: Bearer $CRON_SECRET" "$BASE_URL/cron/retention"
+0 3 * * * curl -s -H "Authorization: Bearer $UNITAE_CRON_SECRET" "$UNITAE_BASE_URL/cron/retention"
 
 # Board expiration check — daily at 7:00 AM
-0 7 * * * curl -s -H "Authorization: Bearer $CRON_SECRET" "$BASE_URL/cron/board-expirations"
+0 7 * * * curl -s -H "Authorization: Bearer $UNITAE_CRON_SECRET" "$UNITAE_BASE_URL/cron/board-expirations"
 
 # Notification flush — every 5 minutes
-*/5 * * * * curl -s -H "Authorization: Bearer $CRON_SECRET" "$BASE_URL/cron/process-notifications"
+*/5 * * * * curl -s -H "Authorization: Bearer $UNITAE_CRON_SECRET" "$UNITAE_BASE_URL/cron/process-notifications"
 ```
 
 ### systemd timer

--- a/docs/self-hosting/getting-started.md
+++ b/docs/self-hosting/getting-started.md
@@ -43,6 +43,9 @@ DB_RUNTIME_URL=postgresql://unitae_app:your-strong-database-password@postgres:54
 # Redis (Docker Compose service name)
 REDIS_HOST=redis
 REDIS_PORT=6379
+
+# Cron secret (required for scheduled maintenance tasks)
+UNITAE_CRON_SECRET=your-cron-secret-at-least-32-characters
 ```
 
 By default, `DB_RUNTIME_PASSWORD` matches `DB_PASSWORD`. If you set a different password, update the connection string in `DB_RUNTIME_URL` accordingly.


### PR DESCRIPTION
## Summary

- **Dockerfile**: Pre-create `/app/content/uploads` with `unitae` user ownership so file uploads work on fresh Docker deployments without manual `chown`
- **Cron docs**: Fix crontab example using wrong variable names (`$CRON_SECRET` → `$UNITAE_CRON_SECRET`, `$BASE_URL` → `$UNITAE_BASE_URL`)
- **Getting started**: Add `UNITAE_CRON_SECRET` to the `.env` example so users configure it during initial setup

## Test plan

- [ ] Build Docker image and verify `/app/content/uploads` exists with uid 1001 ownership
- [ ] Deploy fresh instance and upload a board document without manual permission fixes
- [ ] Verify crontab example works with correct variable names