### PR TITLE
fix(publishers): keep search input visible when no results match

### DIFF
--- a/app/features/publishers/routes/publishers/publisher-list.tsx
+++ b/app/features/publishers/routes/publishers/publisher-list.tsx
@@ -54,14 +54,15 @@ export function loader({ request, context }: Route.LoaderArgs) {
       })),
       canManagePublisher,
       canViewActivities,
+      searchQuery: search ?? '',
     }
   })
 }
 
 export default function PublisherListPage({ loaderData }: Route.ComponentProps) {
-  const { users, canManagePublisher, canViewActivities } = loaderData
+  const { users, canManagePublisher, canViewActivities, searchQuery } = loaderData
 
-  if (users.length < 1) {
+  if (users.length < 1 && searchQuery.length < 1) {
     return (
       <div className="flex flex-col gap-6">
         <PageHeader
@@ -108,67 +109,75 @@ export default function PublisherListPage({ loaderData }: Route.ComponentProps) 
 
       <SearchInput placeholder={m.publishers_search_placeholder()} />
 
-      <div className="overflow-hidden rounded-xl border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="text-center max-sm:text-left">{m.publishers_table_firstname()}</TableHead>
-              <TableHead className="text-center">{m.publishers_table_lastname()}</TableHead>
-              <TableHead className="text-center">{m.publishers_table_group()}</TableHead>
-              <TableHead className="text-center max-sm:hidden">{m.publishers_table_contact()}</TableHead>
-              <TableHead className="w-0">
-                <span className="sr-only">Actions</span>
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {users.map(user => (
-              <TableRow key={user.email}>
-                <TableCell className="text-center max-sm:text-left">
-                  <Link to={`/publishers/${user.id}/view`} className="hover:text-primary">
-                    {user.firstname}
-                  </Link>
-                </TableCell>
-                <TableCell className="text-center">
-                  <Link to={`/publishers/${user.id}/view`} className="hover:text-primary">
-                    {user.lastname?.toLocaleUpperCase()}
-                  </Link>
-                </TableCell>
-                <TableCell className="text-center">
-                  {user.publisherGroup != null && (
-                    <Link to={`/groups/${user.publisherGroup.id}/edit`} className="hover:text-primary">
-                      {user.publisherGroup.name}
+      {users.length < 1 ? (
+        <EmptyState
+          icon={Users}
+          title={m.publishers_empty_no_match_title()}
+          description={m.publishers_empty_no_match_description({ query: searchQuery })}
+        />
+      ) : (
+        <div className="overflow-hidden rounded-xl border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-center max-sm:text-left">{m.publishers_table_firstname()}</TableHead>
+                <TableHead className="text-center">{m.publishers_table_lastname()}</TableHead>
+                <TableHead className="text-center">{m.publishers_table_group()}</TableHead>
+                <TableHead className="text-center max-sm:hidden">{m.publishers_table_contact()}</TableHead>
+                <TableHead className="w-0">
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map(user => (
+                <TableRow key={user.email}>
+                  <TableCell className="text-center max-sm:text-left">
+                    <Link to={`/publishers/${user.id}/view`} className="hover:text-primary">
+                      {user.firstname}
                     </Link>
-                  )}
-                </TableCell>
-                <TableCell className="text-center max-sm:hidden">
-                  {user.email.includes('@placeholder.unitae.app') === false && (
-                    <Link to={`mailto:${user.email}`} className="hover:text-primary">
-                      <Mail className="inline size-4" />
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Link to={`/publishers/${user.id}/view`} className="hover:text-primary">
+                      {user.lastname?.toLocaleUpperCase()}
                     </Link>
-                  )}
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    <Button asChild variant="ghost" size="icon">
-                      <Link to={`/publishers/${user.id}/view`}>
-                        <Eye className="size-4" />
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {user.publisherGroup != null && (
+                      <Link to={`/groups/${user.publisherGroup.id}/edit`} className="hover:text-primary">
+                        {user.publisherGroup.name}
                       </Link>
-                    </Button>
-                    {canManagePublisher && (
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center max-sm:hidden">
+                    {user.email.includes('@placeholder.unitae.app') === false && (
+                      <Link to={`mailto:${user.email}`} className="hover:text-primary">
+                        <Mail className="inline size-4" />
+                      </Link>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-1">
                       <Button asChild variant="ghost" size="icon">
-                        <Link to={`./${user.id}/edit`}>
-                          <Pencil className="size-4" />
+                        <Link to={`/publishers/${user.id}/view`}>
+                          <Eye className="size-4" />
                         </Link>
                       </Button>
-                    )}
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+                      {canManagePublisher && (
+                        <Button asChild variant="ghost" size="icon">
+                          <Link to={`./${user.id}/edit`}>
+                            <Pencil className="size-4" />
+                          </Link>
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/features/publishers/server/publishers.integration.test.ts
+++ b/app/features/publishers/server/publishers.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { PrismaClient } from '~/database/generated/client'
 import type { CongregationId, UserId } from '~/shared/types/branded'
 import { createTestCongregation, createTestUser } from '~/tests/factories'
-import { getPublisherById } from './publishers.server'
+import { getPublisherById, getPublishersWithGroup } from './publishers.server'
 
 const adapter = new PrismaPg({
   connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
@@ -62,5 +62,76 @@ describe('getPublisherById', () => {
     )
 
     expect(publisher).toBeNull()
+  })
+})
+
+describe('getPublishersWithGroup search filter', () => {
+  let searchCongregationId: number
+  const searchSuffix = Date.now()
+  const expectedFirstname = `SearchableFirst-${searchSuffix}`
+  const expectedLastname = `SearchableLast-${searchSuffix}`
+  const otherFirstname = `OtherFirst-${searchSuffix}`
+  const otherLastname = `OtherLast-${searchSuffix}`
+
+  beforeAll(async () => {
+    const cong = await createTestCongregation(testDb)
+    searchCongregationId = cong.id
+
+    await createTestUser(testDb, searchCongregationId, {
+      isPublisher: true,
+      firstname: expectedFirstname,
+      lastname: expectedLastname,
+    })
+    await createTestUser(testDb, searchCongregationId, {
+      isPublisher: true,
+      firstname: otherFirstname,
+      lastname: otherLastname,
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.user.deleteMany({ where: { congregationId: searchCongregationId } })
+    await testDb.congregation.deleteMany({ where: { id: searchCongregationId } })
+  })
+
+  it('returns only publishers whose firstname matches', async () => {
+    const result = await withScope(searchCongregationId, tx =>
+      getPublishersWithGroup(tx, searchCongregationId, { search: expectedFirstname }),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.firstname).toBe(expectedFirstname)
+  })
+
+  it('returns only publishers whose lastname matches', async () => {
+    const result = await withScope(searchCongregationId, tx =>
+      getPublishersWithGroup(tx, searchCongregationId, { search: expectedLastname }),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.lastname).toBe(expectedLastname)
+  })
+
+  it('matches case-insensitively', async () => {
+    const result = await withScope(searchCongregationId, tx =>
+      getPublishersWithGroup(tx, searchCongregationId, { search: expectedLastname.toLowerCase() }),
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.lastname).toBe(expectedLastname)
+  })
+
+  it('returns an empty array when no publisher matches (bug #133)', async () => {
+    const result = await withScope(searchCongregationId, tx =>
+      getPublishersWithGroup(tx, searchCongregationId, { search: `zzz-no-match-${searchSuffix}` }),
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('returns all publishers when search is absent', async () => {
+    const result = await withScope(searchCongregationId, tx => getPublishersWithGroup(tx, searchCongregationId))
+
+    expect(result).toHaveLength(2)
   })
 })

--- a/app/features/publishers/server/publishers.server.test.ts
+++ b/app/features/publishers/server/publishers.server.test.ts
@@ -48,4 +48,32 @@ describe('getPublishersWithGroup', () => {
     const result = await getPublishersWithGroup(db, 1)
     expect(result).toEqual(fakePublishers)
   })
+
+  it('applies a case-insensitive OR filter on firstname and lastname when search is provided', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
+    await getPublishersWithGroup(db, 1, { search: 'jean' })
+
+    const where = vi.mocked(db.user.findMany).mock.calls[0]?.[0]?.where
+    expect(where).toMatchObject({
+      OR: [
+        { firstname: { contains: 'jean', mode: 'insensitive' } },
+        { lastname: { contains: 'jean', mode: 'insensitive' } },
+      ],
+    })
+  })
+
+  it('does not apply an OR filter when search is absent', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
+    await getPublishersWithGroup(db, 1)
+
+    const where = vi.mocked(db.user.findMany).mock.calls[0]?.[0]?.where
+    expect(where).not.toHaveProperty('OR')
+  })
+
+  it('returns an empty array when no publisher matches the search', async () => {
+    vi.mocked(db.user.findMany).mockResolvedValue([] as never)
+
+    const result = await getPublishersWithGroup(db, 1, { search: 'zzz-no-match' })
+    expect(result).toEqual([])
+  })
 })

--- a/app/i18n/messages/en.json
+++ b/app/i18n/messages/en.json
@@ -868,6 +868,8 @@
     "publishers_create_button": "Create publisher",
     "publishers_empty_title": "There are no publishers yet!",
     "publishers_empty_description": "To add publishers use the &laquo; Create publisher &raquo; button at the top right of this page or create publisher cards from users.",
+    "publishers_empty_no_match_title": "No publishers found",
+    "publishers_empty_no_match_description": "No publisher matches \"{query}\". Try another search term.",
     "publishers_search_placeholder": "Search for a publisher...",
     "publishers_search_button": "Search",
     "publishers_view_activity_title": "View publisher activity",

--- a/app/i18n/messages/fr.json
+++ b/app/i18n/messages/fr.json
@@ -870,6 +870,8 @@
     "publishers_create_button": "Créer proclamateur",
     "publishers_empty_title": "Il n'y a aucun proclamateur pour le moment !",
     "publishers_empty_description": "Pour ajouter des proclamateurs utilisez le bouton &laquo; Créer proclamateur &raquo; en haut à droite de cette page ou créez des fiches de proclamateur à partir des utilisateurs.",
+    "publishers_empty_no_match_title": "Aucun proclamateur trouvé",
+    "publishers_empty_no_match_description": "Aucun proclamateur ne correspond à « {query} ». Essayez un autre terme de recherche.",
     "publishers_search_placeholder": "Rechercher un proclamateur...",
     "publishers_search_button": "Rechercher",
     "publishers_view_activity_title": "Consulter l'activité des proclamateurs",

--- a/app/tests/e2e/create-publisher.spec.ts
+++ b/app/tests/e2e/create-publisher.spec.ts
@@ -9,6 +9,8 @@ const NEW_PUBLISHER_URL_RE = /\/publishers\/new/
 const FIRSTNAME_FIELD_RE = /prénom/i
 const LASTNAME_FIELD_RE = /^nom$/i
 const SUBMIT_BUTTON_RE = /enregistrer|sauvegarder|créer|ajouter/i
+const SEARCH_PLACEHOLDER_RE = /rechercher un proclamateur/i
+const NO_MATCH_TITLE_RE = /aucun proclamateur trouvé/i
 
 test.describe('Publishers', () => {
   test.beforeEach(async ({ page }) => {
@@ -71,5 +73,35 @@ test.describe('Publishers', () => {
     await page.goto('/publishers')
     await page.waitForLoadState('networkidle')
     await expect(page.getByText(lastname)).toBeVisible()
+  })
+
+  test('search input stays visible when no publishers match the query (#133)', async ({ page }) => {
+    await page.goto('/publishers')
+    await page.waitForLoadState('networkidle')
+
+    const searchInput = page.getByPlaceholder(SEARCH_PLACEHOLDER_RE)
+    // The search input is only rendered when at least one publisher exists.
+    // In a fully-empty congregation the bug cannot reproduce — skip.
+    if (!(await searchInput.isVisible({ timeout: 3000 }).catch(() => false))) test.skip()
+
+    const query = `zzz-no-match-${Date.now()}`
+    await searchInput.fill(query)
+
+    // SearchInput debounces URL updates by 300ms
+    await page.waitForURL(url => url.searchParams.get('q') === query, { timeout: 5_000 })
+    await page.waitForLoadState('networkidle')
+
+    // Bug: the search input used to disappear together with the results.
+    // Fix: it must remain in the DOM so the user can correct the typo.
+    await expect(searchInput).toBeVisible()
+    await expect(searchInput).toHaveValue(query)
+    await expect(page.getByText(NO_MATCH_TITLE_RE)).toBeVisible()
+    await expect(page.getByText(query)).toBeVisible()
+
+    // Clearing the input restores the previous list view
+    await searchInput.fill('')
+    await page.waitForURL(url => !url.searchParams.has('q'), { timeout: 5_000 })
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(NO_MATCH_TITLE_RE)).not.toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

- Closes #133
- The publishers list no longer hides the search bar when a query returns zero results — the user can correct their typo without leaving the page.
- Distinguishes two empty states: genuinely-empty congregation (unchanged copy, no search input) vs. no-match-for-query (search input still visible above a "no match for «query»" empty state).

## Test plan

- [x] Open `/publishers` on a congregation with at least one publisher
- [x] Type a query that matches nothing (e.g., `zzzzz`) — search input stays visible, empty state mentions the query
- [x] Clear the search — list reappears
- [x] Genuinely-empty congregation still shows the original empty state with no search input