### PR TITLE
fix: visual issues — padding, nav link, sidebar cleanup

### DIFF
--- a/app/features/dashboard/routes/index.tsx
+++ b/app/features/dashboard/routes/index.tsx
@@ -1,5 +1,15 @@
-import { AlertTriangle, CalendarOff, CalendarPlus, ChevronRight, FileText, Info, MapPin, Mic, Plus } from 'lucide-react'
-import { Link } from 'react-router'
+import {
+  AlertTriangle,
+  CalendarOff,
+  CalendarPlus,
+  ChevronRight,
+  FileText,
+  Info,
+  MapPin,
+  Mic,
+  Plus,
+} from "lucide-react";
+import { Link } from "react-router";
 
 import {
   getNextMeeting,
@@ -8,64 +18,107 @@ import {
   getUpcomingAbsences,
   getUserTerritories,
   type TerritoryStatus,
-} from '~/features/dashboard/server/dashboard.server'
-import { buildUrgentItems } from '~/features/dashboard/ui/build-urgent-items'
-import { OnboardingChecklist } from '~/features/dashboard/ui/OnboardingChecklist'
-import * as m from '~/paraglide/messages'
-import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
-import logger from '~/shared/infra/logger.server'
-import { Role } from '~/shared/types/role'
-import { Alert, AlertDescription } from '~/shared/ui/alert'
-import { Badge } from '~/shared/ui/badge'
-import { Button } from '~/shared/ui/button'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '~/shared/ui/card'
-import { EmptyState } from '~/shared/ui/EmptyState'
-import { RelativeTime } from '~/shared/ui/RelativeTime'
+} from "~/features/dashboard/server/dashboard.server";
+import { buildUrgentItems } from "~/features/dashboard/ui/build-urgent-items";
+import { OnboardingChecklist } from "~/features/dashboard/ui/OnboardingChecklist";
+import * as m from "~/paraglide/messages";
+import {
+  permissionsContext,
+  userContext,
+  withScopeFromContext,
+} from "~/shared/auth/route-context.server";
+import logger from "~/shared/infra/logger.server";
+import { Role } from "~/shared/types/role";
+import { Alert, AlertDescription } from "~/shared/ui/alert";
+import { Badge } from "~/shared/ui/badge";
+import { Button } from "~/shared/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/shared/ui/card";
+import { EmptyState } from "~/shared/ui/EmptyState";
+import { RelativeTime } from "~/shared/ui/RelativeTime";
 
-import type { Route } from './+types/index'
+import type { Route } from "./+types/index";
 
 export const meta: Route.MetaFunction = () => {
-  return [{ title: 'Accueil - Unitae' }]
-}
+  return [{ title: "Accueil - Unitae" }];
+};
 
-async function safeQuery<T>(label: string, userId: number, fn: () => Promise<T>): Promise<T | null> {
+async function safeQuery<T>(
+  label: string,
+  userId: number,
+  fn: () => Promise<T>,
+): Promise<T | null> {
   try {
-    return await fn()
+    return await fn();
   } catch (error) {
-    logger.error(`Dashboard widget "${label}" failed for user ${userId}`, error)
-    return null
+    logger.error(
+      `Dashboard widget "${label}" failed for user ${userId}`,
+      error,
+    );
+    return null;
   }
 }
 
 export function loader({ context }: Route.LoaderArgs) {
-  const currentUser = context.get(userContext)
-  const permissions = context.get(permissionsContext)
-  const isAdmin = permissions.has(Role.Admin)
-  const isTerritoriesManager = permissions.has(Role.TerritoriesManager)
+  const currentUser = context.get(userContext);
+  const permissions = context.get(permissionsContext);
+  const isAdmin = permissions.has(Role.Admin);
+  const isTerritoriesManager = permissions.has(Role.TerritoriesManager);
 
-  return withScopeFromContext(context, async db => {
-    const [territories, recentDocuments, unreadDocumentCount, absences, nextMeeting] = await Promise.all([
-      safeQuery('territories', currentUser.id, () => getUserTerritories(db, currentUser.id)),
-      safeQuery('documents', currentUser.id, () => getRecentDocuments(db, currentUser.id, currentUser.congregationId)),
-      safeQuery('unread-count', currentUser.id, () =>
+  return withScopeFromContext(context, async (db) => {
+    const [
+      territories,
+      recentDocuments,
+      unreadDocumentCount,
+      absences,
+      nextMeeting,
+    ] = await Promise.all([
+      safeQuery("territories", currentUser.id, () =>
+        getUserTerritories(db, currentUser.id),
+      ),
+      safeQuery("documents", currentUser.id, () =>
+        getRecentDocuments(db, currentUser.id, currentUser.congregationId),
+      ),
+      safeQuery("unread-count", currentUser.id, () =>
         getUnreadDocumentCount(db, currentUser.id, currentUser.congregationId),
       ),
-      safeQuery('absences', currentUser.id, () => getUpcomingAbsences(db, currentUser.id, currentUser.congregationId)),
-      safeQuery('next-meeting', currentUser.id, () => getNextMeeting(db, currentUser.id)),
-    ])
+      safeQuery("absences", currentUser.id, () =>
+        getUpcomingAbsences(db, currentUser.id, currentUser.congregationId),
+      ),
+      safeQuery("next-meeting", currentUser.id, () =>
+        getNextMeeting(db, currentUser.id),
+      ),
+    ]);
 
     // Onboarding: count entities for admin checklist
-    let onboarding = null
+    let onboarding = null;
     if (isAdmin) {
-      const [publisherCount, territoryCount, documentCount] = await Promise.all([
-        safeQuery('onboarding-publishers', currentUser.id, () => db.user.count({ where: { isPublisher: true } })),
-        safeQuery('onboarding-territories', currentUser.id, () => db.territory.count()),
-        safeQuery('onboarding-documents', currentUser.id, () => db.boardDocument.count()),
-      ])
+      const [publisherCount, territoryCount, documentCount] = await Promise.all(
+        [
+          safeQuery("onboarding-publishers", currentUser.id, () =>
+            db.user.count({ where: { isPublisher: true } }),
+          ),
+          safeQuery("onboarding-territories", currentUser.id, () =>
+            db.territory.count(),
+          ),
+          safeQuery("onboarding-documents", currentUser.id, () =>
+            db.boardDocument.count(),
+          ),
+        ],
+      );
       // Only show onboarding if all counts loaded successfully — avoid showing
       // misleading "incomplete setup" when the database query failed
-      if (publisherCount != null && territoryCount != null && documentCount != null) {
-        onboarding = { publisherCount, territoryCount, documentCount }
+      if (
+        publisherCount != null &&
+        territoryCount != null &&
+        documentCount != null
+      ) {
+        onboarding = { publisherCount, territoryCount, documentCount };
       }
     }
 
@@ -79,28 +132,31 @@ export function loader({ context }: Route.LoaderArgs) {
       onboarding,
       isAdmin,
       isTerritoriesManager,
-    }
-  })
+    };
+  });
 }
 
-const statusVariant: Record<TerritoryStatus, 'success' | 'warning' | 'destructive'> = {
-  'on-time': 'success',
-  'due-soon': 'warning',
-  overdue: 'destructive',
-}
+const statusVariant: Record<
+  TerritoryStatus,
+  "success" | "warning" | "destructive"
+> = {
+  "on-time": "success",
+  "due-soon": "warning",
+  overdue: "destructive",
+};
 
 function statusLabel(status: TerritoryStatus): string {
-  if (status === 'on-time') return m.dashboard_territory_on_time()
-  if (status === 'due-soon') return m.dashboard_territory_due_soon()
-  return m.dashboard_territory_overdue()
+  if (status === "on-time") return m.dashboard_territory_on_time();
+  if (status === "due-soon") return m.dashboard_territory_due_soon();
+  return m.dashboard_territory_overdue();
 }
 
 function formatDateShort(date: Date | string): string {
-  return new Date(date).toLocaleDateString('fr-FR', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  })
+  return new Date(date).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 }
 
 export default function Dashboard({ loaderData }: Route.ComponentProps) {
@@ -114,17 +170,22 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
     onboarding,
     isAdmin,
     isTerritoriesManager,
-  } = loaderData
+  } = loaderData;
 
-  const today = new Date().toLocaleDateString('fr-FR', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  })
+  const today = new Date().toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
 
   // Build urgent items from across features
-  const urgentItems = buildUrgentItems(territories, unreadDocumentCount, nextMeeting, absences?.upcoming ?? null)
+  const urgentItems = buildUrgentItems(
+    territories,
+    unreadDocumentCount,
+    nextMeeting,
+    absences?.upcoming ?? null,
+  );
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-8">
@@ -135,7 +196,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
             {m.dashboard_greeting_hello()}
           </p>
           <h1 className="font-display font-semibold text-4xl tracking-tight md:text-5xl">
-            {currentUser.firstname ?? ''}
+            {currentUser.firstname ?? ""}
           </h1>
           <p className="mt-2 text-muted-foreground">{today}</p>
         </div>
@@ -148,7 +209,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
           </Button>
           {(isAdmin || isTerritoriesManager) && (
             <Button variant="outline" size="sm" asChild>
-              <Link to="/territories">
+              <Link to="/territories/attributions/new/available-territories">
                 <MapPin className="size-4" />
                 {m.dashboard_quick_action_assign_territory()}
               </Link>
@@ -168,8 +229,11 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
 
       {/* Urgent strip */}
       {urgentItems.length > 0 && (
-        <div className="flex animate-fade-in-up flex-col gap-2" style={{ animationDelay: '100ms' }}>
-          {urgentItems.map(item => (
+        <div
+          className="flex animate-fade-in-up flex-col gap-2"
+          style={{ animationDelay: "100ms" }}
+        >
+          {urgentItems.map((item) => (
             <Link
               key={item.key}
               to={item.to}
@@ -188,21 +252,24 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
 
       {/* Widget grid */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="animate-fade-in-up" style={{ animationDelay: '150ms' }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: "150ms" }}>
           <TerritoriesCard territories={territories} />
         </div>
-        <div className="animate-fade-in-up" style={{ animationDelay: '200ms' }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: "200ms" }}>
           <NextMeetingCard meeting={nextMeeting} />
         </div>
-        <div className="animate-fade-in-up" style={{ animationDelay: '250ms' }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: "250ms" }}>
           <DocumentsCard documents={recentDocuments} />
         </div>
-        <div className="animate-fade-in-up" style={{ animationDelay: '300ms' }}>
-          <AbsencesCard absences={absences?.upcoming ?? null} shouldNudge={absences?.shouldNudge ?? false} />
+        <div className="animate-fade-in-up" style={{ animationDelay: "300ms" }}>
+          <AbsencesCard
+            absences={absences?.upcoming ?? null}
+            shouldNudge={absences?.shouldNudge ?? false}
+          />
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 // --- Widget components ---
@@ -213,10 +280,14 @@ function WidgetError() {
       <AlertTriangle className="size-4 shrink-0" />
       <span className="text-sm">{m.dashboard_widget_error()}</span>
     </div>
-  )
+  );
 }
 
-function TerritoriesCard({ territories }: { territories: Awaited<ReturnType<typeof getUserTerritories>> | null }) {
+function TerritoriesCard({
+  territories,
+}: {
+  territories: Awaited<ReturnType<typeof getUserTerritories>> | null;
+}) {
   return (
     <Card className="h-full">
       <CardHeader>
@@ -233,14 +304,16 @@ function TerritoriesCard({ territories }: { territories: Awaited<ReturnType<type
           />
         ) : (
           <div className="flex flex-col gap-1.5">
-            {territories.map(t => (
+            {territories.map((t) => (
               <Link
                 key={t.id}
                 to={`/me/territories/${t.territory.id}`}
                 className="flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-muted/50"
               >
                 <div className="flex items-center gap-2">
-                  <span className="font-medium text-sm">{t.territory.number}</span>
+                  <span className="font-medium text-sm">
+                    {t.territory.number}
+                  </span>
                   <span className="text-muted-foreground text-xs">
                     <RelativeTime date={t.lateDate} />
                   </span>
@@ -259,10 +332,14 @@ function TerritoriesCard({ territories }: { territories: Awaited<ReturnType<type
         </Button>
       </CardFooter>
     </Card>
-  )
+  );
 }
 
-function NextMeetingCard({ meeting }: { meeting: Awaited<ReturnType<typeof getNextMeeting>> | null }) {
+function NextMeetingCard({
+  meeting,
+}: {
+  meeting: Awaited<ReturnType<typeof getNextMeeting>> | null;
+}) {
   if (meeting === null) {
     return (
       <Card className="h-full">
@@ -273,16 +350,17 @@ function NextMeetingCard({ meeting }: { meeting: Awaited<ReturnType<typeof getNe
           <EmptyState icon={Mic} title={m.dashboard_next_meeting_no_event()} />
         </CardContent>
       </Card>
-    )
+    );
   }
 
-  const meetingDate = new Date(meeting.startDate).toLocaleDateString('fr-FR', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-  })
+  const meetingDate = new Date(meeting.startDate).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
 
-  const hasUserAssignments = meeting.userPartIds.length > 0 || meeting.userServiceRoleIds.length > 0
+  const hasUserAssignments =
+    meeting.userPartIds.length > 0 || meeting.userServiceRoleIds.length > 0;
 
   return (
     <Card className="h-full">
@@ -296,34 +374,48 @@ function NextMeetingCard({ meeting }: { meeting: Awaited<ReturnType<typeof getNe
       </CardHeader>
       <CardContent>
         {!hasUserAssignments ? (
-          <p className="text-muted-foreground text-sm">{m.dashboard_next_meeting_no_assignments()}</p>
+          <p className="text-muted-foreground text-sm">
+            {m.dashboard_next_meeting_no_assignments()}
+          </p>
         ) : (
           <div className="flex flex-col gap-1.5">
             {meeting.partAssignments
-              .filter(p => meeting.userPartIds.includes(p.id))
-              .map(part => {
+              .filter((p) => meeting.userPartIds.includes(p.id))
+              .map((part) => {
                 const isAssignee =
-                  part.assignee && meeting.userPartIds.includes(part.id) && part.assignee.id !== part.assistant?.id
+                  part.assignee &&
+                  meeting.userPartIds.includes(part.id) &&
+                  part.assignee.id !== part.assistant?.id;
                 const roleLabel = isAssignee
                   ? m.dashboard_next_meeting_assigned_as_speaker()
-                  : m.dashboard_next_meeting_assigned_as_assistant()
+                  : m.dashboard_next_meeting_assigned_as_assistant();
 
                 return (
-                  <div key={part.id} className="rounded-lg bg-primary/5 px-3 py-2">
+                  <div
+                    key={part.id}
+                    className="rounded-lg bg-primary/5 px-3 py-2"
+                  >
                     <div className="flex items-center justify-between gap-2">
                       <span className="font-medium text-sm">{part.name}</span>
                       <Badge variant="outline" className="text-xs">
                         {roleLabel}
                       </Badge>
                     </div>
-                    {part.topic && <p className="mt-0.5 text-muted-foreground text-xs">{part.topic}</p>}
+                    {part.topic && (
+                      <p className="mt-0.5 text-muted-foreground text-xs">
+                        {part.topic}
+                      </p>
+                    )}
                   </div>
-                )
+                );
               })}
             {meeting.serviceRoleAssignments
-              .filter(r => meeting.userServiceRoleIds.includes(r.id))
-              .map(role => (
-                <div key={role.id} className="flex items-center justify-between rounded-lg bg-primary/5 px-3 py-2">
+              .filter((r) => meeting.userServiceRoleIds.includes(r.id))
+              .map((role) => (
+                <div
+                  key={role.id}
+                  className="flex items-center justify-between rounded-lg bg-primary/5 px-3 py-2"
+                >
                   <span className="font-medium text-sm">{role.name}</span>
                   <Badge variant="outline" className="text-xs">
                     {m.dashboard_next_meeting_assigned_as_service()}
@@ -334,10 +426,14 @@ function NextMeetingCard({ meeting }: { meeting: Awaited<ReturnType<typeof getNe
         )}
       </CardContent>
     </Card>
-  )
+  );
 }
 
-function DocumentsCard({ documents }: { documents: Awaited<ReturnType<typeof getRecentDocuments>> | null }) {
+function DocumentsCard({
+  documents,
+}: {
+  documents: Awaited<ReturnType<typeof getRecentDocuments>> | null;
+}) {
   return (
     <Card className="h-full">
       <CardHeader>
@@ -350,16 +446,24 @@ function DocumentsCard({ documents }: { documents: Awaited<ReturnType<typeof get
           <EmptyState icon={FileText} title={m.dashboard_no_documents()} />
         ) : (
           <div className="flex flex-col gap-1">
-            {documents.map(doc => (
+            {documents.map((doc) => (
               <Link
                 key={`${doc.kind}-${doc.id}`}
-                to={doc.kind === 'pdf' ? `/board/documents/${doc.id}/viewer` : `/board/dynamic/${doc.id}/viewer`}
+                to={
+                  doc.kind === "pdf"
+                    ? `/board/documents/${doc.id}/viewer`
+                    : `/board/dynamic/${doc.id}/viewer`
+                }
                 className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-muted/50"
               >
-                {!doc.alreadyViewed && <span className="size-2 shrink-0 rounded-full bg-primary" />}
+                {!doc.alreadyViewed && (
+                  <span className="size-2 shrink-0 rounded-full bg-primary" />
+                )}
                 {doc.alreadyViewed && <span className="size-2 shrink-0" />}
                 <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
-                  <span className={`truncate text-sm ${doc.alreadyViewed ? 'text-muted-foreground' : 'font-medium'}`}>
+                  <span
+                    className={`truncate text-sm ${doc.alreadyViewed ? "text-muted-foreground" : "font-medium"}`}
+                  >
                     {doc.title}
                   </span>
                   <span className="shrink-0 text-muted-foreground text-xs">
@@ -377,15 +481,15 @@ function DocumentsCard({ documents }: { documents: Awaited<ReturnType<typeof get
         </Button>
       </CardFooter>
     </Card>
-  )
+  );
 }
 
 function AbsencesCard({
   absences,
   shouldNudge,
 }: {
-  absences: Awaited<ReturnType<typeof getUpcomingAbsences>>['upcoming'] | null
-  shouldNudge: boolean
+  absences: Awaited<ReturnType<typeof getUpcomingAbsences>>["upcoming"] | null;
+  shouldNudge: boolean;
 }) {
   return (
     <Card className="h-full">
@@ -395,7 +499,9 @@ function AbsencesCard({
           <Button variant="ghost" size="icon-xs" asChild>
             <Link to="/me/days-off/new">
               <Plus className="size-4" />
-              <span className="sr-only">{m.dashboard_quick_action_plan_absence()}</span>
+              <span className="sr-only">
+                {m.dashboard_quick_action_plan_absence()}
+              </span>
             </Link>
           </Button>
         </div>
@@ -408,7 +514,9 @@ function AbsencesCard({
             {shouldNudge && (
               <Alert className="mb-3 border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-400">
                 <Info className="size-4" />
-                <AlertDescription>{m.dashboard_absence_nudge()}</AlertDescription>
+                <AlertDescription>
+                  {m.dashboard_absence_nudge()}
+                </AlertDescription>
               </Alert>
             )}
             {absences.length === 0
@@ -418,12 +526,14 @@ function AbsencesCard({
                     title={m.dashboard_no_absences()}
                     action={
                       <Button variant="outline" size="sm" asChild>
-                        <Link to="/me/days-off/new">{m.dashboard_plan_absence()}</Link>
+                        <Link to="/me/days-off/new">
+                          {m.dashboard_plan_absence()}
+                        </Link>
                       </Button>
                     }
                   />
                 )
-              : absences.map(a => (
+              : absences.map((a) => (
                   <Link
                     key={a.id}
                     to="/me/days-off"
@@ -431,7 +541,8 @@ function AbsencesCard({
                   >
                     <CalendarOff className="size-4 shrink-0 text-muted-foreground" />
                     <span className="text-sm">
-                      {formatDateShort(a.startDate)} — {formatDateShort(a.endDate)}
+                      {formatDateShort(a.startDate)} —{" "}
+                      {formatDateShort(a.endDate)}
                     </span>
                   </Link>
                 ))}
@@ -446,5 +557,5 @@ function AbsencesCard({
         </CardFooter>
       )}
     </Card>
-  )
+  );
 }

--- a/app/features/display-board/ui/dynamic/PioneersView.tsx
+++ b/app/features/display-board/ui/dynamic/PioneersView.tsx
@@ -1,30 +1,37 @@
-import { Star } from 'lucide-react'
-import * as m from '~/paraglide/messages'
-import { Card, CardContent } from '~/shared/ui/card'
-import { EmptyState } from '~/shared/ui/EmptyState'
+import { Star } from "lucide-react";
+import * as m from "~/paraglide/messages";
+import { Card, CardContent } from "~/shared/ui/card";
+import { EmptyState } from "~/shared/ui/EmptyState";
 
 interface Pioneer {
-  id: number
-  firstname: string | null
-  lastname: string | null
-  type: string
-  anonymizedAt: Date | null
+  id: number;
+  firstname: string | null;
+  lastname: string | null;
+  type: string;
+  anonymizedAt: Date | null;
 }
 
 interface PioneersViewData {
-  pioneers: Pioneer[]
+  pioneers: Pioneer[];
 }
 
-function formatName(user: { firstname: string | null; lastname: string | null; anonymizedAt: Date | null }): string {
-  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user()
-  return [user.firstname, user.lastname].filter(Boolean).join(' ') || '—'
+function formatName(user: {
+  firstname: string | null;
+  lastname: string | null;
+  anonymizedAt: Date | null;
+}): string {
+  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user();
+  return [user.firstname, user.lastname].filter(Boolean).join(" ") || "—";
 }
 
 function labelForType(type: string): string {
-  if (type === 'PionnierPermanant') return m.board_dynamic_pioneers_type_permanent()
-  if (type === 'PionnierSpecial') return m.board_dynamic_pioneers_type_special()
-  if (type === 'Missionnaire') return m.board_dynamic_pioneers_type_missionary()
-  return type
+  if (type === "PionnierPermanant")
+    return m.board_dynamic_pioneers_type_permanent();
+  if (type === "PionnierSpecial")
+    return m.board_dynamic_pioneers_type_special();
+  if (type === "Missionnaire")
+    return m.board_dynamic_pioneers_type_missionary();
+  return type;
 }
 
 export function PioneersView({ pioneers }: PioneersViewData) {
@@ -35,25 +42,25 @@ export function PioneersView({ pioneers }: PioneersViewData) {
         title={m.board_dynamic_pioneers_empty_title()}
         description={m.board_dynamic_pioneers_empty_description()}
       />
-    )
+    );
   }
 
   const byType = pioneers.reduce<Record<string, Pioneer[]>>((acc, pioneer) => {
-    if (!acc[pioneer.type]) acc[pioneer.type] = []
-    acc[pioneer.type].push(pioneer)
-    return acc
-  }, {})
+    if (!acc[pioneer.type]) acc[pioneer.type] = [];
+    acc[pioneer.type].push(pioneer);
+    return acc;
+  }, {});
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 p-4 md:p-6">
       {Object.entries(byType).map(([type, members]) => (
         <Card key={type}>
-          <CardContent className="flex flex-col gap-3 pt-6">
+          <CardContent className="flex flex-col gap-3">
             <h2 className="font-display font-semibold text-lg">
               {labelForType(type)} ({members.length})
             </h2>
             <ul className="grid list-disc gap-1 pl-5 text-sm sm:grid-cols-2">
-              {members.map(pioneer => (
+              {members.map((pioneer) => (
                 <li key={pioneer.id}>{formatName(pioneer)}</li>
               ))}
             </ul>
@@ -61,5 +68,5 @@ export function PioneersView({ pioneers }: PioneersViewData) {
         </Card>
       ))}
     </div>
-  )
+  );
 }

--- a/app/features/display-board/ui/dynamic/ProgrammeView.tsx
+++ b/app/features/display-board/ui/dynamic/ProgrammeView.tsx
@@ -1,44 +1,50 @@
-import type { LucideIcon } from 'lucide-react'
-import { BookOpen, Calendar, ChevronRight, Gem, HeartHandshake } from 'lucide-react'
-import { type RefObject, useEffect, useMemo, useRef, useState } from 'react'
-import type { ProgrammeDynamicConfig } from '~/features/display-board/model/dynamic-document.type'
-import { groupPartsBySlot } from '~/features/events/model/group-parts-by-slot'
-import * as m from '~/paraglide/messages'
-import { Badge } from '~/shared/ui/badge'
-import { EmptyState } from '~/shared/ui/EmptyState'
-import { usePersistedState } from '~/shared/ui/hooks/use-persisted-state'
-import { cn } from '~/shared/utils/utils'
+import type { LucideIcon } from "lucide-react";
+import {
+  BookOpen,
+  Calendar,
+  ChevronRight,
+  Gem,
+  HeartHandshake,
+} from "lucide-react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
+import type { ProgrammeDynamicConfig } from "~/features/display-board/model/dynamic-document.type";
+import { groupPartsBySlot } from "~/features/events/model/group-parts-by-slot";
+import * as m from "~/paraglide/messages";
+import { Badge } from "~/shared/ui/badge";
+import { EmptyState } from "~/shared/ui/EmptyState";
+import { usePersistedState } from "~/shared/ui/hooks/use-persisted-state";
+import { cn } from "~/shared/utils/utils";
 
 // ---------------------------------------------------------------------------
 // Section color mapping — uses CSS custom properties from tailwind.css
 // ---------------------------------------------------------------------------
 
 const SECTION_COLOR_MAP: [string, string][] = [
-  ['joyaux', 'var(--color-section-treasures)'],
-  ['minist', 'var(--color-section-ministry)'],
-  ['chr', 'var(--color-section-living)'],
-]
+  ["joyaux", "var(--color-section-treasures)"],
+  ["minist", "var(--color-section-ministry)"],
+  ["chr", "var(--color-section-living)"],
+];
 
 function sectionColor(section: string): string {
-  const lower = section.toLowerCase()
+  const lower = section.toLowerCase();
   for (const [pattern, cssVar] of SECTION_COLOR_MAP) {
-    if (lower.includes(pattern)) return cssVar
+    if (lower.includes(pattern)) return cssVar;
   }
-  return 'var(--color-muted-foreground)'
+  return "var(--color-muted-foreground)";
 }
 
 const SECTION_ICONS: [string, LucideIcon][] = [
-  ['joyaux', Gem],
-  ['minist', BookOpen],
-  ['chr', HeartHandshake],
-]
+  ["joyaux", Gem],
+  ["minist", BookOpen],
+  ["chr", HeartHandshake],
+];
 
 function sectionIcon(section: string): LucideIcon | undefined {
-  const lower = section.toLowerCase()
+  const lower = section.toLowerCase();
   for (const [pattern, icon] of SECTION_ICONS) {
-    if (lower.includes(pattern)) return icon
+    if (lower.includes(pattern)) return icon;
   }
-  return undefined
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,53 +52,53 @@ function sectionIcon(section: string): LucideIcon | undefined {
 // ---------------------------------------------------------------------------
 
 interface PartAssignment {
-  id: number
-  name: string
-  section: string
-  track: string
-  order: number
-  topic: string
-  durationMin: number | null
+  id: number;
+  name: string;
+  section: string;
+  track: string;
+  order: number;
+  topic: string;
+  durationMin: number | null;
   assignee: {
-    id: number
-    firstname: string | null
-    lastname: string | null
-    anonymizedAt: Date | null
-  } | null
+    id: number;
+    firstname: string | null;
+    lastname: string | null;
+    anonymizedAt: Date | null;
+  } | null;
   assistant: {
-    id: number
-    firstname: string | null
-    lastname: string | null
-    anonymizedAt: Date | null
-  } | null
+    id: number;
+    firstname: string | null;
+    lastname: string | null;
+    anonymizedAt: Date | null;
+  } | null;
 }
 
 interface ServiceRoleAssignment {
-  id: number
-  name: string
+  id: number;
+  name: string;
   assignee?: {
-    id: number
-    firstname: string | null
-    lastname: string | null
-    anonymizedAt: Date | null
-  } | null
+    id: number;
+    firstname: string | null;
+    lastname: string | null;
+    anonymizedAt: Date | null;
+  } | null;
 }
 
 interface ProgrammeEvent {
-  id: number
-  name: string
-  startDate: Date
-  templateId?: number | null
-  partAssignments: PartAssignment[]
-  serviceRoleAssignments?: ServiceRoleAssignment[]
+  id: number;
+  name: string;
+  startDate: Date;
+  templateId?: number | null;
+  partAssignments: PartAssignment[];
+  serviceRoleAssignments?: ServiceRoleAssignment[];
 }
 
 export interface ProgrammeViewData {
-  events: ProgrammeEvent[]
-  showServices: boolean
-  config: ProgrammeDynamicConfig | null
-  highlightQuery?: string
-  scrollContainerRef?: RefObject<HTMLDivElement | null>
+  events: ProgrammeEvent[];
+  showServices: boolean;
+  config: ProgrammeDynamicConfig | null;
+  highlightQuery?: string;
+  scrollContainerRef?: RefObject<HTMLDivElement | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,130 +106,183 @@ export interface ProgrammeViewData {
 // ---------------------------------------------------------------------------
 
 function formatName(
-  user: { firstname: string | null; lastname: string | null; anonymizedAt: Date | null } | null,
+  user: {
+    firstname: string | null;
+    lastname: string | null;
+    anonymizedAt: Date | null;
+  } | null,
 ): string | null {
-  if (!user) return null
-  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user()
-  const name = [user.firstname, user.lastname].filter(Boolean).join(' ')
-  return name || null
+  if (!user) return null;
+  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user();
+  const name = [user.firstname, user.lastname].filter(Boolean).join(" ");
+  return name || null;
 }
 
-function formatAssigneeWithAssistant(assignee: string | null, assistant: string | null): string | null {
-  if (!assignee) return null
-  if (assistant) return `${assignee} / ${assistant}`
-  return assignee
+function formatAssigneeWithAssistant(
+  assignee: string | null,
+  assistant: string | null,
+): string | null {
+  if (!assignee) return null;
+  if (assistant) return `${assignee} / ${assistant}`;
+  return assignee;
 }
 
 function formatDate(date: Date): string {
-  return new Date(date).toLocaleDateString('fr-FR', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-  })
+  return new Date(date).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
 }
 
 function getWeekKey(date: Date): string {
-  const d = new Date(date)
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7))
-  return d.toISOString().slice(0, 10)
+  const d = new Date(date);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  return d.toISOString().slice(0, 10);
 }
 
 function getWeekLabel(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+  });
 }
 
 function getMonth(date: Date): string {
-  return new Date(date).toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
+  return new Date(date).toLocaleDateString("fr-FR", {
+    month: "long",
+    year: "numeric",
+  });
 }
 
 function nameMatches(
-  user: { firstname: string | null; lastname: string | null; anonymizedAt: Date | null } | null,
+  user: {
+    firstname: string | null;
+    lastname: string | null;
+    anonymizedAt: Date | null;
+  } | null,
   query: string,
 ): boolean {
-  const name = formatName(user)
-  if (!name) return false
-  return name.toLowerCase().includes(query)
+  const name = formatName(user);
+  if (!name) return false;
+  return name.toLowerCase().includes(query);
 }
 
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function SectionHeader({ section, icon: Icon }: { section: string; icon?: LucideIcon }) {
-  const color = sectionColor(section)
+function SectionHeader({
+  section,
+  icon: Icon,
+}: {
+  section: string;
+  icon?: LucideIcon;
+}) {
+  const color = sectionColor(section);
   return (
     <div className="mb-1 flex items-center gap-2">
       {Icon && <Icon className="size-3.5" style={{ color }} />}
-      <span className="font-bold text-xs uppercase tracking-wider" style={{ color }}>
+      <span
+        className="font-bold text-xs uppercase tracking-wider"
+        style={{ color }}
+      >
         {section}
       </span>
     </div>
-  )
+  );
 }
 
-function PartRow({ part, highlighted, dimmed }: { part: PartAssignment; highlighted: boolean; dimmed: boolean }) {
-  const assigneeName = formatName(part.assignee)
-  const assistantName = formatName(part.assistant)
-  const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
-  const displayName = part.topic !== '' ? part.topic : part.name
+function PartRow({
+  part,
+  highlighted,
+  dimmed,
+}: {
+  part: PartAssignment;
+  highlighted: boolean;
+  dimmed: boolean;
+}) {
+  const assigneeName = formatName(part.assignee);
+  const assistantName = formatName(part.assistant);
+  const rightText = formatAssigneeWithAssistant(assigneeName, assistantName);
+  const displayName = part.topic !== "" ? part.topic : part.name;
 
   return (
     <li
       className={cn(
-        'grid grid-cols-[1fr_auto] items-baseline gap-x-4 py-0.5',
-        dimmed && 'opacity-30 transition-opacity',
+        "grid grid-cols-[1fr_auto] items-baseline gap-x-4 py-0.5",
+        dimmed && "opacity-30 transition-opacity",
       )}
     >
       <span className="min-w-0 truncate font-semibold text-foreground text-sm">
         {displayName}
         {part.durationMin != null && (
-          <span className="ml-1 font-normal text-muted-foreground text-xs">({part.durationMin} min)</span>
+          <span className="ml-1 font-normal text-muted-foreground text-xs">
+            ({part.durationMin} min)
+          </span>
         )}
       </span>
       {rightText ? (
         <span
           className={cn(
-            'shrink-0 text-foreground text-sm',
-            highlighted && 'rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40',
+            "shrink-0 text-foreground text-sm",
+            highlighted && "rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40",
           )}
         >
           {rightText}
         </span>
       ) : (
-        <span className="shrink-0 text-muted-foreground/40 text-sm italic">&mdash;</span>
+        <span className="shrink-0 text-muted-foreground/40 text-sm italic">
+          &mdash;
+        </span>
       )}
     </li>
-  )
+  );
 }
 
-function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: string }) {
-  const representative = parts[0]
-  const hasQuery = query.length > 0
+function MultiTrackPart({
+  parts,
+  query,
+}: {
+  parts: PartAssignment[];
+  query: string;
+}) {
+  const representative = parts[0];
+  const hasQuery = query.length > 0;
 
-  const displayName = representative.topic !== '' ? representative.topic : representative.name
+  const displayName =
+    representative.topic !== "" ? representative.topic : representative.name;
 
   return (
     <div>
       <div className="font-semibold text-foreground text-sm">
         {displayName}
         {representative.durationMin != null && (
-          <span className="ml-1 font-normal text-muted-foreground text-xs">({representative.durationMin} min)</span>
+          <span className="ml-1 font-normal text-muted-foreground text-xs">
+            ({representative.durationMin} min)
+          </span>
         )}
       </div>
       {parts.map((part, idx) => {
-        const assigneeName = formatName(part.assignee)
-        const assistantName = formatName(part.assistant)
-        const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
-        const trackName = part.track || `Salle ${idx + 1}`
-        const highlighted = hasQuery && (nameMatches(part.assignee, query) || nameMatches(part.assistant, query))
-        const dimmed = hasQuery && !highlighted
+        const assigneeName = formatName(part.assignee);
+        const assistantName = formatName(part.assistant);
+        const rightText = formatAssigneeWithAssistant(
+          assigneeName,
+          assistantName,
+        );
+        const trackName = part.track || `Salle ${idx + 1}`;
+        const highlighted =
+          hasQuery &&
+          (nameMatches(part.assignee, query) ||
+            nameMatches(part.assistant, query));
+        const dimmed = hasQuery && !highlighted;
 
         return (
           <li
             key={part.id}
             className={cn(
-              'ml-3 grid grid-cols-[1fr_auto] items-baseline gap-x-4 py-0.5',
-              dimmed && 'opacity-30 transition-opacity',
+              "ml-3 grid grid-cols-[1fr_auto] items-baseline gap-x-4 py-0.5",
+              dimmed && "opacity-30 transition-opacity",
             )}
           >
             <span className="shrink-0 font-semibold text-muted-foreground text-xs uppercase tracking-wide">
@@ -232,20 +291,23 @@ function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: stri
             {rightText ? (
               <span
                 className={cn(
-                  'shrink-0 text-foreground text-sm',
-                  highlighted && 'rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40',
+                  "shrink-0 text-foreground text-sm",
+                  highlighted &&
+                    "rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40",
                 )}
               >
                 {rightText}
               </span>
             ) : (
-              <span className="shrink-0 text-muted-foreground/40 text-sm italic">&mdash;</span>
+              <span className="shrink-0 text-muted-foreground/40 text-sm italic">
+                &mdash;
+              </span>
             )}
           </li>
-        )
+        );
       })}
     </div>
-  )
+  );
 }
 
 function ServiceSection({
@@ -253,16 +315,19 @@ function ServiceSection({
   hasParts,
   query,
 }: {
-  services: ServiceRoleAssignment[]
-  hasParts: boolean
-  query: string
+  services: ServiceRoleAssignment[];
+  hasParts: boolean;
+  query: string;
 }) {
-  const [collapsed, setCollapsed] = usePersistedState('programme-services-collapsed', false)
-  const canCollapse = hasParts
-  const hasQuery = query.length > 0
+  const [collapsed, setCollapsed] = usePersistedState(
+    "programme-services-collapsed",
+    false,
+  );
+  const canCollapse = hasParts;
+  const hasQuery = query.length > 0;
 
   return (
-    <div className={hasParts ? 'mt-3' : ''}>
+    <div className={hasParts ? "mt-3" : ""}>
       {canCollapse ? (
         <button
           type="button"
@@ -270,7 +335,10 @@ function ServiceSection({
           className="mb-1 flex w-full cursor-pointer items-center gap-1.5 text-left"
         >
           <ChevronRight
-            className={cn('size-4 text-muted-foreground transition-transform duration-200', !collapsed && 'rotate-90')}
+            className={cn(
+              "size-4 text-muted-foreground transition-transform duration-200",
+              !collapsed && "rotate-90",
+            )}
           />
           <span className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
             {m.board_viewer_services_label({ count: String(services.length) })}
@@ -284,53 +352,66 @@ function ServiceSection({
 
       <div
         className={cn(
-          canCollapse && 'grid transition-[grid-template-rows] duration-200 ease-in-out',
-          canCollapse && (collapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'),
+          canCollapse &&
+            "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          canCollapse && (collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"),
         )}
       >
-        <div className={cn(canCollapse && 'overflow-hidden')}>
+        <div className={cn(canCollapse && "overflow-hidden")}>
           <div className="grid grid-cols-1 gap-x-4 gap-y-0.5 sm:grid-cols-2">
-            {services.map(role => {
-              const name = formatName(role.assignee ?? null)
-              const highlighted = hasQuery && nameMatches(role.assignee ?? null, query)
-              const dimmed = hasQuery && !highlighted
+            {services.map((role) => {
+              const name = formatName(role.assignee ?? null);
+              const highlighted =
+                hasQuery && nameMatches(role.assignee ?? null, query);
+              const dimmed = hasQuery && !highlighted;
 
               return (
                 <div
                   key={role.id}
                   className={cn(
-                    'grid grid-cols-[1fr_auto] items-baseline gap-x-4',
-                    dimmed && 'opacity-30 transition-opacity',
+                    "grid grid-cols-[1fr_auto] items-baseline gap-x-4",
+                    dimmed && "opacity-30 transition-opacity",
                   )}
                 >
-                  <span className="text-muted-foreground text-sm">{role.name}</span>
+                  <span className="text-muted-foreground text-sm">
+                    {role.name}
+                  </span>
                   {name ? (
                     <span
                       className={cn(
-                        'font-medium text-foreground text-sm',
-                        highlighted && 'rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40',
+                        "font-medium text-foreground text-sm",
+                        highlighted &&
+                          "rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40",
                       )}
                     >
                       {name}
                     </span>
                   ) : (
-                    <span className="text-muted-foreground/40 text-sm italic">&mdash;</span>
+                    <span className="text-muted-foreground/40 text-sm italic">
+                      &mdash;
+                    </span>
                   )}
                 </div>
-              )
+              );
             })}
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
-export function ProgrammeView({ events, showServices, config, highlightQuery, scrollContainerRef }: ProgrammeViewData) {
+export function ProgrammeView({
+  events,
+  showServices,
+  config,
+  highlightQuery,
+  scrollContainerRef,
+}: ProgrammeViewData) {
   if (events.length === 0) {
     return (
       <EmptyState
@@ -338,110 +419,117 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
         title={m.board_dynamic_programme_empty_title()}
         description={m.board_dynamic_programme_empty_description()}
       />
-    )
+    );
   }
 
-  const query = highlightQuery?.toLowerCase().trim() ?? ''
-  const hasQuery = query.length > 0
+  const query = highlightQuery?.toLowerCase().trim() ?? "";
+  const hasQuery = query.length > 0;
 
   // Build per-template config map for filtering
   const configMap = config
-    ? new Map(config.templates.map(t => [t.templateId, { parts: t.parts, services: t.services }]))
-    : null
+    ? new Map(
+        config.templates.map((t) => [
+          t.templateId,
+          { parts: t.parts, services: t.services },
+        ]),
+      )
+    : null;
 
   // Order events
   const orderedEvents =
-    config?.groupBy === 'template'
+    config?.groupBy === "template"
       ? [...events].sort((a, b) => {
-          const nameA = a.name
-          const nameB = b.name
-          if (nameA !== nameB) return nameA.localeCompare(nameB)
-          return new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+          const nameA = a.name;
+          const nameB = b.name;
+          if (nameA !== nameB) return nameA.localeCompare(nameB);
+          return (
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+          );
         })
-      : events
+      : events;
 
   // Compute unique weeks
   // biome-ignore lint/correctness/useHookAtTopLevel: orderedEvents is stable per render (derived from props)
   const weekKeys = useMemo(() => {
-    const seen = new Set<string>()
-    const keys: string[] = []
+    const seen = new Set<string>();
+    const keys: string[] = [];
     for (const event of orderedEvents) {
-      const wk = getWeekKey(new Date(event.startDate))
+      const wk = getWeekKey(new Date(event.startDate));
       if (!seen.has(wk)) {
-        seen.add(wk)
-        keys.push(wk)
+        seen.add(wk);
+        keys.push(wk);
       }
     }
-    return keys
-  }, [orderedEvents])
+    return keys;
+  }, [orderedEvents]);
 
-  const showWeekNav = weekKeys.length > 1
+  const showWeekNav = weekKeys.length > 1;
   // biome-ignore lint/correctness/useHookAtTopLevel: same reason as above
-  const weekRefs = useRef(new Map<string, HTMLDivElement | null>())
+  const weekRefs = useRef(new Map<string, HTMLDivElement | null>());
   // biome-ignore lint/correctness/useHookAtTopLevel: same reason as above
-  const [activeWeek, setActiveWeek] = useState<string>(weekKeys[0] ?? '')
+  const [activeWeek, setActiveWeek] = useState<string>(weekKeys[0] ?? "");
 
   // Track first event id per week for ref attachment
   // biome-ignore lint/correctness/useHookAtTopLevel: hooks are always called — the early return above is only for empty events
   const firstEventIdPerWeek = useMemo(() => {
-    const map = new Set<number>()
-    const seen = new Set<string>()
+    const map = new Set<number>();
+    const seen = new Set<string>();
     for (const event of orderedEvents) {
-      const wk = getWeekKey(new Date(event.startDate))
+      const wk = getWeekKey(new Date(event.startDate));
       if (!seen.has(wk)) {
-        seen.add(wk)
-        map.add(event.id)
+        seen.add(wk);
+        map.add(event.id);
       }
     }
-    return map
-  }, [orderedEvents])
+    return map;
+  }, [orderedEvents]);
 
   // IntersectionObserver to track active week
   // biome-ignore lint/correctness/useHookAtTopLevel: same reason as above
   useEffect(() => {
-    const container = scrollContainerRef?.current
-    if (!container || !showWeekNav) return
+    const container = scrollContainerRef?.current;
+    if (!container || !showWeekNav) return;
 
     const observer = new IntersectionObserver(
-      entries => {
+      (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
-            const weekKey = entry.target.getAttribute('data-week')
-            if (weekKey) setActiveWeek(weekKey)
+            const weekKey = entry.target.getAttribute("data-week");
+            if (weekKey) setActiveWeek(weekKey);
           }
         }
       },
-      { root: container, rootMargin: '-10% 0px -80% 0px', threshold: 0 },
-    )
+      { root: container, rootMargin: "-10% 0px -80% 0px", threshold: 0 },
+    );
 
     for (const [, el] of weekRefs.current) {
-      if (el) observer.observe(el)
+      if (el) observer.observe(el);
     }
 
-    return () => observer.disconnect()
-  }, [scrollContainerRef, showWeekNav])
+    return () => observer.disconnect();
+  }, [scrollContainerRef, showWeekNav]);
 
   // Track month boundaries
-  let prevMonth = ''
+  let prevMonth = "";
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 p-4 md:p-6">
       {/* Week navigation strip */}
       {showWeekNav && (
         <div className="sticky top-0 z-20 -mx-4 flex gap-1.5 overflow-x-auto bg-background/95 px-4 py-2 backdrop-blur-sm md:-mx-6 md:px-6">
-          {weekKeys.map(wk => (
+          {weekKeys.map((wk) => (
             <button
               key={wk}
               type="button"
               onClick={() => {
-                const el = weekRefs.current.get(wk)
-                el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                const el = weekRefs.current.get(wk);
+                el?.scrollIntoView({ behavior: "smooth", block: "start" });
               }}
               className={cn(
-                'shrink-0 rounded-full border px-3 py-1 font-medium text-xs transition-colors',
+                "shrink-0 rounded-full border px-3 py-1 font-medium text-xs transition-colors",
                 activeWeek === wk
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-card text-muted-foreground hover:bg-accent',
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-card text-muted-foreground hover:bg-accent",
               )}
             >
               {getWeekLabel(wk)}
@@ -451,19 +539,23 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
       )}
 
       {/* Events */}
-      {orderedEvents.map(event => {
-        const templateConfig = event.templateId && configMap ? configMap.get(event.templateId) : null
-        const eventShowParts = templateConfig?.parts ?? true
-        const eventShowServices = templateConfig?.services ?? showServices
+      {orderedEvents.map((event) => {
+        const templateConfig =
+          event.templateId && configMap
+            ? configMap.get(event.templateId)
+            : null;
+        const eventShowParts = templateConfig?.parts ?? true;
+        const eventShowServices = templateConfig?.services ?? showServices;
 
-        const sections = groupPartsBySlot(event.partAssignments)
-        const isFirstOfWeek = firstEventIdPerWeek.has(event.id)
-        const weekKey = getWeekKey(new Date(event.startDate))
+        const sections = groupPartsBySlot(event.partAssignments);
+        const isFirstOfWeek = firstEventIdPerWeek.has(event.id);
+        const weekKey = getWeekKey(new Date(event.startDate));
 
         // Month boundary separator
-        const currentMonth = getMonth(event.startDate)
-        const showMonthSeparator = prevMonth !== '' && currentMonth !== prevMonth
-        prevMonth = currentMonth
+        const currentMonth = getMonth(event.startDate);
+        const showMonthSeparator =
+          prevMonth !== "" && currentMonth !== prevMonth;
+        prevMonth = currentMonth;
 
         return (
           <div key={event.id}>
@@ -471,18 +563,20 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
             {showMonthSeparator && (
               <div className="flex items-center gap-3 pb-4">
                 <div className="h-px flex-1 bg-border" />
-                <span className="font-medium text-muted-foreground text-xs capitalize">{currentMonth}</span>
+                <span className="font-medium text-muted-foreground text-xs capitalize">
+                  {currentMonth}
+                </span>
                 <div className="h-px flex-1 bg-border" />
               </div>
             )}
 
             {/* Event card */}
             <div
-              className="rounded-lg border border-border/50 bg-card p-3 shadow-sm md:p-4"
-              ref={el => {
+              className="rounded-lg border border-border/50 bg-card px-3 pb-3 shadow-sm md:px-4 md:pb-4"
+              ref={(el) => {
                 if (isFirstOfWeek) {
-                  weekRefs.current.set(weekKey, el)
-                  el?.setAttribute('data-week', weekKey)
+                  weekRefs.current.set(weekKey, el);
+                  el?.setAttribute("data-week", weekKey);
                 }
               }}
               data-week={isFirstOfWeek ? weekKey : undefined}
@@ -490,11 +584,13 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
               {/* Sticky date header */}
               <div
                 className={cn(
-                  'sticky z-10 -mx-3 mb-2 flex items-center justify-between rounded-t-lg bg-background/95 px-3 py-2 backdrop-blur-sm md:-mx-4 md:px-4',
-                  showWeekNav ? 'top-9' : 'top-0',
+                  "sticky z-10 -mx-3 mb-2 flex items-center justify-between rounded-t-lg bg-background/95 px-3 py-2 backdrop-blur-sm md:-mx-4 md:px-4",
+                  showWeekNav ? "top-9" : "top-0",
                 )}
               >
-                <span className="font-bold text-base text-foreground capitalize">{formatDate(event.startDate)}</span>
+                <span className="font-bold text-base text-foreground capitalize">
+                  {formatDate(event.startDate)}
+                </span>
                 <Badge variant="outline" className="text-xs">
                   {event.name}
                 </Badge>
@@ -503,8 +599,8 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
               {/* Parts grouped by section */}
               {eventShowParts &&
                 sections.map(({ section, slots }) => {
-                  const color = sectionColor(section)
-                  const icon = sectionIcon(section)
+                  const color = sectionColor(section);
+                  const icon = sectionIcon(section);
 
                   return (
                     <ul
@@ -513,30 +609,53 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
                       style={{ borderColor: color }}
                       aria-label={section || undefined}
                     >
-                      {section && <SectionHeader section={section} icon={icon} />}
-                      {slots.map(slot => {
+                      {section && (
+                        <SectionHeader section={section} icon={icon} />
+                      )}
+                      {slots.map((slot) => {
                         if (slot.parts.length === 1) {
-                          const part = slot.parts[0]
+                          const part = slot.parts[0];
                           const highlighted =
-                            hasQuery && (nameMatches(part.assignee, query) || nameMatches(part.assistant, query))
-                          const dimmed = hasQuery && !highlighted
+                            hasQuery &&
+                            (nameMatches(part.assignee, query) ||
+                              nameMatches(part.assistant, query));
+                          const dimmed = hasQuery && !highlighted;
 
-                          return <PartRow key={part.id} part={part} highlighted={highlighted} dimmed={dimmed} />
+                          return (
+                            <PartRow
+                              key={part.id}
+                              part={part}
+                              highlighted={highlighted}
+                              dimmed={dimmed}
+                            />
+                          );
                         }
-                        return <MultiTrackPart key={`slot-${slot.parts[0].id}`} parts={slot.parts} query={query} />
+                        return (
+                          <MultiTrackPart
+                            key={`slot-${slot.parts[0].id}`}
+                            parts={slot.parts}
+                            query={query}
+                          />
+                        );
                       })}
                     </ul>
-                  )
+                  );
                 })}
 
               {/* Services */}
-              {eventShowServices && event.serviceRoleAssignments && event.serviceRoleAssignments.length > 0 && (
-                <ServiceSection services={event.serviceRoleAssignments} hasParts={eventShowParts} query={query} />
-              )}
+              {eventShowServices &&
+                event.serviceRoleAssignments &&
+                event.serviceRoleAssignments.length > 0 && (
+                  <ServiceSection
+                    services={event.serviceRoleAssignments}
+                    hasParts={eventShowParts}
+                    query={query}
+                  />
+                )}
             </div>
           </div>
-        )
+        );
       })}
     </div>
-  )
+  );
 }

--- a/app/shared/ui/AppSidebar.tsx
+++ b/app/shared/ui/AppSidebar.tsx
@@ -22,11 +22,15 @@ import {
   UserRoundCog,
   Users,
   UsersRound,
-} from 'lucide-react'
-import { Form, NavLink } from 'react-router'
+} from "lucide-react";
+import { Form, NavLink } from "react-router";
 
-import * as m from '~/paraglide/messages'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '~/shared/ui/collapsible'
+import * as m from "~/paraglide/messages";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/shared/ui/collapsible";
 import {
   Sidebar,
   SidebarContent,
@@ -40,43 +44,51 @@ import {
   SidebarMenuItem,
   SidebarTrigger,
   useSidebar,
-} from '~/shared/ui/sidebar'
-import { ThemeToggle } from '~/shared/ui/ThemeToggle'
+} from "~/shared/ui/sidebar";
+import { ThemeToggle } from "~/shared/ui/ThemeToggle";
 
 export interface AppSidebarPermissions {
-  canViewBoard: boolean
-  canUploadDocument: boolean
-  canManageBoard: boolean
-  canViewPublishers: boolean
-  canViewTerritories: boolean
-  canViewProspection: boolean
-  canManageTerritories: boolean
-  canManageSettings: boolean
-  canManageUsers: boolean
-  canViewPrograms: boolean
-  canViewActivity: boolean
-  isPlatformAdmin: boolean
+  canViewBoard: boolean;
+  canUploadDocument: boolean;
+  canManageBoard: boolean;
+  canViewPublishers: boolean;
+  canViewTerritories: boolean;
+  canViewProspection: boolean;
+  canManageTerritories: boolean;
+  canManageSettings: boolean;
+  canManageUsers: boolean;
+  canViewPrograms: boolean;
+  canViewActivity: boolean;
+  isPlatformAdmin: boolean;
 }
 
 interface AppSidebarProps {
-  permissions: AppSidebarPermissions
-  congregationName?: string
-  onSearchClick?: () => void
+  permissions: AppSidebarPermissions;
+  congregationName?: string;
+  onSearchClick?: () => void;
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sidebar with many permission-based conditional sections
-export function AppSidebar({ permissions, congregationName, onSearchClick }: AppSidebarProps) {
-  const showAssemblee = permissions.canViewPublishers || permissions.canViewPrograms
+export function AppSidebar({
+  permissions,
+  congregationName,
+  onSearchClick,
+}: AppSidebarProps) {
+  const showAssemblee =
+    permissions.canViewPublishers || permissions.canViewPrograms;
   const showTerritories =
-    permissions.canViewTerritories || permissions.canViewProspection || permissions.canManageTerritories
-  const showReglages = permissions.canManageSettings || permissions.canManageUsers
+    permissions.canViewTerritories ||
+    permissions.canViewProspection ||
+    permissions.canManageTerritories;
+  const showReglages =
+    permissions.canManageSettings || permissions.canManageUsers;
 
   return (
     <Sidebar>
       <SidebarHeader>
         <div className="flex items-center justify-between gap-2 border-sidebar-border border-b px-3 py-4">
           <span className="truncate font-bold font-display text-foreground text-lg">
-            {congregationName || 'Unitae'}
+            {congregationName || "Unitae"}
           </span>
           <div className="flex items-center gap-1">
             <ThemeToggle />
@@ -89,8 +101,12 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
           className="mx-2 mt-3 mb-1 flex items-center gap-2 rounded-md border border-sidebar-border px-2 py-1 text-muted-foreground text-xs hover:bg-sidebar-accent"
         >
           <Search className="size-3.5 shrink-0" />
-          <span className="flex-1 truncate text-left">{m.sidebar_search()}</span>
-          <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
+          <span className="flex-1 truncate text-left">
+            {m.sidebar_search()}
+          </span>
+          <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
+            ⌘K
+          </kbd>
         </button>
       </SidebarHeader>
 
@@ -100,7 +116,11 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
             <SidebarMenu>
               <SidebarNavItem to="/" icon={Home} label={m.sidebar_home()} end />
               {permissions.canViewBoard && !permissions.canManageBoard && (
-                <SidebarNavItem to="/board" icon={LayoutGrid} label={m.sidebar_board()} />
+                <SidebarNavItem
+                  to="/board"
+                  icon={LayoutGrid}
+                  label={m.sidebar_board()}
+                />
               )}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -118,9 +138,22 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
               <CollapsibleContent>
                 <SidebarGroupContent>
                   <SidebarMenu>
-                    <SidebarNavItem to="/board" icon={LayoutGrid} label={m.sidebar_board()} end />
-                    <SidebarNavItem to="/board/sections" icon={FolderOpen} label={m.sidebar_sections()} />
-                    <SidebarNavItem to="/board/documents" icon={FileText} label={m.sidebar_documents()} />
+                    <SidebarNavItem
+                      to="/board"
+                      icon={LayoutGrid}
+                      label={m.sidebar_board()}
+                      end
+                    />
+                    <SidebarNavItem
+                      to="/board/sections"
+                      icon={FolderOpen}
+                      label={m.sidebar_sections()}
+                    />
+                    <SidebarNavItem
+                      to="/board/documents"
+                      icon={FileText}
+                      label={m.sidebar_documents()}
+                    />
                   </SidebarMenu>
                 </SidebarGroupContent>
               </CollapsibleContent>
@@ -141,13 +174,26 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
                 <SidebarGroupContent>
                   <SidebarMenu>
                     {permissions.canViewPublishers && (
-                      <SidebarNavItem to="/publishers" icon={Users} label={m.sidebar_publishers()} />
+                      <SidebarNavItem
+                        to="/publishers"
+                        icon={Users}
+                        label={m.sidebar_publishers()}
+                      />
                     )}
                     {permissions.canViewPublishers && (
-                      <SidebarNavItem to="/groups" icon={UsersRound} label={m.sidebar_publisher_groups()} />
+                      <SidebarNavItem
+                        to="/groups"
+                        icon={UsersRound}
+                        label={m.sidebar_publisher_groups()}
+                      />
                     )}
                     {permissions.canViewPrograms && (
-                      <SidebarNavItem to="/programs" icon={CalendarDays} label={m.sidebar_programs()} end />
+                      <SidebarNavItem
+                        to="/programs"
+                        icon={CalendarDays}
+                        label={m.sidebar_programs()}
+                        end
+                      />
                     )}
                   </SidebarMenu>
                 </SidebarGroupContent>
@@ -176,13 +222,26 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
                       />
                     )}
                     {permissions.canViewTerritories && (
-                      <SidebarNavItem to="/territories" icon={MapIcon} label={m.sidebar_territories()} end />
+                      <SidebarNavItem
+                        to="/territories"
+                        icon={MapIcon}
+                        label={m.sidebar_territories()}
+                        end
+                      />
                     )}
                     {permissions.canViewProspection && (
-                      <SidebarNavItem to="/territories/buildings" icon={Building2} label={m.sidebar_prospection()} />
+                      <SidebarNavItem
+                        to="/territories/buildings"
+                        icon={Building2}
+                        label={m.sidebar_prospection()}
+                      />
                     )}
                     {permissions.canManageTerritories && (
-                      <SidebarNavItem to="/territories/stats" icon={PieChart} label={m.sidebar_statistics()} />
+                      <SidebarNavItem
+                        to="/territories/stats"
+                        icon={PieChart}
+                        label={m.sidebar_statistics()}
+                      />
                     )}
                   </SidebarMenu>
                 </SidebarGroupContent>
@@ -204,10 +263,18 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
                 <SidebarGroupContent>
                   <SidebarMenu>
                     {permissions.canManageSettings && (
-                      <SidebarNavItem to="/settings/general" icon={Settings} label={m.sidebar_settings_general()} />
+                      <SidebarNavItem
+                        to="/settings/general"
+                        icon={Settings}
+                        label={m.sidebar_settings_general()}
+                      />
                     )}
                     {permissions.canManageUsers && (
-                      <SidebarNavItem to="/settings/users" icon={UserCog} label={m.sidebar_users()} />
+                      <SidebarNavItem
+                        to="/settings/users"
+                        icon={UserCog}
+                        label={m.sidebar_users()}
+                      />
                     )}
                     {permissions.canManageSettings && (
                       <>
@@ -221,8 +288,16 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
                           icon={MapIcon}
                           label={m.sidebar_settings_territories()}
                         />
-                        <SidebarNavItem to="/settings/data" icon={HardDrive} label={m.sidebar_settings_data()} />
-                        <SidebarNavItem to="/settings/audit-log" icon={ClipboardList} label={m.sidebar_audit_log()} />
+                        <SidebarNavItem
+                          to="/settings/data"
+                          icon={HardDrive}
+                          label={m.sidebar_settings_data()}
+                        />
+                        <SidebarNavItem
+                          to="/settings/audit-log"
+                          icon={ClipboardList}
+                          label={m.sidebar_audit_log()}
+                        />
                       </>
                     )}
                   </SidebarMenu>
@@ -244,7 +319,11 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
               <CollapsibleContent>
                 <SidebarGroupContent>
                   <SidebarMenu>
-                    <SidebarNavItem to="/platform-admin" icon={UserRoundCog} label={m.sidebar_administration()} />
+                    <SidebarNavItem
+                      to="/platform-admin"
+                      icon={UserRoundCog}
+                      label={m.sidebar_administration()}
+                    />
                   </SidebarMenu>
                 </SidebarGroupContent>
               </CollapsibleContent>
@@ -255,13 +334,27 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
 
       <SidebarFooter className="border-sidebar-border border-t">
         <SidebarMenu>
-          <SidebarNavItem to="/me/profile" icon={User} label={m.sidebar_my_profile()} />
-          <SidebarNavItem to="/me/territories" icon={MapPin} label={m.sidebar_my_territories()} />
-          <SidebarNavItem to="/me/days-off" icon={CalendarOff} label={m.sidebar_my_absences()} />
-          <SidebarNavItem to="/me/notifications" icon={Bell} label={m.sidebar_my_notifications()} />
+          <SidebarNavItem
+            to="/me/profile"
+            icon={User}
+            label={m.sidebar_my_profile()}
+          />
+          <SidebarNavItem
+            to="/me/territories"
+            icon={MapPin}
+            label={m.sidebar_my_territories()}
+          />
+          <SidebarNavItem
+            to="/me/days-off"
+            icon={CalendarOff}
+            label={m.sidebar_my_absences()}
+          />
           <SidebarMenuItem>
             <Form action="/logout" method="post">
-              <SidebarMenuButton type="submit" className="text-muted-foreground hover:text-destructive">
+              <SidebarMenuButton
+                type="submit"
+                className="text-muted-foreground hover:text-destructive"
+              >
                 <LogOut className="size-4" />
                 <span>{m.sidebar_logout()}</span>
               </SidebarMenuButton>
@@ -270,7 +363,7 @@ export function AppSidebar({ permissions, congregationName, onSearchClick }: App
         </SidebarMenu>
       </SidebarFooter>
     </Sidebar>
-  )
+  );
 }
 
 function SidebarNavItem({
@@ -279,12 +372,12 @@ function SidebarNavItem({
   label,
   end,
 }: {
-  to: string
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  end?: boolean
+  to: string;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  end?: boolean;
 }) {
-  const { isMobile, setOpenMobile } = useSidebar()
+  const { isMobile, setOpenMobile } = useSidebar();
 
   return (
     <SidebarMenuItem>
@@ -293,7 +386,7 @@ function SidebarNavItem({
           to={to}
           end={end}
           onClick={() => {
-            if (isMobile) setOpenMobile(false)
+            if (isMobile) setOpenMobile(false);
           }}
         >
           <Icon className="size-4" />
@@ -301,5 +394,5 @@ function SidebarNavItem({
         </NavLink>
       </SidebarMenuButton>
     </SidebarMenuItem>
-  )
+  );
 }


### PR DESCRIPTION
## Summary

- Remove excess top padding (`pt-6`) from PioneersView card content and drop top padding from ProgrammeView event cards so sticky date headers sit flush at the card top
- Fix the "assign territory" quick action on the dashboard to link directly to the available-territories page instead of the territories index
- Remove the broken notifications sidebar nav item that linked to a non-existent route

## Test plan

- [ ] Open display board dynamic views (Pioneers, Programme) and verify card headers are not pushed down by extra padding
- [ ] Click "Assign territory" on the dashboard and verify it navigates to `/territories/attributions/new/available-territories`
- [ ] Check the sidebar footer and confirm the notifications link is gone and logout still works