### PR TITLE
fix: publisher form fixes and gender-aware field visibility

### DIFF
--- a/app/features/publishers/routes/publishers/edit-group.tsx
+++ b/app/features/publishers/routes/publishers/edit-group.tsx
@@ -38,6 +38,7 @@ export function loader({ params, context }: Route.LoaderArgs) {
     const brothers = await db.user.findMany({
       where: {
         congregationId: currentUser.congregationId,
+        isMale: true,
         // biome-ignore lint/style/useNamingConvention: Prisma OR operator
         OR: [{ isHelder: true }, { isServant: true }],
       },

--- a/app/features/publishers/routes/publishers/edit-publisher.tsx
+++ b/app/features/publishers/routes/publishers/edit-publisher.tsx
@@ -1,5 +1,6 @@
 import { parseWithZod } from '@conform-to/zod'
 import { Archive, IdCard } from 'lucide-react'
+import { useState } from 'react'
 import { data, Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { updatePublisherSchema } from '~/features/publishers/schemas/edit-publisher.schema'
@@ -67,6 +68,7 @@ export function loader({ params, context }: Route.LoaderArgs) {
 export default function EditPublisher({ loaderData }: Route.ComponentProps) {
   const { user, groups, hideAuxiliaryPioneer } = loaderData
   const { blocker, markDirty } = useUnsavedChanges()
+  const [gender, setGender] = useState<'male' | 'female' | null>(user.isMale ? 'male' : 'female')
 
   return (
     <div className="flex flex-col gap-6">
@@ -94,8 +96,8 @@ export default function EditPublisher({ loaderData }: Route.ComponentProps) {
       />
 
       <Form method="post" className="flex flex-col gap-6" onChange={markDirty}>
-        <PublisherPersonalInformationForm user={user} />
-        <PublisherNominationForm user={user} />
+        <PublisherPersonalInformationForm user={user} onGenderChange={setGender} />
+        <PublisherNominationForm user={user} gender={gender} />
         <PublisherFieldServiceForm user={user} groups={groups} hideAuxiliaryPioneer={hideAuxiliaryPioneer} />
 
         <SubmitButton size="lg" className="self-start">

--- a/app/features/publishers/routes/publishers/new-group.tsx
+++ b/app/features/publishers/routes/publishers/new-group.tsx
@@ -35,6 +35,7 @@ export function loader({ context }: Route.LoaderArgs) {
     const brothers = await db.user.findMany({
       where: {
         congregationId: currentUser.congregationId,
+        isMale: true,
         // biome-ignore lint/style/useNamingConvention: Prisma OR operator
         OR: [{ isHelder: true }, { isServant: true }],
         responsibleFor: {

--- a/app/features/publishers/routes/publishers/new-publisher.tsx
+++ b/app/features/publishers/routes/publishers/new-publisher.tsx
@@ -1,4 +1,5 @@
 import { parseWithZod } from '@conform-to/zod'
+import { useState } from 'react'
 import { data, Form, redirect } from 'react-router'
 import { commitSession, getSession } from '~/features/authentication/server/session.server'
 import { createPublisherSchema } from '~/features/publishers/schemas/publisher.schema'
@@ -13,7 +14,9 @@ import {
   userContext,
   withScopeFromContext,
 } from '~/shared/auth/route-context.server'
+import { getBoolSetting } from '~/shared/domain/settings.server'
 import { useUnsavedChanges } from '~/shared/hooks/use-unsaved-changes'
+import { CongregationSettingKey } from '~/shared/types/congregation-setting-key'
 import { Role } from '~/shared/types/role'
 import { PageHeader } from '~/shared/ui/PageHeader'
 import { SubmitButton } from '~/shared/ui/SubmitButton'
@@ -37,14 +40,20 @@ export function loader({ context }: Route.LoaderArgs) {
 
   return withScopeFromContext(context, async db => {
     const groups = await db.publisherGroup.findMany({ where: { congregationId: currentUser.congregationId } })
+    const showAuxiliaryPioneer = await getBoolSetting(
+      db,
+      CongregationSettingKey.AuxiliaryPioneerProfileActivated,
+      currentUser.congregationId,
+    )
 
-    return { groups, hideAuxiliaryPioneer: false }
+    return { groups, hideAuxiliaryPioneer: !showAuxiliaryPioneer }
   })
 }
 
 export default function NewPublisher({ loaderData }: Route.ComponentProps) {
   const { groups, hideAuxiliaryPioneer } = loaderData
   const { blocker, markDirty } = useUnsavedChanges()
+  const [gender, setGender] = useState<'male' | 'female' | null>(null)
 
   return (
     <div className="flex flex-col gap-6">
@@ -57,8 +66,8 @@ export default function NewPublisher({ loaderData }: Route.ComponentProps) {
       />
 
       <Form method="post" className="flex flex-col gap-6" onChange={markDirty}>
-        <PublisherPersonalInformationForm />
-        <PublisherNominationForm />
+        <PublisherPersonalInformationForm onGenderChange={setGender} />
+        <PublisherNominationForm gender={gender} />
         <PublisherFieldServiceForm groups={groups} hideAuxiliaryPioneer={hideAuxiliaryPioneer} />
 
         <SubmitButton size="lg" className="self-start">
@@ -78,7 +87,7 @@ export async function action({ request, context }: Route.ActionArgs) {
     return data(submission.reply(), { status: 400 })
   }
 
-  const { firstname, lastname, email, gender, birthDate, baptismDate, isHelder, isServant, isAnointed, group, type } =
+  const { firstname, lastname, email, gender, birthDate, baptismDate, isHelder, isServant, isAnointed, group, type, phone, address } =
     submission.value
 
   return withScopeFromContext(context, async db => {
@@ -97,6 +106,8 @@ export async function action({ request, context }: Route.ActionArgs) {
         groupId: group ?? 0,
         type,
         congregationId: currentUser.congregationId,
+        phone: phone ?? '',
+        address: address ?? '',
       })
 
       session.flash('success', m.publishers_new_success({ name: user.firstname ?? '' }))

--- a/app/features/publishers/schemas/publisher.schema.ts
+++ b/app/features/publishers/schemas/publisher.schema.ts
@@ -21,6 +21,8 @@ export const createPublisherSchema = z.object({
     .transform(v => v === 'on'),
   group: z.coerce.number().optional(),
   type: z.string(),
+  phone: z.string().optional().default(''),
+  address: z.string().optional().default(''),
 })
 
 export type CreatePublisherInput = z.infer<typeof createPublisherSchema>

--- a/app/features/publishers/server/create-publisher.server.test.ts
+++ b/app/features/publishers/server/create-publisher.server.test.ts
@@ -65,6 +65,20 @@ describe('createPublisher', () => {
     expect(call.data.email).toBe('jean.dupont@placeholder.unitae.app')
   })
 
+  it('saves phone and address to the database', async () => {
+    mockDb.user.create.mockResolvedValue({ id: 3 } as never)
+
+    await createPublisher(mockDb as any, baseCongregation, {
+      ...baseParams,
+      phone: '0612345678',
+      address: '5 rue de la Paix',
+    })
+
+    const call = mockDb.user.create.mock.calls[0][0]
+    expect(call.data.phone).toBe('0612345678')
+    expect(call.data.address).toBe('5 rue de la Paix')
+  })
+
   it('throws LimitError when publisher limit reached', async () => {
     mockErrorIfWouldGoOverLimit.mockRejectedValue(new Error('Limit reached'))
 

--- a/app/features/publishers/server/create-publisher.server.test.ts
+++ b/app/features/publishers/server/create-publisher.server.test.ts
@@ -40,6 +40,8 @@ const baseParams = {
   groupId: null,
   type: 'publisher',
   congregationId: 1,
+  phone: '',
+  address: '',
 }
 
 describe('createPublisher', () => {

--- a/app/features/publishers/server/create-publisher.server.ts
+++ b/app/features/publishers/server/create-publisher.server.ts
@@ -15,6 +15,8 @@ export interface CreatePublisherParams {
   groupId: number | null
   type: string
   congregationId: number
+  phone: string
+  address: string
 }
 
 export async function createPublisher(
@@ -48,6 +50,8 @@ export async function createPublisher(
       publisherGroupId: Number.isNaN(params.groupId) ? null : params.groupId,
       type: params.type,
       congregationId: params.congregationId,
+      phone: params.phone,
+      address: params.address,
     },
   })
 }

--- a/app/features/publishers/ui/PublisherNominationForm.tsx
+++ b/app/features/publishers/ui/PublisherNominationForm.tsx
@@ -3,7 +3,9 @@ import type { UserInput } from '~/shared/types/user-input'
 import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Label } from '~/shared/ui/label'
 
-export default function PublisherNominationForm({ user }: { user?: UserInput }) {
+export default function PublisherNominationForm({ user, gender }: { user?: UserInput; gender?: 'male' | 'female' | null }) {
+  if (gender !== 'male') return null
+
   return (
     <Card>
       <CardHeader>

--- a/app/features/publishers/ui/PublisherPersonalInformationForm.tsx
+++ b/app/features/publishers/ui/PublisherPersonalInformationForm.tsx
@@ -4,7 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/shared/ui/card'
 import { Input } from '~/shared/ui/input'
 import { Label } from '~/shared/ui/label'
 
-export default function PublisherPersonalInformationForm({ user }: { user?: UserInput }) {
+export default function PublisherPersonalInformationForm({
+  user,
+  onGenderChange,
+}: {
+  user?: UserInput
+  onGenderChange?: (gender: 'male' | 'female') => void
+}) {
   return (
     <Card>
       <CardHeader>
@@ -67,6 +73,7 @@ export default function PublisherPersonalInformationForm({ user }: { user?: User
                   value="male"
                   required
                   defaultChecked={user?.isMale === true}
+                  onChange={() => onGenderChange?.('male')}
                 />
                 {m.publishers_form_gender_male()}
               </label>
@@ -78,6 +85,7 @@ export default function PublisherPersonalInformationForm({ user }: { user?: User
                   value="female"
                   required
                   defaultChecked={user?.isMale === false}
+                  onChange={() => onGenderChange?.('female')}
                 />
                 {m.publishers_form_gender_female()}
               </label>


### PR DESCRIPTION
## Summary

- Fix `phone` and `address` being silently dropped on new publisher submit — added fields to create schema, `CreatePublisherParams`, and `db.user.create`
- Fix `hideAuxiliaryPioneer` hardcoded to `false` in `/publishers/new` loader — now reads the congregation setting like the edit page does
- Hide the nomination card (elder/servant checkboxes) when gender is female or not yet selected — gender state lifted to page components and passed to `PublisherNominationForm`
- Exclude female publishers from group responsible/deputy selectors by adding `isMale: true` to the brothers query in `new-group` and `edit-group` loaders

## Test plan

- [ ] Create a male publisher → nomination card visible, `phone`/`address` saved
- [ ] Create a female publisher → nomination card hidden, `phone`/`address` saved
- [ ] Switch gender radio on new publisher form → nomination card appears/disappears reactively
- [ ] Edit a female publisher → nomination card hidden on load; edit a male publisher → card visible, switching to female hides it
- [ ] Verify `/publishers/new` respects the auxiliary pioneer congregation setting
- [ ] Verify female publishers do not appear in the responsible/deputy dropdowns on group forms
- [ ] `pnpm test:unit` passes (666 tests)