### PR TITLE
refactor(auth): source permission descriptions from i18n only

### DIFF
--- a/app/database/migrations/20260508000000_drop_permission_description/migration.sql
+++ b/app/database/migrations/20260508000000_drop_permission_description/migration.sql
@@ -1,0 +1,4 @@
+-- Drop the unused "description" column from "Permission". Translations are sourced from
+-- Paraglide messages keyed by "Permission"."key", so the column carried no runtime value.
+
+ALTER TABLE "Permission" DROP COLUMN "description";

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -162,9 +162,8 @@ model User {
 }
 
 model Permission {
-  id          Int    @id @default(autoincrement())
-  key         String @unique
-  description String @default("")
+  id                      Int                          @id @default(autoincrement())
+  key                     String                       @unique
   congregationPermissions CongregationUserPermission[]
 }
 

--- a/app/features/settings/routes/users/edit-user.tsx
+++ b/app/features/settings/routes/users/edit-user.tsx
@@ -34,24 +34,28 @@ import { requireParamId } from '~/shared/utils/params.server'
 
 import type { Route } from './+types/edit-user'
 
+// Exhaustive over Permission so TypeScript flags any new value missing a description.
+const PERMISSION_DESCRIPTIONS: Record<Permission, () => string> = {
+  [Permission.Admin]: () => m.permission_desc_admin(),
+  [Permission.BoardUploader]: () => m.permission_desc_board_uploader(),
+  [Permission.BoardValidator]: () => m.permission_desc_board_validator(),
+  [Permission.TerritoriesViewer]: () => m.permission_desc_territories_viewer(),
+  [Permission.TerritoriesManager]: () => m.permission_desc_territories_manager(),
+  [Permission.SettingsUserManager]: () => m.permission_desc_settings_user_manager(),
+  [Permission.PublisherViewer]: () => m.permission_desc_publisher_viewer(),
+  [Permission.PublisherManager]: () => m.permission_desc_publisher_manager(),
+  [Permission.ActivityManager]: () => m.permission_desc_activity_manager(),
+  [Permission.ActivityViewer]: () => m.permission_desc_activity_viewer(),
+  [Permission.ProgramViewer]: () => m.permission_desc_program_viewer(),
+  [Permission.ProgramManager]: () => m.permission_desc_program_manager(),
+  [Permission.ProspectionViewer]: () => m.permission_desc_prospection_viewer(),
+  [Permission.ProspectionManager]: () => m.permission_desc_prospection_manager(),
+  [Permission.ExternalSpeakerViewer]: () => m.permission_desc_external_speaker_viewer(),
+  [Permission.ExternalSpeakerManager]: () => m.permission_desc_external_speaker_manager(),
+}
+
 function getPermissionDescription(key: string): string {
-  const descriptions: Record<string, () => string> = {
-    admin: () => m.permission_desc_admin(),
-    'board-uploader': () => m.permission_desc_board_uploader(),
-    'board-validator': () => m.permission_desc_board_validator(),
-    'territories-viewer': () => m.permission_desc_territories_viewer(),
-    'territories-manager': () => m.permission_desc_territories_manager(),
-    'settings-user-manager': () => m.permission_desc_settings_user_manager(),
-    'publisher-viewer': () => m.permission_desc_publisher_viewer(),
-    'publisher-manager': () => m.permission_desc_publisher_manager(),
-    'activity-manager': () => m.permission_desc_activity_manager(),
-    'activity-viewer': () => m.permission_desc_activity_viewer(),
-    'program-viewer': () => m.permission_desc_program_viewer(),
-    'program-manager': () => m.permission_desc_program_manager(),
-    'prospection-viewer': () => m.permission_desc_prospection_viewer(),
-    'prospection-manager': () => m.permission_desc_prospection_manager(),
-  }
-  return descriptions[key]?.() ?? key
+  return PERMISSION_DESCRIPTIONS[key as Permission]?.() ?? key
 }
 
 export const meta: Route.MetaFunction = () => {

--- a/app/features/settings/server/export-user-data.server.test.ts
+++ b/app/features/settings/server/export-user-data.server.test.ts
@@ -42,7 +42,7 @@ describe('exportUserData', () => {
 
     mockDb.user.findUnique.mockResolvedValue(fakeUser as never)
     mockDb.congregationUserPermission.findMany.mockResolvedValue([
-      { permission: { key: 'Admin', description: 'Administrateur' } },
+      { permission: { key: 'Admin' } },
     ] as never)
     mockDb.publisherActivity.findMany.mockResolvedValue([
       { month: 3, year: 2025, hours: 10, studies: 1, type: 'normal', isPublisher: true, notes: '' },
@@ -71,7 +71,7 @@ describe('exportUserData', () => {
     const result = await exportUserData(mockDb as never, 1)
 
     expect(result.user).toEqual(fakeUser)
-    expect(result.permissions).toEqual([{ key: 'Admin', description: 'Administrateur' }])
+    expect(result.permissions).toEqual([{ key: 'Admin' }])
     expect(result.publisherActivities).toHaveLength(1)
     expect(result.attributions).toHaveLength(1)
     expect(result.publisherGroup).not.toBeNull()

--- a/app/features/settings/server/export-user-data.server.ts
+++ b/app/features/settings/server/export-user-data.server.ts
@@ -52,7 +52,7 @@ export async function exportUserData(db: TransactionClient, userId: number): Pro
       db.congregationUserPermission.findMany({
         where: { userId },
         select: {
-          permission: { select: { key: true, description: true } },
+          permission: { select: { key: true } },
         },
       }),
       db.publisherActivity.findMany({

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -1963,6 +1963,8 @@
     "permission_desc_program_manager": "Can manage congregation programs (edit)",
     "permission_desc_prospection_viewer": "Can view territory prospecting data",
     "permission_desc_prospection_manager": "Can manage territory prospecting data (edit)",
+    "permission_desc_external_speaker_viewer": "Can view the external speakers registry",
+    "permission_desc_external_speaker_manager": "Can manage the external speakers registry (create, edit, archive)",
     "seed_event_kind_absence": "Absence",
     "seed_template_midweek": "Midweek meeting",
     "seed_template_weekend": "Weekend meeting",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -1966,6 +1966,8 @@
     "permission_desc_program_manager": "Peut gérer les programmes de l'assemblée (modifier)",
     "permission_desc_prospection_viewer": "Peut voir les données de prospection du territoires",
     "permission_desc_prospection_manager": "Peut gérer les données de prospection du territoires (modifier)",
+    "permission_desc_external_speaker_viewer": "Peut consulter le registre des orateurs externes",
+    "permission_desc_external_speaker_manager": "Peut gérer le registre des orateurs externes (créer, modifier, archiver)",
     "seed_event_kind_absence": "Absence",
     "seed_template_midweek": "Réunion de semaine",
     "seed_template_weekend": "Réunion du week-end",

--- a/app/shared/domain/setup.server.ts
+++ b/app/shared/domain/setup.server.ts
@@ -5,38 +5,19 @@ import { Permission } from '~/shared/types/permission'
 
 type Locale = (typeof locales)[number]
 
-const PERMISSION_DESCRIPTIONS: Record<Permission, string> = {
-  [Permission.Admin]: "Peut administrer l'application",
-  [Permission.BoardUploader]: "Peut téléverser de nouveaux documents sur le tableau d'affichage",
-  [Permission.BoardValidator]: "Peut valider les documents sur le tableau d'affichage et les rendre visibles",
-  [Permission.TerritoriesViewer]: 'Peut voir les listes de territoires et les attributations',
-  [Permission.TerritoriesManager]: 'Peut gérer les territoires (créer, modifier, supprimer)',
-  [Permission.ProspectionViewer]: 'Peut voir les données de prospection du territoires',
-  [Permission.ProspectionManager]: 'Peut gérer les données de prospection du territoires (modifier)',
-  [Permission.SettingsUserManager]: 'Peut gérer les utilisateurs (créer, modifier, supprimer)',
-  [Permission.PublisherViewer]: 'Peut voir les proclamateurs',
-  [Permission.PublisherManager]: 'Peut gérer les proclamateurs (créer, modifier, supprimer)',
-  [Permission.ActivityViewer]: `Peut voir l'activité des proclamateurs`,
-  [Permission.ActivityManager]: `Peut gérer l'activité des proclamateurs (modifier)`,
-  [Permission.ProgramViewer]: `Peut voir les programmes de l'assemblée`,
-  [Permission.ProgramManager]: `Peut gérer les programmes de l'assemblée (modifier)`,
-  [Permission.ExternalSpeakerViewer]: 'Peut consulter le registre des orateurs externes',
-  [Permission.ExternalSpeakerManager]: 'Peut gérer le registre des orateurs externes (créer, modifier, archiver)',
-}
-
 /**
  * Ensure all Permission rows exist. Uses upsert so it is safe to call on every
- * setup / registration — existing permissions are updated, missing ones are created.
+ * setup / registration — existing permissions are kept, missing ones are created.
  *
  * Called from setup (single-tenant), registration (multi-tenant), and the seed script.
  */
 // biome-ignore lint/suspicious/noExplicitAny: accepts both PrismaClient and scoped transaction client
 export async function seedPermissions(db: any) {
-  for (const [key, description] of Object.entries(PERMISSION_DESCRIPTIONS)) {
+  for (const key of Object.values(Permission)) {
     await db.permission.upsert({
       where: { key },
-      update: { description },
-      create: { key, description },
+      update: {},
+      create: { key },
     })
   }
 }


### PR DESCRIPTION
## Summary
- Drop the dead `Permission.description` column (UI has been reading from Paraglide all along) — schema, migration, seed, and GDPR export shape updated.
- Closes #136 — adds missing `permission_desc_external_speaker_viewer` / `_manager` in fr.json + en.json, and re-types the edit-user lookup as `Record<Permission, () => string>` so TypeScript flags any future Permission missing a description.

## Test plan
- [x] `pnpm prisma generate`
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint`
- [x] `pnpm test:unit` (934 passing)
- [x] `pnpm db:migrate` applied locally
- [x] `pnpm test:integration` (96 passing)
- [ ] Manual: open `/settings/users/:userId/edit`, confirm both external-speaker permissions render localised text in FR + EN

## Notes
- Control-plane `schema.prisma` is still on the pre-#152 names (`UserRole` / `CongregationUserRole` with `description`). The control-plane sync will need to land both the rename and this column drop together.