### PR TITLE
chore: improve CI workflows, dependabot, and PR template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,32 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     cooldown:
       default-days: 5
+    groups:
+      patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     cooldown:
       default-days: 8

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,12 +12,7 @@
 
 ## Checklist
 
-- [ ] Mon code respecte le style du projet (`pnpm build:format`)
-- [ ] Les types TypeScript sont valides (`pnpm test:typecheck`)
-- [ ] Le linting passe (`pnpm test:lint`)
-- [ ] Les tests unitaires passent (`pnpm test:unit`)
-- [ ] Les tests d'intégration passent (`pnpm test:integration`)
-- [ ] Le build de production réussit (`pnpm build`)
+- [ ] J'ai formaté mon code avant de pousser (`pnpm build:format`)
 - [ ] J'ai mis à jour la documentation si nécessaire
 
 ## Issue liée

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@
 - [ ] Mon code respecte le style du projet (`pnpm build:format`)
 - [ ] Les types TypeScript sont valides (`pnpm test:typecheck`)
 - [ ] Le linting passe (`pnpm test:lint`)
+- [ ] Les tests unitaires passent (`pnpm test:unit`)
+- [ ] Les tests d'intégration passent (`pnpm test:integration`)
 - [ ] Le build de production réussit (`pnpm build`)
 - [ ] J'ai mis à jour la documentation si nécessaire
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -34,11 +34,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
+      - name: Extract Docker metadata (runtime)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Extract Docker metadata (worker)
+        id: meta-worker
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/unitae/unitae/worker
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Extract Docker metadata (migrate)
+        id: meta-migrate
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/unitae/unitae/migrate
           tags: |
             type=sha,prefix=
             type=ref,event=branch
@@ -65,7 +87,8 @@ jobs:
           file: docker/Dockerfile
           target: worker
           push: true
-          tags: ghcr.io/unitae/unitae/worker:latest
+          tags: ${{ steps.meta-worker.outputs.tags }}
+          labels: ${{ steps.meta-worker.outputs.labels }}
           cache-from: type=gha
 
       - name: Build and push migrate image
@@ -75,7 +98,8 @@ jobs:
           file: docker/Dockerfile
           target: migrate
           push: true
-          tags: ghcr.io/unitae/unitae/migrate:latest
+          tags: ${{ steps.meta-migrate.outputs.tags }}
+          labels: ${{ steps.meta-migrate.outputs.labels }}
           cache-from: type=gha
 
       - name: Sign the published Docker image

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -46,6 +48,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -71,6 +75,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -126,6 +132,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -163,6 +171,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -226,6 +236,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Apply database migrations
         run: pnpm prisma migrate deploy
 
+      - name: Seed database
+        run: pnpm prisma db seed
+
       - name: Run integration tests
         run: pnpm test:integration
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -48,8 +46,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -75,8 +71,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -132,8 +126,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -171,8 +163,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -236,8 +226,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.26.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -67,13 +67,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -122,13 +122,13 @@ jobs:
       REDIS_PORT: "6379"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -159,13 +159,13 @@ jobs:
     needs: [lint, typecheck, test, integration]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -180,7 +180,7 @@ jobs:
         run: pnpm build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: build/
@@ -222,13 +222,13 @@ jobs:
       REDIS_PORT: "6379"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -237,7 +237,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -266,7 +266,7 @@ jobs:
         run: pnpm prisma db seed
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: build/
@@ -279,7 +279,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -162,7 +162,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -225,7 +225,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check cross-feature import boundaries
         run: pnpm test:boundaries
 
+      - name: Security audit
+        run: pnpm audit --audit-level=high
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
@@ -84,10 +87,73 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: unitae
+          POSTGRES_PASSWORD: unitae
+          POSTGRES_DB: unitae_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U unitae -d unitae_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_URL: postgresql://unitae:unitae@localhost:5432/unitae_test
+      DB_RUNTIME_URL: postgresql://unitae_app:unitae_app@localhost:5432/unitae_test
+      UNITAE_SESSION_SECRET: ci-test-secret-at-least-32-characters-long
+      RESEND_API_KEY: re_test
+      REDIS_HOST: localhost
+      REDIS_PORT: "6379"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma generate
+
+      - name: Create non-superuser app role for RLS
+        run: |
+          psql "$DB_URL" -c "CREATE ROLE unitae_app LOGIN PASSWORD 'unitae_app' NOSUPERUSER;"
+          psql "$DB_URL" -c "GRANT unitae_app TO unitae;"
+
+      - name: Apply database migrations
+        run: pnpm prisma migrate deploy
+
+      - name: Run integration tests
+        run: pnpm test:integration
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, integration]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,6 +175,13 @@ jobs:
 
       - name: Build application
         run: pnpm build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: build/
+          retention-days: 1
 
   e2e:
     name: E2E Tests
@@ -160,11 +233,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Generate Prisma client and Paraglide messages
-        run: pnpm prisma generate && pnpm react-router typegen
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Generate Prisma client
+        run: pnpm prisma generate
 
       - name: Create non-superuser app role for RLS
         run: |
@@ -177,8 +262,11 @@ jobs:
       - name: Seed database
         run: pnpm prisma db seed
 
-      - name: Build application
-        run: pnpm build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: build/
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -251,8 +251,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
 
-      - name: Generate Prisma client
-        run: pnpm prisma generate
+      - name: Generate Prisma client and i18n messages
+        run: pnpm prisma generate && pnpm react-router typegen
 
       - name: Create non-superuser app role for RLS
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Prisma client
-        run: pnpm prisma generate
+      - name: Generate Prisma client and i18n messages
+        run: pnpm prisma generate && pnpm react-router typegen
 
       - name: Create non-superuser app role for RLS
         run: |

--- a/app/features/dashboard/server/dashboard.integration.test.ts
+++ b/app/features/dashboard/server/dashboard.integration.test.ts
@@ -5,7 +5,7 @@ import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { PublisherType } from '~/shared/types/publisher-type'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/app/features/display-board/server/dynamic-documents.integration.test.ts
+++ b/app/features/display-board/server/dynamic-documents.integration.test.ts
@@ -4,7 +4,7 @@ import { PrismaClient } from '~/database/generated/client'
 import { PublisherType } from '~/shared/types/publisher-type'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/app/features/publishers/server/publishers.integration.test.ts
+++ b/app/features/publishers/server/publishers.integration.test.ts
@@ -6,7 +6,7 @@ import { createTestCongregation, createTestUser } from '~/tests/factories'
 import { getPublisherById } from './publishers.server'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/app/features/settings/server/data-transfer.integration.test.ts
+++ b/app/features/settings/server/data-transfer.integration.test.ts
@@ -10,7 +10,7 @@ import { EntityIdMap, type ManifestJson } from './data-transfer.type'
 // --- Test DB setup (same pattern as db.server.integration.test.ts) ---
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/app/shared/domain/limits.integration.test.ts
+++ b/app/shared/domain/limits.integration.test.ts
@@ -5,7 +5,7 @@ import { createTestCongregation, createTestUser } from '~/tests/factories'
 import { LimitService } from './limits.server'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/app/shared/infra/db.server.integration.test.ts
+++ b/app/shared/infra/db.server.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { PrismaClient } from '~/database/generated/client'
 
 const adapter = new PrismaPg({
-  connectionString: process.env.DB_URL,
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
   max: 5,
   connectionTimeoutMillis: 5000,
 })

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
             "@prisma/engines",
             "better-sqlite3",
             "esbuild",
+            "msgpackr-extract",
+            "msw",
             "prisma"
         ]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+onlyBuiltDependencies:
+  - '@prisma/engines'
+  - better-sqlite3
+  - esbuild
+  - msgpackr-extract
+  - msw
+  - prisma
+
 importers:
 
   .:


### PR DESCRIPTION
## Summary

- **CI: integration tests added** — `pnpm test:integration` now runs as a parallel gate on every PR, catching RLS/service-layer regressions before merge
- **CI: eliminated double build** — `build` job uploads its artifact; `e2e` downloads it instead of rebuilding from scratch (~2–3 min saved per PR)
- **CI: Playwright browser cache** — browsers cached by `pnpm-lock.yaml` hash, avoiding a ~300MB re-download on every run
- **CI: security audit** — `pnpm audit --audit-level=high` added to the `lint` job
- **CD: versioned Docker tags for worker/migrate** — worker and migrate images now get sha/branch/semver tags in addition to `latest`, enabling rollback
- **Dependabot: github-actions ecosystem** — action versions are now auto-updated weekly (supply chain hygiene)
- **Dependabot: weekly schedule + grouping** — switched from daily to weekly for all ecosystems; patch/minor npm updates batched into one PR
- **PR template: trimmed checklist** — removed items already enforced by CI; kept only human-judgment checks (format reminder, documentation)

## Test plan

- [ ] Open a test PR and confirm 5 parallel jobs appear: `lint`, `typecheck`, `unit-tests`, `integration`, `build` (waiting on all four)
- [ ] Confirm `build` job uploads a `build-output` artifact visible in the Actions run summary
- [ ] Confirm `e2e` job has no `pnpm build` step in its logs
- [ ] Confirm Playwright cache hit on a second PR run
- [ ] Confirm CD produces sha/branch/semver tags for worker and migrate images in GHCR after a merge to main