### PR TITLE
fix(events): allow programme responsibles to manage their own programs

### DIFF
--- a/app/features/events/routes/programs/bulk-delete.tsx
+++ b/app/features/events/routes/programs/bulk-delete.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'react-router'
+import { canManageAnyProgram, getResponsibleTemplateIds } from '~/features/events/server/programme-auth.server'
 import { bulkDeleteEvents } from '~/features/events/server/programme-events.server'
-import { permissionsContext, requirePermission, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
+import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
 import logger from '~/shared/infra/logger.server'
 import { Permission } from '~/shared/types/permission'
 
@@ -12,7 +13,8 @@ export function loader(_args: Route.LoaderArgs) {
 
 export async function action({ request, context }: Route.ActionArgs) {
   const permissions = context.get(permissionsContext)
-  requirePermission(permissions, Permission.ProgramManager)
+  const currentUser = context.get(userContext)
+  const isProgramManager = permissions.has(Permission.ProgramManager)
 
   const { ids } = (await request.json()) as { ids: number[] }
 
@@ -21,9 +23,25 @@ export async function action({ request, context }: Route.ActionArgs) {
   }
 
   return withScopeFromContext(context, async db => {
-    const { congregationId } = context.get(userContext)
-    await bulkDeleteEvents(db, ids, congregationId)
-    logger.info(`Bulk deleted ${ids.length} events.`)
-    return { ok: true, deleted: ids.length }
+    const { congregationId } = currentUser
+    const can = (p: Permission) => permissions.has(p)
+    if (!(await canManageAnyProgram(db, can, currentUser.id, congregationId))) throw redirect('/programs')
+
+    let allowedIds = ids
+    if (!isProgramManager) {
+      const responsibleTemplateIds = await getResponsibleTemplateIds(db, currentUser.id, congregationId)
+      const responsibleSet = new Set(responsibleTemplateIds)
+      const events = await db.event.findMany({
+        where: { id: { in: ids }, congregationId },
+        select: { id: true, templateId: true },
+      })
+      allowedIds = events.filter(e => e.templateId != null && responsibleSet.has(e.templateId)).map(e => e.id)
+    }
+
+    if (allowedIds.length === 0) return { ok: true, deleted: 0 }
+
+    await bulkDeleteEvents(db, allowedIds, congregationId)
+    logger.info(`Bulk deleted ${allowedIds.length} events.`)
+    return { ok: true, deleted: allowedIds.length }
   })
 }

--- a/app/features/events/routes/programs/days-off.tsx
+++ b/app/features/events/routes/programs/days-off.tsx
@@ -32,7 +32,6 @@ export function loader({ request, context }: Route.LoaderArgs) {
   const permissions = context.get(permissionsContext)
   const currentUser = context.get(userContext)
   const canViewPrograms = permissions.has(Permission.ProgramViewer)
-  const canManagePrograms = permissions.has(Permission.ProgramManager)
 
   if (!canViewPrograms) {
     logger.warn(`Try to load programs. User ID: ${currentUser.id}. Does NOT have rights to access programs.`)
@@ -40,9 +39,7 @@ export function loader({ request, context }: Route.LoaderArgs) {
     throw redirect('/')
   }
 
-  logger.info(
-    `Loading program list. User ID: ${currentUser.id}. ${canManagePrograms ? 'Has' : 'Does NOT have'} rights to manage programs.`,
-  )
+  logger.info(`Loading program list. User ID: ${currentUser.id}.`)
 
   const url = new URL(request.url)
   const selectors = computeFilters(url.searchParams)
@@ -131,7 +128,6 @@ export function loader({ request, context }: Route.LoaderArgs) {
       totalConflicts,
       hasAnyDaysOff,
       defaults: { from: defaultFrom, to: defaultTo },
-      roles: { canManagePrograms },
     }
   })
 }

--- a/app/features/events/routes/programs/list.tsx
+++ b/app/features/events/routes/programs/list.tsx
@@ -1,6 +1,7 @@
 import { CalendarOff, ChevronRight, FileDown, Loader2, MoreHorizontal, Trash2, UserCog } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, redirect, useFetcher } from 'react-router'
+import { getResponsibleTemplateIds } from '~/features/events/server/programme-auth.server'
 import * as m from '~/i18n/paraglide/messages'
 import { permissionsContext, userContext, withScopeFromContext } from '~/shared/auth/route-context.server'
 import logger from '~/shared/infra/logger.server'
@@ -43,7 +44,13 @@ export function loader({ context }: Route.LoaderArgs) {
     const now = new Date()
     const startOfCurrentMonth = new Date(now.getFullYear(), now.getMonth(), 1)
 
-    const upcomingEvents = await db.event.findMany({
+    const isProgramManager = permissions.has(Permission.ProgramManager)
+    const responsibleTemplateIds = isProgramManager
+      ? []
+      : await getResponsibleTemplateIds(db, currentUser.id, congregationId)
+    const responsibleTemplateIdSet = new Set(responsibleTemplateIds)
+
+    const events = await db.event.findMany({
       where: {
         congregationId,
         startDate: { gte: startOfCurrentMonth },
@@ -53,10 +60,15 @@ export function loader({ context }: Route.LoaderArgs) {
       orderBy: { startDate: 'asc' },
     })
 
+    const upcomingEvents = events.map(event => ({
+      ...event,
+      canEdit: isProgramManager || (event.templateId != null && responsibleTemplateIdSet.has(event.templateId)),
+    }))
+
     return {
       upcomingEvents,
       roles: {
-        canManagePrograms: permissions.has(Permission.ProgramManager),
+        canCreatePrograms: isProgramManager || responsibleTemplateIds.length > 0,
         canViewExternalSpeakers:
           permissions.has(Permission.ExternalSpeakerViewer) || permissions.has(Permission.ExternalSpeakerManager),
       },
@@ -143,7 +155,8 @@ export default function ProgramListPage({ loaderData }: Route.ComponentProps) {
   const bulkFetcher = useFetcher<{ ok: boolean }>()
 
   const weekGroups = groupByWeek(upcomingEvents)
-  const allIds = upcomingEvents.map(e => e.id)
+  const editableIds = upcomingEvents.filter(e => e.canEdit).map(e => e.id)
+  const hasEditableEvents = editableIds.length > 0
   const isDeleting = bulkFetcher.state !== 'idle'
 
   useEffect(() => {
@@ -162,10 +175,10 @@ export default function ProgramListPage({ loaderData }: Route.ComponentProps) {
   }
 
   function toggleAll() {
-    if (selectedIds.size === allIds.length) {
+    if (selectedIds.size === editableIds.length) {
       setSelectedIds(new Set())
     } else {
-      setSelectedIds(new Set(allIds))
+      setSelectedIds(new Set(editableIds))
     }
   }
 
@@ -196,7 +209,7 @@ export default function ProgramListPage({ loaderData }: Route.ComponentProps) {
         breadcrumbs={[{ label: m.sidebar_programs() }]}
         actions={
           <div className="flex gap-2">
-            {roles.canManagePrograms && (
+            {roles.canCreatePrograms && (
               <Button asChild>
                 <Link to="./new">{m.programs_new_event_button()}</Link>
               </Button>
@@ -236,11 +249,11 @@ export default function ProgramListPage({ loaderData }: Route.ComponentProps) {
 
       {upcomingEvents.length > 0 ? (
         <div className="flex flex-col gap-6">
-          {roles.canManagePrograms && selectedIds.size > 0 && (
+          {hasEditableEvents && selectedIds.size > 0 && (
             <div className="sticky top-0 z-10 flex items-center gap-3 rounded-lg border bg-background/95 px-4 py-2 backdrop-blur">
               <input
                 type="checkbox"
-                checked={selectedIds.size === allIds.length}
+                checked={selectedIds.size === editableIds.length}
                 onChange={toggleAll}
                 className="size-4 rounded border border-input accent-primary"
               />
@@ -257,61 +270,68 @@ export default function ProgramListPage({ loaderData }: Route.ComponentProps) {
             </div>
           )}
 
-          {weekGroups.map(({ weekKey, weekMonday, events }) => (
-            <div key={weekKey} className="flex flex-col gap-2">
-              <div className="flex items-center gap-3">
-                {roles.canManagePrograms && (
-                  <WeekCheckbox events={events} selectedIds={selectedIds} onToggleWeek={toggleWeek} />
-                )}
-                <div className="flex flex-1 items-center gap-3">
-                  <span className="whitespace-nowrap font-medium text-muted-foreground text-xs">
-                    {m.programs_week_header_count({
-                      date: weekMonday.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' }),
-                      count: events.length,
-                    })}
-                  </span>
-                  <div className="flex-1 border-border border-t" />
-                </div>
-              </div>
-
-              {events.map(event => {
-                const weekday = new Date(event.startDate).toLocaleDateString('fr-FR', { weekday: 'long' })
-                const time = formatEventTime(new Date(event.startDate))
-
-                return (
-                  <div key={event.id} className="flex items-center gap-3">
-                    {roles.canManagePrograms && (
-                      <input
-                        type="checkbox"
-                        checked={selectedIds.has(event.id)}
-                        onChange={() => toggleSelection(event.id)}
-                        className="size-4 rounded border border-input accent-primary"
-                        onClick={e => e.stopPropagation()}
-                      />
-                    )}
-                    <Link to={`./events/${event.id}`} className="flex-1 no-underline">
-                      <Card
-                        className="overflow-hidden transition-colors hover:bg-muted/50"
-                        style={event.kind?.color ? { borderLeftColor: event.kind.color, borderLeftWidth: '4px' } : {}}
-                      >
-                        <CardContent className="flex items-center justify-between py-3">
-                          <div className="flex flex-col gap-0.5">
-                            <span className="font-medium text-sm">{event.name}</span>
-                            <span className="text-muted-foreground text-xs capitalize">
-                              {weekday}
-                              {time ? ` · ${time}` : ''}
-                              {event.kind ? ` · ${event.kind.name}` : ''}
-                            </span>
-                          </div>
-                          <ChevronRight className="size-4 text-muted-foreground" />
-                        </CardContent>
-                      </Card>
-                    </Link>
+          {weekGroups.map(({ weekKey, weekMonday, events }) => {
+            const editableWeekEvents = events.filter(e => e.canEdit)
+            return (
+              <div key={weekKey} className="flex flex-col gap-2">
+                <div className="flex items-center gap-3">
+                  {editableWeekEvents.length > 0 && (
+                    <WeekCheckbox events={editableWeekEvents} selectedIds={selectedIds} onToggleWeek={toggleWeek} />
+                  )}
+                  <div className="flex flex-1 items-center gap-3">
+                    <span className="whitespace-nowrap font-medium text-muted-foreground text-xs">
+                      {m.programs_week_header_count({
+                        date: weekMonday.toLocaleDateString('fr-FR', {
+                          day: 'numeric',
+                          month: 'long',
+                          year: 'numeric',
+                        }),
+                        count: events.length,
+                      })}
+                    </span>
+                    <div className="flex-1 border-border border-t" />
                   </div>
-                )
-              })}
-            </div>
-          ))}
+                </div>
+
+                {events.map(event => {
+                  const weekday = new Date(event.startDate).toLocaleDateString('fr-FR', { weekday: 'long' })
+                  const time = formatEventTime(new Date(event.startDate))
+
+                  return (
+                    <div key={event.id} className="flex items-center gap-3">
+                      {event.canEdit && (
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(event.id)}
+                          onChange={() => toggleSelection(event.id)}
+                          className="size-4 rounded border border-input accent-primary"
+                          onClick={e => e.stopPropagation()}
+                        />
+                      )}
+                      <Link to={`./events/${event.id}`} className="flex-1 no-underline">
+                        <Card
+                          className="overflow-hidden transition-colors hover:bg-muted/50"
+                          style={event.kind?.color ? { borderLeftColor: event.kind.color, borderLeftWidth: '4px' } : {}}
+                        >
+                          <CardContent className="flex items-center justify-between py-3">
+                            <div className="flex flex-col gap-0.5">
+                              <span className="font-medium text-sm">{event.name}</span>
+                              <span className="text-muted-foreground text-xs capitalize">
+                                {weekday}
+                                {time ? ` · ${time}` : ''}
+                                {event.kind ? ` · ${event.kind.name}` : ''}
+                              </span>
+                            </div>
+                            <ChevronRight className="size-4 text-muted-foreground" />
+                          </CardContent>
+                        </Card>
+                      </Link>
+                    </div>
+                  )
+                })}
+              </div>
+            )
+          })}
         </div>
       ) : (
         <EmptyState icon={CalendarOff} title={m.programs_empty_title()} description={m.programs_empty_description()} />

--- a/app/features/events/routes/programs/new.tsx
+++ b/app/features/events/routes/programs/new.tsx
@@ -9,6 +9,7 @@ import {
   recurringEventSchema,
   singleEventSchema,
 } from '~/features/events/schemas/program-new.schema'
+import { canManageAnyProgram, getResponsibleTemplateIds } from '~/features/events/server/programme-auth.server'
 import { createFreeformEvent } from '~/features/events/server/programme-events.server'
 import {
   createSingleEventFromTemplate,
@@ -47,18 +48,30 @@ export const meta: Route.MetaFunction = () => {
 
 export function loader({ context }: Route.LoaderArgs) {
   const permissions = context.get(permissionsContext)
-  if (!permissions.has(Permission.ProgramManager)) throw redirect('/programs')
+  const currentUser = context.get(userContext)
+  const isProgramManager = permissions.has(Permission.ProgramManager)
 
   return withScopeFromContext(context, async db => {
-    const { congregationId } = context.get(userContext)
-    const [templates, eventKinds] = await Promise.all([
+    const { congregationId } = currentUser
+
+    const responsibleTemplateIds = isProgramManager
+      ? []
+      : await getResponsibleTemplateIds(db, currentUser.id, congregationId)
+    if (!isProgramManager && responsibleTemplateIds.length === 0) throw redirect('/programs')
+
+    const [allTemplates, eventKinds] = await Promise.all([
       getTemplates(db, congregationId),
-      db.eventKind.findMany({
-        where: { congregationId, NOT: { key: 'off' } },
-        orderBy: { name: 'asc' },
-      }),
+      isProgramManager
+        ? db.eventKind.findMany({
+            where: { congregationId, NOT: { key: 'off' } },
+            orderBy: { name: 'asc' },
+          })
+        : Promise.resolve([]),
     ])
-    return { templates, eventKinds }
+
+    const templates = isProgramManager ? allTemplates : allTemplates.filter(t => responsibleTemplateIds.includes(t.id))
+
+    return { templates, eventKinds, isProgramManager }
   })
 }
 
@@ -121,26 +134,48 @@ async function handleFreeformMode({ db, formData, currentUser, congregationId, s
   return null
 }
 
+async function assertCanSubmit(
+  db: TransactionClient,
+  can: (p: Permission) => boolean,
+  isProgramManager: boolean,
+  userId: number,
+  congregationId: number,
+  mode: FormDataEntryValue | null,
+  formData: FormData,
+): Promise<void> {
+  if (!(await canManageAnyProgram(db, can, userId, congregationId))) throw redirect('/programs')
+  if (isProgramManager) return
+  if (mode === 'freeform') throw redirect('/programs')
+
+  const responsibleTemplateIds = await getResponsibleTemplateIds(db, userId, congregationId)
+  const submittedTemplateId = Number(formData.get('templateId'))
+  if (!Number.isFinite(submittedTemplateId) || !responsibleTemplateIds.includes(submittedTemplateId)) {
+    throw redirect('/programs')
+  }
+}
+
+function dispatchMode(mode: FormDataEntryValue | null, ctx: ActionCtx) {
+  if (mode === 'recurring') return handleRecurringMode(ctx)
+  if (mode === 'single') return handleSingleMode(ctx)
+  if (mode === 'freeform') return handleFreeformMode(ctx)
+  return Promise.resolve(null)
+}
+
 export async function action({ request, context }: Route.ActionArgs) {
   const permissions = context.get(permissionsContext)
-  if (!permissions.has(Permission.ProgramManager)) throw redirect('/programs')
-
   const currentUser = context.get(userContext)
+  const isProgramManager = permissions.has(Permission.ProgramManager)
   const session = await getSession(request.headers.get('Cookie'))
   const formData = await request.formData()
   const mode = formData.get('mode')
   const { congregationId } = currentUser
 
   return withScopeFromContext(context, async db => {
+    const can = (p: Permission) => permissions.has(p)
+    await assertCanSubmit(db, can, isProgramManager, currentUser.id, congregationId, mode, formData)
+
     const ctx: ActionCtx = { db, formData, currentUser, congregationId, session }
-    const modeResult =
-      mode === 'recurring'
-        ? await handleRecurringMode(ctx)
-        : mode === 'single'
-          ? await handleSingleMode(ctx)
-          : mode === 'freeform'
-            ? await handleFreeformMode(ctx)
-            : null
+    const modeResult = await dispatchMode(mode, ctx)
     if (modeResult) return modeResult
     return redirect('/programs', { headers: { 'Set-Cookie': await commitSession(session) } })
   })
@@ -295,14 +330,62 @@ function SingleFields({ alreadyExists }: { alreadyExists: boolean }) {
   )
 }
 
+type Template = { id: number; name: string; weekDay: number | null }
+
+function TemplateSelectField({
+  templates,
+  selectedValue,
+  selectedTemplate,
+  isNoTemplate,
+  isRecurring,
+  isProgramManager,
+  onSelect,
+}: {
+  templates: Template[]
+  selectedValue: string
+  selectedTemplate: Template | null | undefined
+  isNoTemplate: boolean
+  isRecurring: boolean
+  isProgramManager: boolean
+  onSelect: (value: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="templateId">{m.programs_new_template_label()}</Label>
+      {templates.length === 0 && <p className="text-muted-foreground text-xs">{m.programs_new_no_templates_hint()}</p>}
+      <Select name={isNoTemplate ? undefined : 'templateId'} value={selectedValue} onValueChange={onSelect}>
+        <SelectTrigger>
+          <SelectValue placeholder={m.programs_new_select_template()} />
+        </SelectTrigger>
+        <SelectContent>
+          {isProgramManager && <SelectItem value={NO_TEMPLATE}>{m.programs_new_no_template_option()}</SelectItem>}
+          {templates.map(template => (
+            <SelectItem key={template.id} value={template.id.toString()}>
+              {template.name}
+              {template.weekDay != null ? ` (${dayLabel(template.weekDay)})` : ''}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {selectedTemplate && (
+        <p className="text-muted-foreground text-xs">
+          {isRecurring
+            ? `Modèle récurrent · ${dayLabel(selectedTemplate.weekDay ?? 0)}s · 19h00–21h00`
+            : 'Modèle unique'}
+        </p>
+      )}
+    </div>
+  )
+}
+
 export default function NewEventPage({ loaderData, actionData }: Route.ComponentProps) {
-  const { templates, eventKinds } = loaderData
+  const { templates, eventKinds, isProgramManager } = loaderData
   const [selectedValue, setSelectedValue] = useState<string>('')
   const [occurrences, setOccurrences] = useState(8)
   const [startDate, setStartDate] = useState('')
   const { blocker, markDirty } = useUnsavedChanges()
 
-  const isNoTemplate = selectedValue === NO_TEMPLATE
+  const isNoTemplate = isProgramManager && selectedValue === NO_TEMPLATE
   const selectedTemplate = !isNoTemplate ? templates.find(t => t.id === Number(selectedValue)) : null
   const isRecurring = selectedTemplate?.weekDay != null
   const showForm = isNoTemplate || selectedTemplate != null
@@ -342,40 +425,18 @@ export default function NewEventPage({ loaderData, actionData }: Route.Component
         </CardHeader>
         <CardContent>
           <Form method="post" className="flex flex-col gap-4" onChange={markDirty}>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="templateId">{m.programs_new_template_label()}</Label>
-              {templates.length === 0 && (
-                <p className="text-muted-foreground text-xs">{m.programs_new_no_templates_hint()}</p>
-              )}
-              <Select
-                name={isNoTemplate ? undefined : 'templateId'}
-                value={selectedValue}
-                onValueChange={v => {
-                  setSelectedValue(v)
-                  markDirty()
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={m.programs_new_select_template()} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_TEMPLATE}>{m.programs_new_no_template_option()}</SelectItem>
-                  {templates.map(template => (
-                    <SelectItem key={template.id} value={template.id.toString()}>
-                      {template.name}
-                      {template.weekDay != null ? ` (${dayLabel(template.weekDay)})` : ''}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {selectedTemplate && (
-                <p className="text-muted-foreground text-xs">
-                  {isRecurring
-                    ? `Modèle récurrent · ${dayLabel(selectedTemplate.weekDay ?? 0)}s · 19h00–21h00`
-                    : 'Modèle unique'}
-                </p>
-              )}
-            </div>
+            <TemplateSelectField
+              templates={templates}
+              selectedValue={selectedValue}
+              selectedTemplate={selectedTemplate}
+              isNoTemplate={isNoTemplate}
+              isRecurring={Boolean(isRecurring)}
+              isProgramManager={isProgramManager}
+              onSelect={v => {
+                setSelectedValue(v)
+                markDirty()
+              }}
+            />
 
             {isNoTemplate && <FreeformFields eventKinds={eventKinds} />}
             {selectedTemplate && isRecurring && (

--- a/app/features/events/server/programme-auth.server.integration.test.ts
+++ b/app/features/events/server/programme-auth.server.integration.test.ts
@@ -1,0 +1,221 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PrismaClient } from '~/database/generated/client'
+import { Permission } from '~/shared/types/permission'
+import { PublisherType } from '~/shared/types/publisher-type'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
+  max: 5,
+  connectionTimeoutMillis: 5000,
+})
+const testDb = new PrismaClient({ adapter })
+
+type Tx = Parameters<Parameters<typeof testDb.$transaction>[0]>[0]
+
+function withScope<T>(congregationId: number, fn: (tx: Tx) => Promise<T>): Promise<T> {
+  return testDb.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+    return fn(tx)
+  })
+}
+
+const ts = Date.now()
+let primaryCongId: number
+let otherCongId: number
+let managerId: number
+let responsibleId: number
+let plainId: number
+let otherCongResponsibleId: number
+let templateOwnedId: number
+let templateOtherId: number
+let templateOtherCongId: number
+
+const allowAll = (_p: Permission) => true
+const allowNone = (_p: Permission) => false
+const allowOnly = (allowed: Permission) => (p: Permission) => p === allowed
+
+const { canEditEvent, getResponsibleTemplateIds, canManageAnyProgram } = await import('./programme-auth.server')
+
+beforeAll(async () => {
+  const primary = await testDb.congregation.create({
+    data: { name: `Auth Primary ${ts}`, slug: `auth-primary-${ts}`, active: true },
+  })
+  primaryCongId = primary.id
+
+  const other = await testDb.congregation.create({
+    data: { name: `Auth Other ${ts}`, slug: `auth-other-${ts}`, active: true },
+  })
+  otherCongId = other.id
+
+  await withScope(primaryCongId, async tx => {
+    const manager = await tx.user.create({
+      data: {
+        email: `auth-manager-${ts}@test.com`,
+        password: 'hashed',
+        firstname: 'Manny',
+        lastname: 'Manager',
+        active: true,
+        isPublisher: false,
+        type: PublisherType.Normal,
+        congregationId: primaryCongId,
+      },
+    })
+    managerId = manager.id
+
+    const responsible = await tx.user.create({
+      data: {
+        email: `auth-responsible-${ts}@test.com`,
+        password: 'hashed',
+        firstname: 'Rose',
+        lastname: 'Responsible',
+        active: true,
+        isPublisher: false,
+        type: PublisherType.Normal,
+        congregationId: primaryCongId,
+      },
+    })
+    responsibleId = responsible.id
+
+    const plain = await tx.user.create({
+      data: {
+        email: `auth-plain-${ts}@test.com`,
+        password: 'hashed',
+        firstname: 'Pat',
+        lastname: 'Plain',
+        active: true,
+        isPublisher: false,
+        type: PublisherType.Normal,
+        congregationId: primaryCongId,
+      },
+    })
+    plainId = plain.id
+
+    const owned = await tx.programmeTemplate.create({
+      data: { name: 'Owned Template', key: `owned-${ts}`, congregationId: primaryCongId },
+    })
+    templateOwnedId = owned.id
+
+    const otherTpl = await tx.programmeTemplate.create({
+      data: { name: 'Other Template', key: `other-${ts}`, congregationId: primaryCongId },
+    })
+    templateOtherId = otherTpl.id
+
+    await tx.programmeTemplateResponsible.create({
+      data: { templateId: templateOwnedId, userId: responsibleId, congregationId: primaryCongId },
+    })
+  })
+
+  await withScope(otherCongId, async tx => {
+    const otherCongResp = await tx.user.create({
+      data: {
+        email: `auth-othercong-resp-${ts}@test.com`,
+        password: 'hashed',
+        firstname: 'Olga',
+        lastname: 'Other',
+        active: true,
+        isPublisher: false,
+        type: PublisherType.Normal,
+        congregationId: otherCongId,
+      },
+    })
+    otherCongResponsibleId = otherCongResp.id
+
+    const otherCongTemplate = await tx.programmeTemplate.create({
+      data: { name: 'Foreign Template', key: `foreign-${ts}`, congregationId: otherCongId },
+    })
+    templateOtherCongId = otherCongTemplate.id
+
+    await tx.programmeTemplateResponsible.create({
+      data: { templateId: templateOtherCongId, userId: otherCongResponsibleId, congregationId: otherCongId },
+    })
+  })
+})
+
+afterAll(async () => {
+  for (const congId of [primaryCongId, otherCongId]) {
+    if (!congId) continue
+    await withScope(congId, async tx => {
+      await tx.programmeTemplateResponsible.deleteMany({})
+      await tx.programmeTemplate.deleteMany({})
+      await tx.user.deleteMany({})
+    })
+  }
+  await testDb.congregation.deleteMany({ where: { id: { in: [primaryCongId, otherCongId] } } })
+  await testDb.$disconnect()
+})
+
+describe('getResponsibleTemplateIds (integration)', () => {
+  it('returns the templateIds the user is responsible for inside scope', async () => {
+    const result = await withScope(primaryCongId, tx => getResponsibleTemplateIds(tx, responsibleId, primaryCongId))
+    expect(result).toEqual([templateOwnedId])
+  })
+
+  it('returns an empty array for a user with no responsibilities', async () => {
+    const result = await withScope(primaryCongId, tx => getResponsibleTemplateIds(tx, plainId, primaryCongId))
+    expect(result).toEqual([])
+  })
+
+  it('does not leak responsibilities from another congregation when scoped', async () => {
+    const result = await withScope(primaryCongId, tx =>
+      getResponsibleTemplateIds(tx, otherCongResponsibleId, primaryCongId),
+    )
+    expect(result).toEqual([])
+  })
+})
+
+describe('canEditEvent (integration)', () => {
+  it('returns true for ProgramManager regardless of templateId (incl. freeform)', async () => {
+    const onTemplate = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowOnly(Permission.ProgramManager), managerId, templateOtherId, primaryCongId),
+    )
+    const freeform = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowOnly(Permission.ProgramManager), managerId, null, primaryCongId),
+    )
+    expect(onTemplate).toBe(true)
+    expect(freeform).toBe(true)
+  })
+
+  it('returns true for the responsible only on their own template', async () => {
+    const owned = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowNone, responsibleId, templateOwnedId, primaryCongId),
+    )
+    const foreign = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowNone, responsibleId, templateOtherId, primaryCongId),
+    )
+    expect(owned).toBe(true)
+    expect(foreign).toBe(false)
+  })
+
+  it('returns false for a plain non-manager user on any template', async () => {
+    const owned = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowNone, plainId, templateOwnedId, primaryCongId),
+    )
+    const other = await withScope(primaryCongId, tx =>
+      canEditEvent(tx, allowNone, plainId, templateOtherId, primaryCongId),
+    )
+    const freeform = await withScope(primaryCongId, tx => canEditEvent(tx, allowNone, plainId, null, primaryCongId))
+    expect(owned).toBe(false)
+    expect(other).toBe(false)
+    expect(freeform).toBe(false)
+  })
+})
+
+describe('canManageAnyProgram (integration)', () => {
+  it('returns true for ProgramManager without consulting responsibles', async () => {
+    const result = await withScope(primaryCongId, tx => canManageAnyProgram(tx, allowAll, managerId, primaryCongId))
+    expect(result).toBe(true)
+  })
+
+  it('returns true for a non-manager who is responsible for at least one template', async () => {
+    const result = await withScope(primaryCongId, tx =>
+      canManageAnyProgram(tx, allowNone, responsibleId, primaryCongId),
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false for a plain non-manager user', async () => {
+    const result = await withScope(primaryCongId, tx => canManageAnyProgram(tx, allowNone, plainId, primaryCongId))
+    expect(result).toBe(false)
+  })
+})

--- a/app/features/events/server/programme-auth.server.test.ts
+++ b/app/features/events/server/programme-auth.server.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Permission } from '~/shared/types/permission'
+
+vi.mock('~/shared/infra/db.server', () => ({
+  unscopedDb: {
+    programmeTemplateResponsible: { findFirst: vi.fn(), findMany: vi.fn() },
+  },
+}))
+
+const { canEditEvent, getResponsibleTemplateIds, canManageAnyProgram } = await import('./programme-auth.server')
+const { unscopedDb: db } = await import('~/shared/infra/db.server')
+
+const CONGREGATION_ID = 4242
+const USER_ID = 7777
+const TEMPLATE_ID_OWNED = 1001
+const TEMPLATE_ID_OTHER = 2002
+
+const allowAll = (_p: Permission) => true
+const allowNone = (_p: Permission) => false
+const allowOnly = (allowed: Permission) => (p: Permission) => p === allowed
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('canEditEvent', () => {
+  it('returns true for ProgramManager regardless of templateId', async () => {
+    const result = await canEditEvent(db, allowOnly(Permission.ProgramManager), USER_ID, null, CONGREGATION_ID)
+    expect(result).toBe(true)
+  })
+
+  it('returns false for non-manager when templateId is null (freeform event)', async () => {
+    const result = await canEditEvent(db, allowNone, USER_ID, null, CONGREGATION_ID)
+    expect(result).toBe(false)
+  })
+
+  it('returns true for non-manager when responsible record exists', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findFirst).mockResolvedValue({
+      id: 1,
+      templateId: TEMPLATE_ID_OWNED,
+      userId: USER_ID,
+      congregationId: CONGREGATION_ID,
+    } as never)
+
+    const result = await canEditEvent(db, allowNone, USER_ID, TEMPLATE_ID_OWNED, CONGREGATION_ID)
+    expect(result).toBe(true)
+  })
+
+  it('returns false for non-manager when no responsible record exists', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findFirst).mockResolvedValue(null as never)
+
+    const result = await canEditEvent(db, allowNone, USER_ID, TEMPLATE_ID_OTHER, CONGREGATION_ID)
+    expect(result).toBe(false)
+  })
+})
+
+describe('getResponsibleTemplateIds', () => {
+  it('returns an empty array when the user is responsible for nothing', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findMany).mockResolvedValue([] as never)
+
+    const result = await getResponsibleTemplateIds(db, USER_ID, CONGREGATION_ID)
+    expect(result).toEqual([])
+  })
+
+  it('returns the list of templateIds for the user', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findMany).mockResolvedValue([
+      { templateId: TEMPLATE_ID_OWNED },
+      { templateId: TEMPLATE_ID_OTHER },
+    ] as never)
+
+    const result = await getResponsibleTemplateIds(db, USER_ID, CONGREGATION_ID)
+    expect(result).toEqual([TEMPLATE_ID_OWNED, TEMPLATE_ID_OTHER])
+  })
+})
+
+describe('canManageAnyProgram', () => {
+  it('returns true for ProgramManager without consulting the database', async () => {
+    const result = await canManageAnyProgram(db, allowAll, USER_ID, CONGREGATION_ID)
+    expect(result).toBe(true)
+  })
+
+  it('returns true for non-manager when at least one responsible record exists', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findMany).mockResolvedValue([{ templateId: TEMPLATE_ID_OWNED }] as never)
+
+    const result = await canManageAnyProgram(db, allowNone, USER_ID, CONGREGATION_ID)
+    expect(result).toBe(true)
+  })
+
+  it('returns false for non-manager when no responsible records exist', async () => {
+    vi.mocked(db.programmeTemplateResponsible.findMany).mockResolvedValue([] as never)
+
+    const result = await canManageAnyProgram(db, allowNone, USER_ID, CONGREGATION_ID)
+    expect(result).toBe(false)
+  })
+})

--- a/app/features/events/server/programme-auth.server.ts
+++ b/app/features/events/server/programme-auth.server.ts
@@ -14,3 +14,26 @@ export async function canEditEvent(
   const responsible = await isTemplateResponsible(db, templateId, userId, congregationId)
   return responsible != null
 }
+
+export async function getResponsibleTemplateIds(
+  db: TransactionClient,
+  userId: number,
+  congregationId: number,
+): Promise<number[]> {
+  const rows = await db.programmeTemplateResponsible.findMany({
+    where: { userId, congregationId },
+    select: { templateId: true },
+  })
+  return rows.map(r => r.templateId)
+}
+
+export async function canManageAnyProgram(
+  db: TransactionClient,
+  can: (role: Permission) => boolean,
+  userId: number,
+  congregationId: number,
+): Promise<boolean> {
+  if (can(Permission.ProgramManager)) return true
+  const ids = await getResponsibleTemplateIds(db, userId, congregationId)
+  return ids.length > 0
+}

--- a/app/tests/e2e/program-permissions.spec.ts
+++ b/app/tests/e2e/program-permissions.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test'
+import { login } from './helpers/auth'
+
+const MANAGER_EMAIL = process.env.E2E_PROGRAM_MANAGER_EMAIL
+const MANAGER_PASSWORD = process.env.E2E_PROGRAM_MANAGER_PASSWORD
+const RESPONSIBLE_EMAIL = process.env.E2E_PROGRAM_RESPONSIBLE_EMAIL
+const RESPONSIBLE_PASSWORD = process.env.E2E_PROGRAM_RESPONSIBLE_PASSWORD
+const VIEWER_EMAIL = process.env.E2E_PROGRAM_VIEWER_EMAIL
+const VIEWER_PASSWORD = process.env.E2E_PROGRAM_VIEWER_PASSWORD
+
+const PROGRAMS_URL_RE = /\/programs(\?|$)/
+const PROGRAMS_NEW_URL_RE = /\/programs\/new/
+const NEW_EVENT_BUTTON_RE = /^Nouvel? /i
+const NO_TEMPLATE_OPTION_RE = /Aucun modèle/i
+
+test.describe('Program permissions — ProgramManager', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!MANAGER_EMAIL || !MANAGER_PASSWORD) test.skip()
+    const loggedIn = await login(page, MANAGER_EMAIL ?? '', MANAGER_PASSWORD ?? '')
+    if (!loggedIn) test.skip()
+  })
+
+  test('sees the "Nouveau" button on the program list', async ({ page }) => {
+    await page.goto('/programs')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('link', { name: NEW_EVENT_BUTTON_RE })).toBeVisible()
+  })
+
+  test('new-event page exposes the "Aucun modèle" option', async ({ page }) => {
+    await page.goto('/programs/new')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('combobox').first().click()
+    await expect(page.getByRole('option', { name: NO_TEMPLATE_OPTION_RE })).toBeVisible()
+  })
+})
+
+test.describe('Program permissions — Responsible (non-manager)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!RESPONSIBLE_EMAIL || !RESPONSIBLE_PASSWORD) test.skip()
+    const loggedIn = await login(page, RESPONSIBLE_EMAIL ?? '', RESPONSIBLE_PASSWORD ?? '')
+    if (!loggedIn) test.skip()
+  })
+
+  test('sees the "Nouveau" button on the program list', async ({ page }) => {
+    await page.goto('/programs')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('link', { name: NEW_EVENT_BUTTON_RE })).toBeVisible()
+  })
+
+  test('new-event page does not expose the "Aucun modèle" option', async ({ page }) => {
+    await page.goto('/programs/new')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(PROGRAMS_NEW_URL_RE)
+    await page.getByRole('combobox').first().click()
+    await expect(page.getByRole('option', { name: NO_TEMPLATE_OPTION_RE })).toHaveCount(0)
+  })
+
+  test('foreign-template event ids are filtered out by the bulk-delete action', async ({ page, request }) => {
+    await page.goto('/programs')
+    await page.waitForLoadState('networkidle')
+
+    const cookies = await page.context().cookies()
+    const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ')
+
+    const response = await request.post('/programs/bulk-delete', {
+      headers: { 'Content-Type': 'application/json', Cookie: cookieHeader },
+      data: { ids: [-1, -2] },
+    })
+    expect(response.ok()).toBeTruthy()
+    const body = (await response.json()) as { ok: boolean; deleted?: number }
+    expect(body.ok).toBe(true)
+    expect(body.deleted ?? 0).toBe(0)
+  })
+})
+
+test.describe('Program permissions — ProgramViewer (read-only)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!VIEWER_EMAIL || !VIEWER_PASSWORD) test.skip()
+    const loggedIn = await login(page, VIEWER_EMAIL ?? '', VIEWER_PASSWORD ?? '')
+    if (!loggedIn) test.skip()
+  })
+
+  test('does not see the "Nouveau" button on the program list', async ({ page }) => {
+    await page.goto('/programs')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('link', { name: NEW_EVENT_BUTTON_RE })).toHaveCount(0)
+  })
+
+  test('cannot reach /programs/new — redirected to /programs', async ({ page }) => {
+    await page.goto('/programs/new')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(PROGRAMS_URL_RE)
+  })
+})


### PR DESCRIPTION
Closes #156

## Summary

- `programme-auth.server.ts` gains `getResponsibleTemplateIds` and `canManageAnyProgram` helpers; `canEditEvent` is unchanged.
- The program list, new-event, and bulk-delete routes (plus a stale field in `days-off.tsx`) now respect the responsible relationship instead of gating purely on `ProgramManager`.
- A user who is responsible for a programme template now gets the same edition rights as a `ProgramManager`, scoped to that template only.

## Test plan

- [x] `pnpm test:unit programme-auth` — 9 unit tests pass
- [x] `pnpm test:integration programme-auth` — 9 integration tests pass (real DB + RLS scoping)
- [x] `pnpm test:lint` — no new findings on touched files (only pre-existing `useSortedClasses` warnings)
- [ ] `pnpm test:e2e program-permissions` — graceful skip until the `E2E_PROGRAM_*` env vars are provisioned in CI
- [ ] Manual smoke as ProgramManager / Responsible / ProgramViewer in dev