### PR TITLE
fix: fix multi-track programme display and add trackOrder for stable track ordering

### DIFF
--- a/app/database/migrations/20260429000000_add_track_order_to_programme_parts/migration.sql
+++ b/app/database/migrations/20260429000000_add_track_order_to_programme_parts/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ProgrammeTemplatePart" ADD COLUMN "trackOrder" INTEGER;
+ALTER TABLE "ProgrammePartAssignment" ADD COLUMN "trackOrder" INTEGER;

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -476,6 +476,7 @@ model ProgrammeTemplatePart {
   name        String
   section     String  @default("")
   track       String  @default("")
+  trackOrder  Int?
   order       Int
   durationMin          Int?
   allowExternalSpeaker Boolean @default(false)
@@ -517,6 +518,7 @@ model ProgrammePartAssignment {
   name        String  @default("")
   section     String  @default("")
   track       String  @default("")
+  trackOrder  Int?
   order       Int     @default(0)
   durationMin Int?
 

--- a/app/features/display-board/routes/documents/new-dynamic.tsx
+++ b/app/features/display-board/routes/documents/new-dynamic.tsx
@@ -1,5 +1,5 @@
 import { parseWithZod } from '@conform-to/zod'
-import { Calendar, Star, Users } from 'lucide-react'
+import { Calendar, Info, Star, Users } from 'lucide-react'
 import { data, Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import type { ProgrammeDynamicConfig } from '~/features/display-board/model/dynamic-document.type'
@@ -10,6 +10,7 @@ import { listAvailableDynamicTypes } from '~/features/display-board/server/dynam
 import * as m from '~/paraglide/messages'
 import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
 import { Role } from '~/shared/types/role'
+import { Alert, AlertDescription } from '~/shared/ui/alert'
 import { Card, CardContent } from '~/shared/ui/card'
 import { EmptyState } from '~/shared/ui/EmptyState'
 import { PageHeader } from '~/shared/ui/PageHeader'
@@ -58,11 +59,10 @@ export default function NewDynamicDocumentPage({ loaderData }: Route.ComponentPr
       />
 
       {!hasSection && (
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-muted-foreground text-sm">{m.board_new_dynamic_requires_section()}</p>
-          </CardContent>
-        </Card>
+        <Alert>
+          <Info />
+          <AlertDescription>{m.board_new_dynamic_requires_section()}</AlertDescription>
+        </Alert>
       )}
 
       {available.length === 0 ? (

--- a/app/features/display-board/server/dynamic-documents.server.ts
+++ b/app/features/display-board/server/dynamic-documents.server.ts
@@ -327,7 +327,7 @@ function fetchProgrammeByIds(
     include: {
       template: true,
       partAssignments: {
-        orderBy: { order: 'asc' },
+        orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
         include: {
           assignee: { select: userSelect },
           assistant: { select: userSelect },
@@ -355,7 +355,7 @@ function fetchProgrammeByKey(
     },
     include: {
       partAssignments: {
-        orderBy: { order: 'asc' },
+        orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
         include: {
           assignee: { select: userSelect },
           assistant: { select: userSelect },

--- a/app/features/display-board/ui/dynamic/ProgrammeView.tsx
+++ b/app/features/display-board/ui/dynamic/ProgrammeView.tsx
@@ -200,10 +200,12 @@ function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: stri
   const representative = parts[0]
   const hasQuery = query.length > 0
 
+  const displayName = representative.topic !== '' ? representative.topic : representative.name
+
   return (
     <div>
       <div className="font-semibold text-foreground text-sm">
-        {representative.name}
+        {displayName}
         {representative.durationMin != null && (
           <span className="ml-1 font-normal text-muted-foreground text-xs">({representative.durationMin} min)</span>
         )}
@@ -212,7 +214,7 @@ function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: stri
         const assigneeName = formatName(part.assignee)
         const assistantName = formatName(part.assistant)
         const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
-        const trackName = part.topic !== '' ? part.topic : part.track || `Salle ${idx + 1}`
+        const trackName = part.track || `Salle ${idx + 1}`
         const highlighted = hasQuery && (nameMatches(part.assignee, query) || nameMatches(part.assistant, query))
         const dimmed = hasQuery && !highlighted
 

--- a/app/features/events/model/group-parts-by-slot.test.ts
+++ b/app/features/events/model/group-parts-by-slot.test.ts
@@ -61,4 +61,18 @@ describe('groupPartsBySlot', () => {
   it('retourne un tableau vide pour une liste vide', () => {
     expect(groupPartsBySlot([])).toEqual([])
   })
+
+  it("préserve le champ track de chaque partie dans un slot parallèle (le rendu l'utilise comme étiquette de salle)", () => {
+    const parts: Part[] = [
+      makePart(1, 'Ministere', 5, 'Salle principale'),
+      makePart(2, 'Ministere', 5, 'Salle secondaire'),
+    ]
+
+    const result = groupPartsBySlot(parts)
+    const slot = result[0].slots[0]
+
+    expect(slot.parts).toHaveLength(2)
+    expect(slot.parts[0].track).toBe('Salle principale')
+    expect(slot.parts[1].track).toBe('Salle secondaire')
+  })
 })

--- a/app/features/events/routes/programs/events/edit.tsx
+++ b/app/features/events/routes/programs/events/edit.tsx
@@ -165,12 +165,13 @@ async function handleAddPart(
   const submission = parseWithZod(formData, { schema: addPartSchema })
   if (submission.status !== 'success') return submission
 
-  const { partName, partSection, partTrack, partOrder, partDuration, partAllowExternalSpeaker } = submission.value
+  const { partName, partSection, partTrack, partTrackOrder, partOrder, partDuration, partAllowExternalSpeaker } = submission.value
   await addPartAssignment(db, {
     eventId,
     name: partName,
     section: partSection,
     track: partTrack,
+    trackOrder: partTrackOrder ?? null,
     order: partOrder,
     durationMin: partDuration ?? null,
     allowExternalSpeaker: partAllowExternalSpeaker,
@@ -187,7 +188,7 @@ async function handleUpdatePart(
   const submission = parseWithZod(formData, { schema: updatePartSchema })
   if (submission.status !== 'success') return submission
 
-  const { partAssignmentId, partName, partSection, partTrack, partOrder, partDuration, partAllowExternalSpeaker } =
+  const { partAssignmentId, partName, partSection, partTrack, partTrackOrder, partOrder, partDuration, partAllowExternalSpeaker } =
     submission.value
   await updatePartAssignment(
     db,
@@ -196,6 +197,7 @@ async function handleUpdatePart(
       name: partName,
       section: partSection,
       track: partTrack,
+      trackOrder: partTrackOrder ?? null,
       order: partOrder,
       durationMin: partDuration ?? null,
       allowExternalSpeaker: partAllowExternalSpeaker,
@@ -289,6 +291,7 @@ export default function EditEventPage({ loaderData }: Route.ComponentProps) {
     name: string
     section: string
     track: string
+    trackOrder: number | null
     order: number
     durationMin: number | null
     allowExternalSpeaker: boolean
@@ -510,6 +513,7 @@ export default function EditEventPage({ loaderData }: Route.ComponentProps) {
                                       name: assignment.name,
                                       section: assignment.section,
                                       track: assignment.track,
+                                      trackOrder: assignment.trackOrder,
                                       order: assignment.order,
                                       durationMin: assignment.durationMin,
                                       allowExternalSpeaker: assignment.allowExternalSpeaker,

--- a/app/features/events/routes/programs/export-pdf-download.tsx
+++ b/app/features/events/routes/programs/export-pdf-download.tsx
@@ -114,7 +114,7 @@ function handleLegacyFormat(
         template: true,
         partAssignments: {
           include: { assignee: true, assistant: true },
-          orderBy: { order: 'asc' },
+          orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
         },
         serviceRoleAssignments: {
           include: { assignee: true },

--- a/app/features/events/schemas/program-edit.schema.ts
+++ b/app/features/events/schemas/program-edit.schema.ts
@@ -13,6 +13,7 @@ export const addPartSchema = z.object({
   partName: z.string().min(1),
   partSection: z.string().optional().default(''),
   partTrack: z.string().optional().default(''),
+  partTrackOrder: z.coerce.number().optional(),
   partOrder: z.coerce.number().default(0),
   partDuration: z.coerce.number().optional(),
   partAllowExternalSpeaker: z
@@ -42,6 +43,7 @@ export const updatePartSchema = z.object({
   partName: z.string().min(1),
   partSection: z.string().optional().default(''),
   partTrack: z.string().optional().default(''),
+  partTrackOrder: z.coerce.number().optional(),
   partOrder: z.coerce.number().default(0),
   partDuration: z.coerce.number().optional(),
   partAllowExternalSpeaker: z

--- a/app/features/events/server/programme-assignments.server.ts
+++ b/app/features/events/server/programme-assignments.server.ts
@@ -12,7 +12,7 @@ export function getEventProgramme(db: TransactionClient, eventId: number, congre
           assignee: true,
           assistant: true,
         },
-        orderBy: { order: 'asc' },
+        orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
       },
       serviceRoleAssignments: {
         include: {

--- a/app/features/events/server/programme-events.server.ts
+++ b/app/features/events/server/programme-events.server.ts
@@ -40,6 +40,7 @@ export function addPartAssignment(
     name: string
     section: string
     track: string
+    trackOrder?: number | null
     order: number
     durationMin: number | null
     allowExternalSpeaker: boolean
@@ -72,7 +73,7 @@ export function addServiceRoleAssignment(
 export function updatePartAssignment(
   db: TransactionClient,
   id: number,
-  data: { name: string; section: string; track: string; order: number; durationMin: number | null; allowExternalSpeaker: boolean },
+  data: { name: string; section: string; track: string; trackOrder?: number | null; order: number; durationMin: number | null; allowExternalSpeaker: boolean },
   congregationId: number,
 ) {
   return db.programmePartAssignment.update({

--- a/app/features/events/server/programme-export.server.ts
+++ b/app/features/events/server/programme-export.server.ts
@@ -43,7 +43,7 @@ export async function getEventsForExport(db: TransactionClient, templateIds: num
       template: true,
       partAssignments: {
         include: { assignee: true, assistant: true },
-        orderBy: { order: 'asc' },
+        orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
       },
       serviceRoleAssignments: {
         include: { assignee: true },

--- a/app/features/events/server/programme-generation.server.ts
+++ b/app/features/events/server/programme-generation.server.ts
@@ -4,7 +4,7 @@ import type { TransactionClient } from '~/shared/infra/db.server'
 interface TemplateWithRelations {
   id: number
   name: string
-  parts: { id: number; name: string; section: string; track: string; order: number; durationMin: number | null; allowExternalSpeaker: boolean }[]
+  parts: { id: number; name: string; section: string; track: string; trackOrder: number | null; order: number; durationMin: number | null; allowExternalSpeaker: boolean }[]
   serviceRoles: { id: number; name: string }[]
 }
 
@@ -51,6 +51,7 @@ async function createEventWithAssignments(
         name: part.name,
         section: part.section,
         track: part.track,
+        trackOrder: part.trackOrder,
         order: part.order,
         durationMin: part.durationMin,
         allowExternalSpeaker: part.allowExternalSpeaker,

--- a/app/features/events/server/programme-templates.server.ts
+++ b/app/features/events/server/programme-templates.server.ts
@@ -45,6 +45,7 @@ export function upsertTemplatePart(
     name: string
     section: string
     track: string
+    trackOrder?: number | null
     order: number
     durationMin: number | null
     allowExternalSpeaker: boolean
@@ -61,6 +62,7 @@ export function upsertTemplatePart(
         name: partData.name,
         section: partData.section,
         track: partData.track,
+        trackOrder: partData.trackOrder,
         order: partData.order,
         durationMin: partData.durationMin,
         allowExternalSpeaker: partData.allowExternalSpeaker,
@@ -73,6 +75,7 @@ export function upsertTemplatePart(
       name: partData.name,
       section: partData.section,
       track: partData.track,
+      trackOrder: partData.trackOrder,
       order: partData.order,
       durationMin: partData.durationMin,
       allowExternalSpeaker: partData.allowExternalSpeaker,

--- a/app/features/events/ui/PartEditSheet.tsx
+++ b/app/features/events/ui/PartEditSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { useFetcher } from 'react-router'
 import * as m from '~/paraglide/messages'
 import { Checkbox } from '~/shared/ui/checkbox'
@@ -12,6 +12,7 @@ type PartData = {
   name: string
   section: string
   track: string
+  trackOrder?: number | null
   order: number
   durationMin: number | null
   allowExternalSpeaker?: boolean
@@ -29,6 +30,11 @@ type PartEditSheetProps = {
 export function PartEditSheet({ open, onOpenChange, part, mode, fetcher, defaultOrder }: PartEditSheetProps) {
   const isEditing = part != null
   const prevState = useRef(fetcher.state)
+  const [trackValue, setTrackValue] = useState(part?.track ?? '')
+
+  useEffect(() => {
+    setTrackValue(part?.track ?? '')
+  }, [part])
 
   useEffect(() => {
     if (prevState.current === 'submitting' && fetcher.state === 'idle') {
@@ -65,8 +71,25 @@ export function PartEditSheet({ open, onOpenChange, part, mode, fetcher, default
 
           <div className="flex flex-col gap-2">
             <Label htmlFor="partTrack">{m.programs_edit_part_track_label()}</Label>
-            <Input id="partTrack" name="partTrack" defaultValue={part?.track ?? ''} />
+            <Input
+              id="partTrack"
+              name="partTrack"
+              value={trackValue}
+              onChange={e => setTrackValue(e.target.value)}
+            />
           </div>
+
+          {trackValue !== '' && (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="partTrackOrder">{m.programs_edit_part_track_order_label()}</Label>
+              <Input
+                id="partTrackOrder"
+                name="partTrackOrder"
+                type="number"
+                defaultValue={part?.trackOrder ?? ''}
+              />
+            </div>
+          )}
 
           <div className="flex gap-4">
             <div className="flex flex-1 flex-col gap-2">

--- a/app/features/events/ui/ProgrammeBoardDocument.tsx
+++ b/app/features/events/ui/ProgrammeBoardDocument.tsx
@@ -3,8 +3,6 @@ import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/rendere
 import { groupPartsBySlot } from '~/features/events/model/group-parts-by-slot'
 import type { ExportEvent, TemplateExportConfig } from '~/features/events/server/programme-export.server'
 
-// Register fonts lazily to avoid conflicts with TerritoryDocument.tsx which uses bare `/fonts/...`
-// paths. @react-pdf/font is a singleton — the last Font.register() for the same family wins.
 function ensureFontsRegistered() {
   const fontsDir = path.join(process.cwd(), 'public', 'fonts')
   Font.register({
@@ -187,7 +185,7 @@ const styles = StyleSheet.create({
     color: '#94a3b8',
     textTransform: 'uppercase',
     letterSpacing: 0.4,
-    width: 40,
+    flexShrink: 0,
   },
   // Services
   servicesDivider: {
@@ -410,12 +408,13 @@ function SinglePart({ part }: { part: PartAssignment }) {
 
 function MultiTrackPart({ parts }: { parts: PartAssignment[] }) {
   const representative = parts[0]
+  const displayName = representative.topic !== '' ? representative.topic : representative.name
 
   return (
     <View>
       <View style={styles.partRow}>
         <Text style={styles.partLeft}>
-          {representative.name}
+          {displayName}
           {representative.durationMin != null && (
             <Text style={styles.partDuration}> ({representative.durationMin} min)</Text>
           )}
@@ -425,7 +424,7 @@ function MultiTrackPart({ parts }: { parts: PartAssignment[] }) {
         const assigneeName = formatName(part.assignee)
         const assistantName = formatName(part.assistant)
         const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
-        const trackName = part.topic !== '' ? part.topic : part.track || `Salle ${idx + 1}`
+        const trackName = part.track || `Salle ${idx + 1}`
         return (
           // biome-ignore lint/suspicious/noArrayIndexKey: track parts within a slot
           <View key={idx} style={styles.trackRow}>

--- a/app/features/settings/routes/congregation/templates/edit.tsx
+++ b/app/features/settings/routes/congregation/templates/edit.tsx
@@ -111,7 +111,7 @@ async function handlePartIntent(
     const submission = parseWithZod(formData, { schema: upsertPartSchema })
     if (submission.status !== 'success') return submission
 
-    const { partId, partName, partSection, partTrack, partOrder, partDuration, partAllowExternalSpeaker } =
+    const { partId, partName, partSection, partTrack, partTrackOrder, partOrder, partDuration, partAllowExternalSpeaker } =
       submission.value
     await upsertTemplatePart(
       db,
@@ -121,6 +121,7 @@ async function handlePartIntent(
         name: partName,
         section: partSection,
         track: partTrack,
+        trackOrder: partTrackOrder ?? null,
         order: partOrder,
         durationMin: partDuration ?? null,
         allowExternalSpeaker: partAllowExternalSpeaker,
@@ -186,6 +187,7 @@ export default function TemplateEditPage({ loaderData }: Route.ComponentProps) {
     name: string
     section: string
     track: string
+    trackOrder: number | null
     order: number
     durationMin: number | null
     allowExternalSpeaker: boolean
@@ -363,6 +365,7 @@ export default function TemplateEditPage({ loaderData }: Route.ComponentProps) {
                                       name: part.name,
                                       section: part.section,
                                       track: part.track,
+                                      trackOrder: part.trackOrder,
                                       order: part.order,
                                       durationMin: part.durationMin,
                                       allowExternalSpeaker: part.allowExternalSpeaker,

--- a/app/features/settings/schemas/template.schema.ts
+++ b/app/features/settings/schemas/template.schema.ts
@@ -26,6 +26,7 @@ export const upsertPartSchema = z.object({
   partName: z.string().min(1),
   partSection: z.string().optional().default(''),
   partTrack: z.string().optional().default(''),
+  partTrackOrder: z.coerce.number().optional(),
   partOrder: z.coerce.number().default(0),
   partDuration: z.coerce.number().optional(),
   partAllowExternalSpeaker: z

--- a/app/features/territories/ui/TerritoryDocument.tsx
+++ b/app/features/territories/ui/TerritoryDocument.tsx
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { Document, Font, Image, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
 import { formatAccessSequence } from '~/features/territories/model/access-format'
 import { shopKindLabels as getShopKindLabels, type ShopKind } from '~/features/territories/model/shop-kind.type'
@@ -7,13 +8,14 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import * as m from '~/paraglide/messages'
 import type { Entrance } from '~/shared/types/entrance'
 
+const fontsDir = path.join(process.cwd(), 'public', 'fonts')
 Font.register({
   family: 'Fira Sans',
   fonts: [
-    { src: '/fonts/FiraSans-Regular.ttf' },
-    { src: '/fonts/FiraSans-Bold.ttf', fontWeight: 'bold' },
-    { src: '/fonts/FiraSans-Italic.ttf', fontStyle: 'italic' },
-    { src: '/fonts/FiraSans-BoldItalic.ttf', fontWeight: 'bold', fontStyle: 'italic' },
+    { src: path.join(fontsDir, 'FiraSans-Regular.ttf') },
+    { src: path.join(fontsDir, 'FiraSans-Bold.ttf'), fontWeight: 'bold' },
+    { src: path.join(fontsDir, 'FiraSans-Italic.ttf'), fontStyle: 'italic' },
+    { src: path.join(fontsDir, 'FiraSans-BoldItalic.ttf'), fontWeight: 'bold', fontStyle: 'italic' },
   ],
 })
 

--- a/app/messages/en.json
+++ b/app/messages/en.json
@@ -1116,6 +1116,7 @@
     "programs_edit_new_part_placeholder": "New part",
     "programs_edit_part_section_label": "Section",
     "programs_edit_part_track_label": "Track / Room",
+    "programs_edit_part_track_order_label": "Track order",
     "programs_edit_part_order_label": "Order",
     "programs_edit_part_duration_label": "Duration (min)",
     "programs_edit_add_button": "Add",

--- a/app/messages/fr.json
+++ b/app/messages/fr.json
@@ -1116,6 +1116,7 @@
     "programs_edit_new_part_placeholder": "Nouvelle partie",
     "programs_edit_part_section_label": "Section",
     "programs_edit_part_track_label": "Groupe / Salle",
+    "programs_edit_part_track_order_label": "Ordre de la salle",
     "programs_edit_part_order_label": "Ordre",
     "programs_edit_part_duration_label": "Durée (min)",
     "programs_edit_add_button": "Ajouter",


### PR DESCRIPTION
## Summary

- **Fix `MultiTrackPart` rendering** (live view + PDF): `topic` now correctly replaces the part name at the top of the group; `part.track` is always used as the track label (previously `topic` was incorrectly used as the label)
- **Fix `TerritoryDocument` font path**: was using bare `/fonts/...` URL paths; changed to absolute `process.cwd()/public/fonts/...` so font registration is consistent regardless of which PDF module is imported first
- **Fix track label width in PDF**: `trackLabel` used a fixed `width: 40` causing room names like "Salle principale" to overflow; changed to `flexShrink: 0` so the label takes its natural width
- **Replace no-section Card with Alert** on `/board/documents/new-dynamic`
- **Add `trackOrder` column** to `ProgrammeTemplatePart` and `ProgrammePartAssignment` for user-controlled ordering of parallel tracks; the field appears in `PartEditSheet` only when a track value is set; propagated from template parts to generated events; all `partAssignments` queries use `[{ order: asc }, { trackOrder: asc, nulls: last }]`

## Test plan

- [ ] Open a programme event with multi-track parts — verify topic shows as part name, track label shows room name
- [ ] Export programme PDF — verify track labels fit on one row and show room names correctly
- [ ] Visit `/board/documents/new-dynamic` with no sections — verify info Alert is shown instead of a card
- [ ] Edit a part with a track set — verify `trackOrder` input appears; clear the track — verify it disappears
- [ ] Set `trackOrder` values on parallel parts, check live board and PDF export respect the order
- [ ] Generate events from a template with `trackOrder` set — verify it is copied to the assignments
- [ ] Run `pnpm test:unit` and `pnpm test:typecheck`