### PR TITLE
chore(deps): apply prefixed labels to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    labels:
+      - "type: dependencies"
+      - "area: infra"
     groups:
       github-actions:
         patterns:
@@ -17,6 +20,8 @@ updates:
       day: "monday"
     cooldown:
       default-days: 5
+    labels:
+      - "type: dependencies"
     groups:
       patch-and-minor:
         update-types:
@@ -30,3 +35,6 @@ updates:
       day: "monday"
     cooldown:
       default-days: 8
+    labels:
+      - "type: dependencies"
+      - "area: infra"


### PR DESCRIPTION
## Summary
- Tag all Dependabot-opened PRs with `type: dependencies`
- Tag github-actions and docker ecosystem PRs with `area: infra`

Follows the prefixed-label taxonomy now in use across open issues.

## Test plan
- [ ] Next Dependabot PR carries the new labels