### PR TITLE
fix(territories): exclude entrances with no active buildings

### DIFF
--- a/app/features/territories/routes/territory/edit.tsx
+++ b/app/features/territories/routes/territory/edit.tsx
@@ -163,7 +163,10 @@ export function loader({ request, params, context }: Route.LoaderArgs) {
         },
       },
       include: {
-        entrances: { include: { buildings: { where: { active: true } } } },
+        entrances: {
+          where: { buildings: { some: { active: true } } },
+          include: { buildings: { where: { active: true } } },
+        },
       },
     });
 

--- a/app/features/territories/server/attributions.server.test.ts
+++ b/app/features/territories/server/attributions.server.test.ts
@@ -66,12 +66,26 @@ describe('findTerritoryWithHistory', () => {
         id_congregationId: { id: 10, congregationId: 1 },
       },
       include: {
-        entrances: { include: { buildings: { where: { active: true } } } },
+        entrances: {
+          where: { buildings: { some: { active: true } } },
+          include: { buildings: { where: { active: true } } },
+        },
         attributions: {
           include: { publisher: true },
           orderBy: [{ startDate: 'desc' }],
         },
       },
+    })
+  })
+
+  it('exclut les allées dont toutes les adresses sont désactivées dans la prospection', async () => {
+    vi.mocked(db.territory.findUnique).mockResolvedValue({ id: 10, entrances: [], attributions: [] } as never)
+
+    await findTerritoryWithHistory(db as never, 10, 1)
+
+    const call = vi.mocked(db.territory.findUnique).mock.calls[0]?.[0]
+    expect(call?.include?.entrances).toMatchObject({
+      where: { buildings: { some: { active: true } } },
     })
   })
 

--- a/app/features/territories/server/attributions.server.ts
+++ b/app/features/territories/server/attributions.server.ts
@@ -36,7 +36,10 @@ export function findTerritoryWithHistory(db: TransactionClient, territoryId: num
       id_congregationId: { id: territoryId, congregationId },
     },
     include: {
-      entrances: { include: { buildings: { where: { active: true } } } },
+      entrances: {
+        where: { buildings: { some: { active: true } } },
+        include: { buildings: { where: { active: true } } },
+      },
       attributions: {
         include: { publisher: true },
         orderBy: [{ startDate: 'desc' }],


### PR DESCRIPTION
## Summary
- Disabling every address on an entrance via the prospection module made the territory un-openable: the loader's `include` filtered buildings to `active: true`, so the entrance came back with an empty `buildings` array and `aggregateEntrance` crashed dereferencing `buildings[0].street`.
- Fix at the query layer in `findTerritoryWithHistory` and the territory edit loader by also requiring `buildings: { some: { active: true } }` on the `entrances` include — entrances with no active buildings are dropped instead of producing the broken shape. This matches the defensive `.filter(e => e.buildings.length > 0)` already present in `routes/my-territories/view.tsx`.
- Updates the existing `findTerritoryWithHistory` query-shape assertion and adds a regression test.

## Test plan
- [x] `pnpm test:unit`
- [x] `pnpm test:lint` (no new warnings on changed files)
- [x] `pnpm test:typecheck`
- [ ] Manual: pick a territory whose entrance has a single building; disable that building in prospection; confirm `/territories/territory/:id/view`, `/edit`, and the PDF download all render without 500 and the entrance no longer appears; re-enable and confirm it reappears.