### PR TITLE
fix(e2e): correct non-existent routes in territory and board specs

### DIFF
--- a/app/tests/e2e/territory-attribution.spec.ts
+++ b/app/tests/e2e/territory-attribution.spec.ts
@@ -6,7 +6,8 @@ const TEST_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'password'
 
 const LOGIN_URL_RE = /\/login/
 const TERRITORIES_URL_RE = /\/territories/
-const NEW_TERRITORY_URL_RE = /\/territories\/new/
+const ATTRIBUTIONS_URL_RE = /\/territories\/attributions/
+const NEW_ATTRIBUTION_URL_RE = /\/territories\/attributions\/new/
 const SUBMIT_BUTTON_RE = /enregistrer|sauvegarder|créer|ajouter/i
 
 test.describe('Territory management', () => {
@@ -19,29 +20,26 @@ test.describe('Territory management', () => {
     const response = await page.goto('/territories')
     await page.waitForLoadState('networkidle')
     expect(response?.status()).toBeLessThan(500)
-    // Must not redirect to login — admin has territory access
     await expect(page).not.toHaveURL(LOGIN_URL_RE)
   })
 
-  test('new territory page is accessible', async ({ page }) => {
-    const response = await page.goto('/territories/new')
-    expect(response?.status()).toBeLessThan(500)
-  })
-
-  test('territory attribution page is accessible when territories exist', async ({ page }) => {
-    await page.goto('/territories')
-    await page.waitForLoadState('networkidle')
-
-    // Try to navigate to attributions — valid route regardless of data
+  test('territory attribution list is accessible', async ({ page }) => {
     const response = await page.goto('/territories/attributions')
+    await page.waitForLoadState('networkidle')
+    expect(response?.status()).toBeLessThan(500)
+    await expect(page).toHaveURL(ATTRIBUTIONS_URL_RE)
+  })
+
+  test('new attribution page is accessible', async ({ page }) => {
+    const response = await page.goto('/territories/attributions/new')
     expect(response?.status()).toBeLessThan(500)
   })
 
-  test('submitting new territory form without required fields shows validation error', async ({ page }) => {
-    await page.goto('/territories/new')
+  test('submitting new attribution form without required fields shows validation error', async ({ page }) => {
+    await page.goto('/territories/attributions/new')
     await page.waitForLoadState('networkidle')
 
-    if (!page.url().includes('/territories/new')) test.skip()
+    if (!page.url().includes('/territories/attributions/new')) test.skip()
 
     const submitButton = page.getByRole('button', { name: SUBMIT_BUTTON_RE })
     if (!(await submitButton.isVisible({ timeout: 3000 }).catch(() => false))) {
@@ -52,8 +50,7 @@ test.describe('Territory management', () => {
     await submitButton.click()
     await page.waitForLoadState('networkidle')
 
-    // Must stay on form page — validation error
-    await expect(page).toHaveURL(NEW_TERRITORY_URL_RE)
+    await expect(page).toHaveURL(NEW_ATTRIBUTION_URL_RE)
   })
 
   test('territories list page has expected structure', async ({ page }) => {
@@ -61,7 +58,6 @@ test.describe('Territory management', () => {
     await page.waitForLoadState('networkidle')
     await expect(page).toHaveURL(TERRITORIES_URL_RE)
 
-    // Page should not be blank
     const bodyText = await page.locator('body').innerText()
     expect(bodyText.length).toBeGreaterThan(0)
   })

--- a/app/tests/e2e/upload-document.spec.ts
+++ b/app/tests/e2e/upload-document.spec.ts
@@ -20,9 +20,8 @@ test.describe('Display board', () => {
     await expect(page).toHaveURL(BOARD_URL_RE)
   })
 
-  test('board management page is accessible', async ({ page }) => {
-    const response = await page.goto('/board/manage')
-    // Should load (200) or redirect to board, never a 500
+  test('board sections page is accessible', async ({ page }) => {
+    const response = await page.goto('/board/sections')
     expect(response?.status()).toBeLessThan(500)
   })
 


### PR DESCRIPTION
## Summary

- `/territories/new` does not exist in the router — territory creation is not a direct form flow. Replaced with `/territories/attributions/new` (the actual attribution creation route).
- `/board/manage` does not exist — board management is at `/board/sections`. Fixed the route.

Both tests were passing because the assertion was `status < 500` (404 < 500 = true), meaning they weren't actually validating real functionality.

## Test plan

- [ ] E2E: `territory-attribution.spec.ts` navigates to real routes
- [ ] E2E: `upload-document.spec.ts` navigates to `/board/sections` instead of the non-existent `/board/manage`
- [ ] CI passes without 404 errors in server logs