### PR TITLE
fix(board): show external speaker on live programme view

### DIFF
--- a/app/features/display-board/model/programme-display.test.ts
+++ b/app/features/display-board/model/programme-display.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/paraglide/messages', () => ({
+  board_read_status_anonymized_user: () => 'Anonyme',
+}))
+
+const { formatName, formatAssigneeWithAssistant, nameMatches, getPartDisplay, partMatchesQuery } = await import(
+  './programme-display'
+)
+
+function makeUser(firstname: string | null, lastname: string | null, anonymizedAt: Date | null = null) {
+  return { firstname, lastname, anonymizedAt }
+}
+
+function makePart(overrides: {
+  externalSpeakerName?: string | null
+  assignee?: ReturnType<typeof makeUser> | null
+  assistant?: ReturnType<typeof makeUser> | null
+}) {
+  return {
+    externalSpeakerName: overrides.externalSpeakerName ?? null,
+    assignee: overrides.assignee ?? null,
+    assistant: overrides.assistant ?? null,
+  }
+}
+
+describe('formatName', () => {
+  it('returns full name when both firstname and lastname are present', () => {
+    expect(formatName(makeUser('Jean', 'Dupont'))).toBe('Jean Dupont')
+  })
+
+  it('returns the available part when one is missing', () => {
+    expect(formatName(makeUser('Jean', null))).toBe('Jean')
+    expect(formatName(makeUser(null, 'Dupont'))).toBe('Dupont')
+  })
+
+  it('returns null for null user', () => {
+    expect(formatName(null)).toBeNull()
+  })
+
+  it('returns null when both name fields are empty', () => {
+    expect(formatName(makeUser(null, null))).toBeNull()
+  })
+
+  it('returns the anonymized placeholder when the user is anonymized', () => {
+    expect(formatName(makeUser('Jean', 'Dupont', new Date()))).toBe('Anonyme')
+  })
+})
+
+describe('formatAssigneeWithAssistant', () => {
+  it('joins assignee and assistant with a slash', () => {
+    expect(formatAssigneeWithAssistant('Jean', 'Marie')).toBe('Jean / Marie')
+  })
+
+  it('returns assignee alone when no assistant', () => {
+    expect(formatAssigneeWithAssistant('Jean', null)).toBe('Jean')
+  })
+
+  it('returns null when no assignee, regardless of assistant', () => {
+    expect(formatAssigneeWithAssistant(null, 'Marie')).toBeNull()
+    expect(formatAssigneeWithAssistant(null, null)).toBeNull()
+  })
+})
+
+describe('nameMatches', () => {
+  it('matches against the formatted name (caller is expected to lowercase the query)', () => {
+    expect(nameMatches(makeUser('Jean', 'Dupont'), 'jean')).toBe(true)
+    expect(nameMatches(makeUser('Jean', 'Dupont'), 'dupont')).toBe(true)
+    expect(nameMatches(makeUser('Jean', 'Dupont'), 'paul')).toBe(false)
+  })
+
+  it('returns false for null user', () => {
+    expect(nameMatches(null, 'jean')).toBe(false)
+  })
+
+  it('matches the anonymized placeholder', () => {
+    expect(nameMatches(makeUser('Jean', 'Dupont', new Date()), 'anon')).toBe(true)
+  })
+})
+
+describe('getPartDisplay', () => {
+  it('returns the external speaker name with isExternal=true when set', () => {
+    const part = makePart({ externalSpeakerName: 'Pierre Martin', assignee: makeUser('Jean', 'Dupont') })
+    expect(getPartDisplay(part)).toEqual({ text: 'Pierre Martin', isExternal: true })
+  })
+
+  it('prefers external speaker over internal assignee even when both are set', () => {
+    const part = makePart({
+      externalSpeakerName: 'Pierre Martin',
+      assignee: makeUser('Jean', 'Dupont'),
+      assistant: makeUser('Marie', 'Curie'),
+    })
+    expect(getPartDisplay(part)).toEqual({ text: 'Pierre Martin', isExternal: true })
+  })
+
+  it('returns assignee alone when no assistant and no external speaker', () => {
+    const part = makePart({ assignee: makeUser('Jean', 'Dupont') })
+    expect(getPartDisplay(part)).toEqual({ text: 'Jean Dupont', isExternal: false })
+  })
+
+  it('returns assignee / assistant when both are set', () => {
+    const part = makePart({ assignee: makeUser('Jean', 'Dupont'), assistant: makeUser('Marie', 'Curie') })
+    expect(getPartDisplay(part)).toEqual({ text: 'Jean Dupont / Marie Curie', isExternal: false })
+  })
+
+  it('returns null text when nothing is set', () => {
+    expect(getPartDisplay(makePart({}))).toEqual({ text: null, isExternal: false })
+  })
+
+  it('treats empty external speaker name as not external', () => {
+    const part = makePart({ externalSpeakerName: '', assignee: makeUser('Jean', 'Dupont') })
+    expect(getPartDisplay(part)).toEqual({ text: 'Jean Dupont', isExternal: false })
+  })
+})
+
+describe('partMatchesQuery', () => {
+  it('matches the external speaker name (caller is expected to lowercase the query)', () => {
+    const part = makePart({ externalSpeakerName: 'Pierre Martin' })
+    expect(partMatchesQuery(part, 'pierre')).toBe(true)
+    expect(partMatchesQuery(part, 'martin')).toBe(true)
+    expect(partMatchesQuery(part, 'paul')).toBe(false)
+  })
+
+  it('matches the assignee name', () => {
+    const part = makePart({ assignee: makeUser('Jean', 'Dupont') })
+    expect(partMatchesQuery(part, 'dupont')).toBe(true)
+  })
+
+  it('matches the assistant name', () => {
+    const part = makePart({ assignee: makeUser('Jean', 'Dupont'), assistant: makeUser('Marie', 'Curie') })
+    expect(partMatchesQuery(part, 'curie')).toBe(true)
+  })
+
+  it('returns false when no name matches', () => {
+    const part = makePart({
+      externalSpeakerName: 'Pierre Martin',
+      assignee: makeUser('Jean', 'Dupont'),
+      assistant: makeUser('Marie', 'Curie'),
+    })
+    expect(partMatchesQuery(part, 'paul')).toBe(false)
+  })
+
+  it('returns false when nothing is set', () => {
+    expect(partMatchesQuery(makePart({}), 'jean')).toBe(false)
+  })
+})

--- a/app/features/display-board/model/programme-display.ts
+++ b/app/features/display-board/model/programme-display.ts
@@ -1,0 +1,49 @@
+import * as m from '~/paraglide/messages'
+
+export type UserNameInfo = {
+  firstname: string | null
+  lastname: string | null
+  anonymizedAt: Date | null
+} | null
+
+export interface PartDisplayLike {
+  externalSpeakerName: string | null
+  assignee: UserNameInfo
+  assistant: UserNameInfo
+}
+
+export interface PartDisplay {
+  text: string | null
+  isExternal: boolean
+}
+
+export function formatName(user: UserNameInfo): string | null {
+  if (!user) return null
+  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user()
+  const name = [user.firstname, user.lastname].filter(Boolean).join(' ')
+  return name || null
+}
+
+export function formatAssigneeWithAssistant(assignee: string | null, assistant: string | null): string | null {
+  if (!assignee) return null
+  if (assistant) return `${assignee} / ${assistant}`
+  return assignee
+}
+
+export function nameMatches(user: UserNameInfo, query: string): boolean {
+  const name = formatName(user)
+  if (!name) return false
+  return name.toLowerCase().includes(query)
+}
+
+export function getPartDisplay(part: PartDisplayLike): PartDisplay {
+  if (part.externalSpeakerName) return { text: part.externalSpeakerName, isExternal: true }
+  const assigneeName = formatName(part.assignee)
+  const assistantName = formatName(part.assistant)
+  return { text: formatAssigneeWithAssistant(assigneeName, assistantName), isExternal: false }
+}
+
+export function partMatchesQuery(part: PartDisplayLike, query: string): boolean {
+  if (part.externalSpeakerName?.toLowerCase().includes(query)) return true
+  return nameMatches(part.assignee, query) || nameMatches(part.assistant, query)
+}

--- a/app/features/display-board/ui/dynamic/ProgrammeView.tsx
+++ b/app/features/display-board/ui/dynamic/ProgrammeView.tsx
@@ -2,6 +2,12 @@ import type { LucideIcon } from 'lucide-react'
 import { BookOpen, Calendar, ChevronRight, Gem, HeartHandshake } from 'lucide-react'
 import { type RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import type { ProgrammeDynamicConfig } from '~/features/display-board/model/dynamic-document.type'
+import {
+  formatName,
+  getPartDisplay,
+  nameMatches,
+  partMatchesQuery,
+} from '~/features/display-board/model/programme-display'
 import { groupPartsBySlot } from '~/features/events/model/group-parts-by-slot'
 import * as m from '~/paraglide/messages'
 import { Badge } from '~/shared/ui/badge'
@@ -53,6 +59,7 @@ interface PartAssignment {
   order: number
   topic: string
   durationMin: number | null
+  externalSpeakerName: string | null
   assignee: {
     id: number
     firstname: string | null
@@ -99,25 +106,6 @@ export interface ProgrammeViewData {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatName(
-  user: {
-    firstname: string | null
-    lastname: string | null
-    anonymizedAt: Date | null
-  } | null,
-): string | null {
-  if (!user) return null
-  if (user.anonymizedAt != null) return m.board_read_status_anonymized_user()
-  const name = [user.firstname, user.lastname].filter(Boolean).join(' ')
-  return name || null
-}
-
-function formatAssigneeWithAssistant(assignee: string | null, assistant: string | null): string | null {
-  if (!assignee) return null
-  if (assistant) return `${assignee} / ${assistant}`
-  return assignee
-}
-
 function formatDate(date: Date): string {
   return new Date(date).toLocaleDateString('fr-FR', {
     weekday: 'long',
@@ -146,19 +134,6 @@ function getMonth(date: Date): string {
   })
 }
 
-function nameMatches(
-  user: {
-    firstname: string | null
-    lastname: string | null
-    anonymizedAt: Date | null
-  } | null,
-  query: string,
-): boolean {
-  const name = formatName(user)
-  if (!name) return false
-  return name.toLowerCase().includes(query)
-}
-
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -176,9 +151,7 @@ function SectionHeader({ section, icon: Icon }: { section: string; icon?: Lucide
 }
 
 function PartRow({ part, highlighted, dimmed }: { part: PartAssignment; highlighted: boolean; dimmed: boolean }) {
-  const assigneeName = formatName(part.assignee)
-  const assistantName = formatName(part.assistant)
-  const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
+  const { text: rightText, isExternal } = getPartDisplay(part)
   const displayName = part.topic !== '' ? part.topic : part.name
 
   return (
@@ -197,11 +170,16 @@ function PartRow({ part, highlighted, dimmed }: { part: PartAssignment; highligh
       {rightText ? (
         <span
           className={cn(
-            'shrink-0 text-foreground text-sm',
+            'flex shrink-0 items-center gap-1.5 text-foreground text-sm',
             highlighted && 'rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40',
           )}
         >
           {rightText}
+          {isExternal && (
+            <Badge variant="secondary" className="text-[10px]">
+              {m.programs_view_external_badge()}
+            </Badge>
+          )}
         </span>
       ) : (
         <span className="shrink-0 text-muted-foreground/40 text-sm italic">&mdash;</span>
@@ -225,11 +203,9 @@ function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: stri
         )}
       </div>
       {parts.map((part, idx) => {
-        const assigneeName = formatName(part.assignee)
-        const assistantName = formatName(part.assistant)
-        const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
+        const { text: rightText, isExternal } = getPartDisplay(part)
         const trackName = part.track || `Salle ${idx + 1}`
-        const highlighted = hasQuery && (nameMatches(part.assignee, query) || nameMatches(part.assistant, query))
+        const highlighted = hasQuery && partMatchesQuery(part, query)
         const dimmed = hasQuery && !highlighted
 
         return (
@@ -246,11 +222,16 @@ function MultiTrackPart({ parts, query }: { parts: PartAssignment[]; query: stri
             {rightText ? (
               <span
                 className={cn(
-                  'shrink-0 text-foreground text-sm',
+                  'flex shrink-0 items-center gap-1.5 text-foreground text-sm',
                   highlighted && 'rounded-sm bg-amber-100 px-1 dark:bg-amber-900/40',
                 )}
               >
                 {rightText}
+                {isExternal && (
+                  <Badge variant="secondary" className="text-[10px]">
+                    {m.programs_view_external_badge()}
+                  </Badge>
+                )}
               </span>
             ) : (
               <span className="shrink-0 text-muted-foreground/40 text-sm italic">&mdash;</span>
@@ -531,8 +512,7 @@ export function ProgrammeView({ events, showServices, config, highlightQuery, sc
                       {slots.map(slot => {
                         if (slot.parts.length === 1) {
                           const part = slot.parts[0]
-                          const highlighted =
-                            hasQuery && (nameMatches(part.assignee, query) || nameMatches(part.assistant, query))
+                          const highlighted = hasQuery && partMatchesQuery(part, query)
                           const dimmed = hasQuery && !highlighted
 
                           return <PartRow key={part.id} part={part} highlighted={highlighted} dimmed={dimmed} />


### PR DESCRIPTION
## Summary

- Render external speaker names with an \`Ext.\` badge on the live programme view (single-track and multi-track parts)
- Extend the search highlight to match the external speaker name in addition to the assignee/assistant
- Extract \`getPartDisplay\`, \`partMatchesQuery\`, and the related name-formatting helpers to \`model/programme-display.ts\` with unit-test coverage

## Test plan

- [x] \`pnpm test:unit\` (801 passing, +22 new cases)
- [x] \`pnpm test:typecheck\`
- [x] \`pnpm test:lint\`
- [ ] Manually verify a programme part with an external speaker shows the name and \`Ext.\` badge in the dynamic document viewer
- [ ] Manually verify the search input dims/highlights rows by external speaker name