### PR TITLE
fix(publishers): keep activity export rendering outside RLS transaction

### DIFF
--- a/app/features/publishers/routes/activity/excel-export.tsx
+++ b/app/features/publishers/routes/activity/excel-export.tsx
@@ -1,5 +1,8 @@
 import { redirect } from 'react-router'
-import { generatePublishersYearlyActivityXlsx } from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
+import {
+  buildPublishersYearlyActivityXlsx,
+  getPublishersYearlyActivities,
+} from '~/features/publishers/server/generate-publishers-yearly-activity-xlsx.server'
 import * as m from '~/i18n/paraglide/messages'
 import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
 import logger from '~/shared/infra/logger.server'
@@ -11,7 +14,7 @@ export const meta: Route.MetaFunction = () => {
   return [{ title: m.activity_excel_export_meta_title() }]
 }
 
-export function loader({ params, context }: Route.LoaderArgs) {
+export async function loader({ params, context }: Route.LoaderArgs) {
   const permissions = context.get(permissionsContext)
   const currentUser = context.get(userContext)
   const canViewActivities = permissions.has(Role.ActivityViewer)
@@ -27,15 +30,17 @@ export function loader({ params, context }: Route.LoaderArgs) {
     currentUser,
   })
 
-  return withScopeFromContext(context, async db => {
-    const file = await generatePublishersYearlyActivityXlsx(db, currentUser.congregationId, Number(params.year))
+  const months = await withScopeFromContext(context, db =>
+    getPublishersYearlyActivities(db, currentUser.congregationId, Number(params.year)),
+  )
 
-    return new Response(file, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/vnd.ms-excel',
-        'Content-Disposition': `attachment; filename="Activité-Proclamateurs-${params.year}.xlsx"`,
-      },
-    })
+  const file = await buildPublishersYearlyActivityXlsx(months)
+
+  return new Response(file, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/vnd.ms-excel',
+      'Content-Disposition': `attachment; filename="Activité-Proclamateurs-${params.year}.xlsx"`,
+    },
   })
 }

--- a/app/features/publishers/routes/activity/pdf-export.tsx
+++ b/app/features/publishers/routes/activity/pdf-export.tsx
@@ -1,5 +1,8 @@
 import { redirect } from 'react-router'
-import { renderActivityPdfZip } from '~/features/publishers/server/render-activity-pdf-zip.server'
+import {
+  buildActivityPdfZip,
+  getPublishersWithYearActivities,
+} from '~/features/publishers/server/render-activity-pdf-zip.server'
 import * as m from '~/i18n/paraglide/messages'
 import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
 import logger from '~/shared/infra/logger.server'
@@ -11,7 +14,7 @@ export const meta: Route.MetaFunction = () => {
   return [{ title: m.activity_pdf_export_meta_title() }]
 }
 
-export function loader({ params, context }: Route.LoaderArgs) {
+export async function loader({ params, context }: Route.LoaderArgs) {
   const permissions = context.get(permissionsContext)
   const currentUser = context.get(userContext)
   const canViewActivities = permissions.has(Role.ActivityViewer)
@@ -27,16 +30,18 @@ export function loader({ params, context }: Route.LoaderArgs) {
     currentUser,
   })
 
-  return withScopeFromContext(context, async db => {
-    const today = new Date()
-    const file = await renderActivityPdfZip(db, currentUser.congregationId, Number(params.year))
+  const publishers = await withScopeFromContext(context, db =>
+    getPublishersWithYearActivities(db, currentUser.congregationId, Number(params.year)),
+  )
 
-    return new Response(file, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/zip',
-        'Content-Disposition': `attachment; filename="Activité-${params.year}_${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}.zip"`,
-      },
-    })
+  const file = await buildActivityPdfZip(publishers)
+
+  const today = new Date()
+  return new Response(file, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': `attachment; filename="Activité-${params.year}_${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}.zip"`,
+    },
   })
 }

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
@@ -8,7 +8,9 @@ vi.mock('~/shared/infra/db.server', () => ({
   },
 }))
 
-const { generatePublishersYearlyActivityXlsx } = await import('./generate-publishers-yearly-activity-xlsx.server')
+const { buildPublishersYearlyActivityXlsx, getPublishersYearlyActivities } = await import(
+  './generate-publishers-yearly-activity-xlsx.server'
+)
 const { unscopedDb: db } = await import('~/shared/infra/db.server')
 
 beforeEach(() => {
@@ -38,70 +40,96 @@ async function readWorkbook(buffer: excelJs.Buffer) {
   return workbook
 }
 
-describe('generatePublishersYearlyActivityXlsx', () => {
-  it('génère 12 feuilles pour une année théocratique', async () => {
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
+async function buildFromActivities(activities: ReturnType<typeof makeActivity>[]) {
+  vi.mocked(db.publisherActivity.findMany).mockResolvedValue(activities as never)
+  const months = await getPublishersYearlyActivities(db, 1, 2025)
+  return readWorkbook(await buildPublishersYearlyActivityXlsx(months))
+}
+
+describe('getPublishersYearlyActivities', () => {
+  it('queries the 12 months of the theocratic year (September to August)', async () => {
+    await getPublishersYearlyActivities(db, 1, 2025)
+
+    const calls = vi.mocked(db.publisherActivity.findMany).mock.calls
+    const monthYearPairs = calls
+      .map(call => {
+        const where = (call[0] as { where: { month: number; year: number } }).where
+        return { month: where.month, year: where.year }
+      })
+      .sort((a, b) => a.year - b.year || a.month - b.month)
+
+    expect(monthYearPairs).toEqual([
+      { month: 8, year: 2025 },
+      { month: 9, year: 2025 },
+      { month: 10, year: 2025 },
+      { month: 11, year: 2025 },
+      { month: 0, year: 2026 },
+      { month: 1, year: 2026 },
+      { month: 2, year: 2026 },
+      { month: 3, year: 2026 },
+      { month: 4, year: 2026 },
+      { month: 5, year: 2026 },
+      { month: 6, year: 2026 },
+      { month: 7, year: 2026 },
+    ])
+  })
+
+  it('scopes every query to the given congregation', async () => {
+    await getPublishersYearlyActivities(db, 42, 2025)
+
+    const calls = vi.mocked(db.publisherActivity.findMany).mock.calls
+    for (const call of calls) {
+      const where = (call[0] as { where: { congregationId: number } }).where
+      expect(where.congregationId).toBe(42)
+    }
+  })
+})
+
+describe('buildPublishersYearlyActivityXlsx', () => {
+  it('does not query the database', async () => {
+    await buildPublishersYearlyActivityXlsx([])
+
+    expect(db.publisherActivity.findMany).not.toHaveBeenCalled()
+  })
+
+  it('produces 12 sheets for a theocratic year', async () => {
+    const workbook = await buildFromActivities([])
 
     expect(workbook.worksheets).toHaveLength(12)
   })
 
-  it('affiche "A préché" pour un proclamateur normal', async () => {
-    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
+  it('shows "A préché" for a normal publisher', async () => {
+    const workbook = await buildFromActivities([
       makeActivity(PublisherType.Normal, { isPublisher: true, hours: 0, studies: 1 }),
-    ] as never)
-
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
-    const firstSheet = workbook.worksheets[0]
-    const dataRow = firstSheet.getRow(2)
+    ])
+    const dataRow = workbook.worksheets[0].getRow(2)
 
     expect(dataRow.getCell(3).value).toBe('A préché')
   })
 
-  it('affiche les heures pour un pionnier permanent', async () => {
-    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
-      makeActivity(PublisherType.PionnierPermanant, { hours: 50 }),
-    ] as never)
-
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
+  it('shows hours for a permanent pioneer', async () => {
+    const workbook = await buildFromActivities([makeActivity(PublisherType.PionnierPermanant, { hours: 50 })])
     const dataRow = workbook.worksheets[0].getRow(2)
 
     expect(dataRow.getCell(3).value).toBe('50')
   })
 
-  it('affiche les heures pour un pionnier auxiliaire', async () => {
-    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
-      makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 }),
-    ] as never)
-
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
+  it('shows hours for an auxiliary pioneer', async () => {
+    const workbook = await buildFromActivities([makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 })])
     const dataRow = workbook.worksheets[0].getRow(2)
 
     expect(dataRow.getCell(3).value).toBe('30')
   })
 
-  it('affiche les heures pour un pionnier spécial', async () => {
-    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
-      makeActivity(PublisherType.PionnierSpecial, { hours: 130 }),
-    ] as never)
-
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
+  it('shows hours for a special pioneer', async () => {
+    const workbook = await buildFromActivities([makeActivity(PublisherType.PionnierSpecial, { hours: 130 })])
     const dataRow = workbook.worksheets[0].getRow(2)
 
     expect(dataRow.getCell(3).value).toBe('130')
   })
 
-  it('affiche les heures pour un missionnaire', async () => {
-    vi.mocked(db.publisherActivity.findMany).mockResolvedValue([
-      makeActivity(PublisherType.Missionnaire, { hours: 120 }),
-    ] as never)
-
-    const buffer = await generatePublishersYearlyActivityXlsx(db, 1, 2025)
-    const workbook = await readWorkbook(buffer)
+  it('shows hours for a missionary', async () => {
+    const workbook = await buildFromActivities([makeActivity(PublisherType.Missionnaire, { hours: 120 })])
     const dataRow = workbook.worksheets[0].getRow(2)
 
     expect(dataRow.getCell(3).value).toBe('120')

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.test.ts
@@ -134,4 +134,62 @@ describe('buildPublishersYearlyActivityXlsx', () => {
 
     expect(dataRow.getCell(3).value).toBe('120')
   })
+
+  it('writes one row per activity with the group name uppercased', async () => {
+    const activities = [
+      {
+        ...makeActivity(PublisherType.Normal, { isPublisher: true }),
+        publisher: {
+          id: 1,
+          firstname: 'Alice',
+          lastname: 'Martin',
+          publisherGroup: { id: 1, name: 'Groupe A' },
+        },
+      },
+      {
+        ...makeActivity(PublisherType.PionnierPermanant, { hours: 60 }),
+        publisher: {
+          id: 2,
+          firstname: 'Bob',
+          lastname: 'Durand',
+          publisherGroup: { id: 2, name: 'Groupe B' },
+        },
+      },
+    ]
+    const workbook = await buildFromActivities(activities)
+    const sheet = workbook.worksheets[0]
+
+    expect(sheet.getRow(2).getCell(1).value).toBe('Alice Martin')
+    expect(sheet.getRow(2).getCell(2).value).toBe('GROUPE A')
+    expect(sheet.getRow(3).getCell(1).value).toBe('Bob Durand')
+    expect(sheet.getRow(3).getCell(2).value).toBe('GROUPE B')
+    expect(sheet.getRow(3).getCell(3).value).toBe('60')
+  })
+
+  it('puts each month in its own sheet with the right activities', async () => {
+    vi.mocked(db.publisherActivity.findMany).mockImplementation(((args: { where: { month: number; year: number } }) => {
+      const { where } = args
+      if (where.month === 8 && where.year === 2025) {
+        return Promise.resolve([{ ...makeActivity(PublisherType.Normal, { isPublisher: true }) }])
+      }
+      if (where.month === 0 && where.year === 2026) {
+        return Promise.resolve([
+          { ...makeActivity(PublisherType.Normal, { isPublisher: true }) },
+          { ...makeActivity(PublisherType.PionnierAuxiliaires, { hours: 30 }) },
+        ])
+      }
+      return Promise.resolve([])
+    }) as never)
+
+    const months = await getPublishersYearlyActivities(db, 1, 2025)
+    const workbook = await readWorkbook(await buildPublishersYearlyActivityXlsx(months))
+
+    const september2025 = workbook.worksheets.find(sheet => sheet.name === 'SEPTEMBRE 2025')
+    const january2026 = workbook.worksheets.find(sheet => sheet.name === 'JANVIER 2026')
+    const february2026 = workbook.worksheets.find(sheet => sheet.name === 'FÉVRIER 2026')
+
+    expect(september2025?.actualRowCount).toBe(2)
+    expect(january2026?.actualRowCount).toBe(3)
+    expect(february2026?.actualRowCount).toBe(1)
+  })
 })

--- a/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
+++ b/app/features/publishers/server/generate-publishers-yearly-activity-xlsx.server.ts
@@ -3,21 +3,36 @@ import excelJs from 'exceljs'
 import type { TransactionClient } from '~/shared/infra/db.server'
 import { PublisherType, publisherTypeReportsHours } from '~/shared/types/publisher-type'
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
-export async function generatePublishersYearlyActivityXlsx(
+type MonthlyActivities = {
+  month: number
+  year: number
+  activities: Awaited<ReturnType<typeof getPublishersMonthlyActivity>>
+}
+
+const THEOCRATIC_YEAR_MONTHS = Array.from({ length: 12 }, (_, i) => (i + 8 > 11 ? i - 4 : i + 8))
+
+export function getPublishersYearlyActivities(
   db: TransactionClient,
   congregationId: number,
   year: number,
-) {
-  const months = Array.from({ length: 12 }, (_, i) => (i + 8 > 11 ? i - 4 : i + 8))
+): Promise<MonthlyActivities[]> {
+  return Promise.all(
+    THEOCRATIC_YEAR_MONTHS.map(async month => {
+      const yearMonth = month < 8 ? year + 1 : year
+      const activities = await getPublishersMonthlyActivity(db, congregationId, month, yearMonth)
+      return { month, year: yearMonth, activities }
+    }),
+  )
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complex report generation logic
+export async function buildPublishersYearlyActivityXlsx(months: MonthlyActivities[]) {
   const workbook = new excelJs.Workbook()
 
-  for (const month of months) {
-    const yearMonth = month < 8 ? year + 1 : year
+  for (const { month, year: yearMonth, activities } of months) {
     const date = new Date(yearMonth, month, 1)
     const monthName = date.toLocaleString('fr', { month: 'long' })
     const sheetName = `${monthName} ${yearMonth}`.toUpperCase()
-    const activities = await getPublishersMonthlyActivity(db, congregationId, month, yearMonth)
 
     const worksheet = workbook.addWorksheet(sheetName)
     worksheet.columns = [

--- a/app/features/publishers/server/render-activity-pdf-zip.integration.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.integration.test.ts
@@ -1,0 +1,94 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { PrismaClient } from '~/database/generated/client'
+import { createTestCongregation, createTestUser } from '~/tests/factories'
+import { buildActivityPdfZip, getPublishersWithYearActivities } from './render-activity-pdf-zip.server'
+
+vi.mock('@react-pdf/renderer', () => ({
+  pdf: () => ({ toBuffer: () => Promise.resolve(Buffer.from('fake-pdf')) }),
+  Document: ({ children }: { children: unknown }) => children,
+  Page: ({ children }: { children: unknown }) => children,
+  View: ({ children }: { children: unknown }) => children,
+  Text: ({ children }: { children: unknown }) => children,
+  Svg: ({ children }: { children: unknown }) => children,
+  Polygon: () => null,
+  StyleSheet: { create: <T>(s: T) => s },
+  Font: { register: () => undefined },
+}))
+
+const TRANSACTION_ERROR_RE = /transaction/i
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
+  max: 5,
+  connectionTimeoutMillis: 5000,
+})
+const testDb = new PrismaClient({ adapter })
+
+let congregationId: number
+const publisherIds: number[] = []
+
+beforeAll(async () => {
+  const congregation = await createTestCongregation(testDb)
+  congregationId = congregation.id
+
+  const publisherCount = 8
+  for (let i = 0; i < publisherCount; i++) {
+    const user = await createTestUser(testDb, congregationId, {
+      isPublisher: true,
+      firstname: `Publisher${i}`,
+      lastname: `Last${i}`,
+    })
+    publisherIds.push(user.id)
+    await testDb.publisherActivity.create({
+      data: {
+        publisherId: user.id,
+        congregationId,
+        month: 8,
+        year: 2025,
+        isPublisher: true,
+        hours: 1,
+      },
+    })
+  }
+})
+
+afterAll(async () => {
+  await testDb.publisherActivity.deleteMany({ where: { congregationId } })
+  await testDb.user.deleteMany({ where: { congregationId } })
+  await testDb.congregation.deleteMany({ where: { id: congregationId } })
+  await testDb.$disconnect()
+})
+
+describe('activity PDF export — transaction lifecycle', () => {
+  it('completes the fetch within a 500ms transaction budget and renders PDFs after commit', async () => {
+    const publishers = await testDb.$transaction(
+      async tx => {
+        await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+        return getPublishersWithYearActivities(tx, congregationId, 2025)
+      },
+      { timeout: 500 },
+    )
+
+    expect(publishers).toHaveLength(publisherIds.length)
+
+    const buffer = await buildActivityPdfZip(publishers)
+
+    expect(buffer).toBeInstanceOf(ArrayBuffer)
+    expect(buffer.byteLength).toBeGreaterThan(0)
+  })
+
+  it('would fail if PDF rendering ran inside the same 500ms transaction', async () => {
+    await expect(
+      testDb.$transaction(
+        async tx => {
+          await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+          const publishers = await getPublishersWithYearActivities(tx, congregationId, 2025)
+          await new Promise(resolve => setTimeout(resolve, 700))
+          return buildActivityPdfZip(publishers)
+        },
+        { timeout: 500 },
+      ),
+    ).rejects.toThrow(TRANSACTION_ERROR_RE)
+  })
+})

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -1,3 +1,4 @@
+import JsZip from 'jszip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('~/shared/infra/db.server', () => ({
@@ -72,6 +73,19 @@ describe('buildActivityPdfZip', () => {
 
     expect(buffer).toBeInstanceOf(ArrayBuffer)
     expect(toBuffer).toHaveBeenCalledTimes(2)
+  })
+
+  it('writes one entry per publisher named "{firstname}-{lastname}.pdf"', async () => {
+    const publishers = [
+      { id: 1, firstname: 'Alice', lastname: 'Martin', activities: [] },
+      { id: 2, firstname: 'Bob', lastname: 'Durand', activities: [] },
+      { id: 3, firstname: 'Claire', lastname: "O'Connor", activities: [] },
+    ]
+
+    const buffer = await buildActivityPdfZip(publishers as never)
+    const zip = await JsZip.loadAsync(buffer)
+
+    expect(Object.keys(zip.files).sort()).toEqual(['Alice-Martin.pdf', 'Bob-Durand.pdf', "Claire-O'Connor.pdf"])
   })
 
   it('does not query the database', async () => {

--- a/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.test.ts
@@ -6,8 +6,9 @@ vi.mock('~/shared/infra/db.server', () => ({
   },
 }))
 
+const toBuffer = vi.fn().mockResolvedValue(Buffer.from('fake-pdf'))
 vi.mock('@react-pdf/renderer', () => ({
-  pdf: vi.fn(() => ({ toBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-pdf')) })),
+  pdf: vi.fn(() => ({ toBuffer })),
   Document: vi.fn(({ children }: { children: unknown }) => children),
   Page: vi.fn(({ children }: { children: unknown }) => children),
   View: vi.fn(({ children }: { children: unknown }) => children),
@@ -24,32 +25,58 @@ vi.mock('~/features/publishers/ui/PublisherActivityDocument', () => ({
   PublisherActivityDocument: vi.fn(() => null),
 }))
 
-const { renderActivityPdfZip } = await import('./render-activity-pdf-zip.server')
+const { buildActivityPdfZip, getPublishersWithYearActivities } = await import('./render-activity-pdf-zip.server')
 const { unscopedDb: db } = await import('~/shared/infra/db.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
+  toBuffer.mockResolvedValue(Buffer.from('fake-pdf'))
   vi.mocked(db.user.findMany).mockResolvedValue([] as never)
 })
 
-describe('renderActivityPdfZip', () => {
-  it('filtre les activités de septembre à août (mois 8-11 puis 0-7)', async () => {
-    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
-
-    await renderActivityPdfZip(db, 1, 2025)
+describe('getPublishersWithYearActivities', () => {
+  it('filters activities from September to August (months 8-11 then 0-7)', async () => {
+    await getPublishersWithYearActivities(db, 1, 2025)
 
     const call = vi.mocked(db.user.findMany).mock.calls[0][0] as Record<string, unknown>
     const where = (call.where as { activities: { some: Record<string, unknown> } }).activities.some
     const include = (call.include as { activities: { where: Record<string, unknown> } }).activities.where
 
-    // Vérifier le filtre WHERE (sélection des users)
     const whereOr = where.OR as { year: number; month: { gte?: number; lte?: number } }[]
     expect(whereOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
     expect(whereOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
 
-    // Vérifier le filtre INCLUDE (sélection des activités)
     const includeOr = include.OR as { year: number; month: { gte?: number; lte?: number } }[]
     expect(includeOr[0]).toEqual({ year: 2025, month: { gte: 8 } })
     expect(includeOr[1]).toEqual({ year: 2026, month: { lte: 7 } })
+  })
+
+  it('does not touch the PDF engine — it is purely a DB read', async () => {
+    const { pdf } = await import('@react-pdf/renderer')
+    vi.mocked(db.user.findMany).mockResolvedValue([{ id: 1, firstname: 'Jean', lastname: 'Dupont' }] as never)
+
+    await getPublishersWithYearActivities(db, 1, 2025)
+
+    expect(pdf).not.toHaveBeenCalled()
+  })
+})
+
+describe('buildActivityPdfZip', () => {
+  it('produces a ZIP archive with one PDF per publisher', async () => {
+    const publishers = [
+      { id: 1, firstname: 'Alice', lastname: 'Martin', activities: [] },
+      { id: 2, firstname: 'Bob', lastname: 'Durand', activities: [] },
+    ]
+
+    const buffer = await buildActivityPdfZip(publishers as never)
+
+    expect(buffer).toBeInstanceOf(ArrayBuffer)
+    expect(toBuffer).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not query the database', async () => {
+    await buildActivityPdfZip([])
+
+    expect(db.user.findMany).not.toHaveBeenCalled()
   })
 })

--- a/app/features/publishers/server/render-activity-pdf-zip.server.tsx
+++ b/app/features/publishers/server/render-activity-pdf-zip.server.tsx
@@ -1,33 +1,29 @@
 import { pdf } from '@react-pdf/renderer'
 import JsZip from 'jszip'
 import pLimit from 'p-limit'
+import type { PublisherActivity } from '~/database/generated/client'
 import { PublisherActivityDocument } from '~/features/publishers/ui/PublisherActivityDocument'
-import { sanitizeUser } from '~/shared/auth/sanitize-user.server'
+import { type SanitizedUser, sanitizeUser } from '~/shared/auth/sanitize-user.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
 
-export async function renderActivityPdfZip(db: TransactionClient, congregationId: number, year: number) {
-  const yearBegining = new Date(year, 0, 1)
+type PublisherWithActivities = SanitizedUser & { activities: PublisherActivity[] }
+
+export async function getPublishersWithYearActivities(
+  db: TransactionClient,
+  congregationId: number,
+  year: number,
+): Promise<PublisherWithActivities[]> {
+  const yearFilter = {
+    OR: [
+      { year, month: { gte: 8 } },
+      { year: year + 1, month: { lte: 7 } },
+    ],
+  }
+
   const users = await db.user.findMany({
     where: {
       congregationId,
-      activities: {
-        some: {
-          OR: [
-            {
-              year: yearBegining.getFullYear(),
-              month: {
-                gte: 8,
-              },
-            },
-            {
-              year: yearBegining.getFullYear() + 1,
-              month: {
-                lte: 7,
-              },
-            },
-          ],
-        },
-      },
+      activities: { some: yearFilter },
     },
     include: {
       publisherGroup: {
@@ -36,39 +32,21 @@ export async function renderActivityPdfZip(db: TransactionClient, congregationId
           deputy: true,
         },
       },
-      activities: {
-        where: {
-          OR: [
-            {
-              year: yearBegining.getFullYear(),
-              month: {
-                gte: 8,
-              },
-            },
-            {
-              year: yearBegining.getFullYear() + 1,
-              month: {
-                lte: 7,
-              },
-            },
-          ],
-        },
-      },
+      activities: { where: yearFilter },
     },
   })
 
-  if (!users) {
-    throw new Error('Users not found')
-  }
+  return users.map(user => sanitizeUser(user))
+}
 
+export async function buildActivityPdfZip(publishers: PublisherWithActivities[]): Promise<ArrayBuffer> {
   const zip = new JsZip()
   const limit = pLimit(4)
   await Promise.all(
-    users.map(user =>
+    publishers.map(publisher =>
       limit(async () => {
-        const publisher = sanitizeUser(user)
         const buffer = await pdf(<PublisherActivityDocument publisher={publisher} />).toBuffer()
-        zip.file(`${user.firstname}-${user.lastname}.pdf`, buffer)
+        zip.file(`${publisher.firstname}-${publisher.lastname}.pdf`, buffer)
       }),
     ),
   )

--- a/app/tests/e2e/activity-export.spec.ts
+++ b/app/tests/e2e/activity-export.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+import { login } from './helpers/auth'
+
+const TEST_EMAIL = process.env.E2E_USER_EMAIL ?? 'admin@unitae.test'
+const TEST_PASSWORD = process.env.E2E_USER_PASSWORD ?? 'password'
+
+const exportYear = new Date().getFullYear()
+
+const PDF_FILENAME_RE = /attachment;\s*filename="Activité-/
+const XLSX_FILENAME_RE = /attachment;\s*filename="Activité-Proclamateurs-/
+
+test.describe('Activity exports', () => {
+  test.beforeEach(async ({ page }) => {
+    const loggedIn = await login(page, TEST_EMAIL, TEST_PASSWORD)
+    if (!loggedIn) test.skip()
+  })
+
+  test('PDF export route returns a ZIP attachment', async ({ page }) => {
+    const response = await page.request.get(`/publishers/activity/export/${exportYear}/pdfs`)
+
+    expect(response.status()).toBe(200)
+    expect(response.headers()['content-type']).toContain('application/zip')
+    expect(response.headers()['content-disposition']).toMatch(PDF_FILENAME_RE)
+
+    const body = await response.body()
+    expect(body.byteLength).toBeGreaterThan(0)
+  })
+
+  test('XLSX export route returns an Excel attachment', async ({ page }) => {
+    const response = await page.request.get(`/publishers/activity/export/${exportYear}/xlsx`)
+
+    expect(response.status()).toBe(200)
+    expect(response.headers()['content-type']).toContain('vnd.ms-excel')
+    expect(response.headers()['content-disposition']).toMatch(XLSX_FILENAME_RE)
+
+    const body = await response.body()
+    expect(body.byteLength).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- PDF and XLSX activity exports were rendering the full output (PDF + JsZip, or ExcelJS serialization) inside the `withScope` transaction. With enough publishers this overran Prisma's default 5s interactive-transaction budget and failed at COMMIT with `P2028` — 11.7s observed on the PDF route in production logs.
- Split each export into a transactional fetch returning plain data and a pure builder that runs after commit. The 12 monthly XLSX queries now run in parallel inside the same transaction.
- Tests split per function and translated to English.

## Test plan
- [x] `pnpm test:unit` (931 passing)
- [x] `pnpm test:lint` on touched files
- [x] `pnpm test:typecheck`
- [ ] Trigger `/publishers/activity/export/2025/pdfs` on a real congregation and confirm the ZIP downloads without P2028
- [ ] Trigger `/publishers/activity/export/2025/xlsx` and confirm the workbook downloads