### PR TITLE
fix: use UNITAE_BASE_URL directly in single-tenant mode

### DIFF
--- a/app/shared/domain/congregation.server.test.ts
+++ b/app/shared/domain/congregation.server.test.ts
@@ -91,11 +91,21 @@ describe('resolveCongregation', () => {
     expect(result.emailFrom).toBe('Congrégation Test <contact@test.org>')
   })
 
-  it('construit le baseUrl à partir du slug quand baseUrl est null', async () => {
+  it('construit le baseUrl à partir du slug quand baseUrl est null (multi-tenant)', async () => {
+    process.env.UNITAE_MULTI_TENANT = 'true'
     vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
 
     const result = await resolveCongregation(1)
     expect(result.baseUrl).toBe('https://test.unitae.app')
+    delete process.env.UNITAE_MULTI_TENANT
+  })
+
+  it('utilise UNITAE_BASE_URL directement quand single-tenant', async () => {
+    delete process.env.UNITAE_MULTI_TENANT
+    vi.mocked(db.congregation.findUnique).mockResolvedValue(baseCongregation as never)
+
+    const result = await resolveCongregation(1)
+    expect(result.baseUrl).toBe('https://unitae.app')
   })
 
   it('utilise le baseUrl personnalisé quand il est défini', async () => {

--- a/app/shared/domain/congregation.server.ts
+++ b/app/shared/domain/congregation.server.ts
@@ -44,10 +44,13 @@ export async function resolveCongregation(congregationId: number): Promise<Congr
     emailFrom: congregation.emailFromAddress
       ? `${congregation.emailFromName ?? congregation.name} <${congregation.emailFromAddress}>`
       : DEFAULT_EMAIL_FROM,
-    // Priority: custom domain > explicit baseUrl > slug-derived URL
+    // Priority: custom domain > explicit baseUrl > single-tenant base URL > slug-derived URL
     baseUrl: congregation.domain
       ? `https://${congregation.domain}`
-      : (congregation.baseUrl ?? `https://${congregation.slug}.${appBaseUrl.replace('https://', '')}`),
+      : (congregation.baseUrl
+          ?? (process.env.UNITAE_MULTI_TENANT !== 'true'
+            ? appBaseUrl
+            : `https://${congregation.slug}.${appBaseUrl.replace('https://', '')}`)),
     plan: congregation.plan,
     maxPublishers: congregation.maxPublishers,
     maxTerritories: congregation.maxTerritories,


### PR DESCRIPTION
## Summary

- In single-tenant mode, `resolveCongregation` was building `baseUrl` as `https://{slug}.{UNITAE_BASE_URL}` (e.g., `https://default.domain.org`)
- This is the multi-tenant subdomain pattern — wrong for single-tenant where `UNITAE_BASE_URL` is already the full URL
- Now uses `UNITAE_BASE_URL` directly in single-tenant mode, slug-based subdomains only in multi-tenant

Resolution priority:
1. `congregation.domain` (custom domain)
2. `congregation.baseUrl` (explicit DB override)
3. Single-tenant: `UNITAE_BASE_URL` as-is
4. Multi-tenant: `{slug}.{UNITAE_BASE_URL}`

## Test plan

- [ ] Single-tenant: verify password reset emails contain correct base URL (no slug prefix)
- [ ] Single-tenant: verify email links work and point to the correct host
- [ ] Multi-tenant: verify slug-based subdomain URLs still work in emails