### PR TITLE
fix: reuse seed congregation in single-tenant setup

### DIFF
--- a/app/features/authentication/server/setup-first-user.server.test.ts
+++ b/app/features/authentication/server/setup-first-user.server.test.ts
@@ -7,7 +7,7 @@ const scopedDb = {
 
 vi.mock('~/shared/infra/db.server', () => ({
   unscopedDb: {
-    congregation: { create: vi.fn() },
+    congregation: { findFirst: vi.fn(), create: vi.fn() },
     user: { create: vi.fn() },
     userRole: { findUnique: vi.fn(), upsert: vi.fn() },
     congregationUserRole: { create: vi.fn() },
@@ -25,6 +25,7 @@ const { unscopedDb: db } = await import('~/shared/infra/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
+  vi.mocked(db.congregation.findFirst).mockResolvedValue(null as never)
   vi.mocked(db.congregation.create).mockResolvedValue({ id: 1, slug: 'test' } as never)
   vi.mocked(db.user.create).mockResolvedValue({ id: 42 } as never)
   vi.mocked(db.userRole.findUnique).mockResolvedValue({ id: 5, key: 'admin' } as never)

--- a/app/features/authentication/server/setup-first-user.server.ts
+++ b/app/features/authentication/server/setup-first-user.server.ts
@@ -18,13 +18,18 @@ export async function setupFirstUser(
 
   const hashedPassword = await hash(password)
 
-  const congregation = await db.congregation.create({
-    data: {
-      name: congregationName,
-      slug: congregationSlug,
-      locale,
-    },
-  })
+  // In single-tenant mode, the seed may have already created a congregation.
+  // Reuse it instead of creating a duplicate.
+  const existingCongregation = await db.congregation.findFirst()
+  const congregation =
+    existingCongregation ??
+    (await db.congregation.create({
+      data: {
+        name: congregationName,
+        slug: congregationSlug,
+        locale,
+      },
+    }))
 
   const user = await db.user.create({
     data: {


### PR DESCRIPTION
## Summary

- In single-tenant mode, `prisma db seed` pre-creates a default congregation with event kinds and programme templates
- `/setup` was always creating a **second** congregation, leaving the seed one orphaned and the admin user in the wrong congregation
- Now `setupFirstUser` checks for an existing congregation and reuses it instead of creating a duplicate
- Does not affect multi-tenant mode (`/register` flow is unchanged)

## Test plan

- [ ] Fresh single-tenant deploy: run seed, then /setup — verify only one congregation exists
- [ ] Fresh single-tenant deploy without seed: /setup still creates a congregation correctly
- [ ] Multi-tenant mode: /register still creates new congregations as before