### PR TITLE
fix(board): handle non-ASCII characters in PDF filename header

### DIFF
--- a/app/features/display-board/server/document.server.ts
+++ b/app/features/display-board/server/document.server.ts
@@ -10,6 +10,13 @@ export function saveFile(congregationId: number, file: File): Promise<string> {
   return saveBoardFile(congregationId, file)
 }
 
+function buildContentDisposition(title: string): string {
+  const filename = `${title}.pdf`
+  const asciiFallback = filename.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, '')
+  const utf8Encoded = encodeURIComponent(filename)
+  return `inline; filename="${asciiFallback}"; filename*=UTF-8''${utf8Encoded}`
+}
+
 export async function getFileStream(document: BoardDocument): Promise<Response | null> {
   const key = document.uri ?? ''
   const file = await getBoardFile(key)
@@ -19,7 +26,7 @@ export async function getFileStream(document: BoardDocument): Promise<Response |
     status: 200,
     headers: {
       'Content-Type': file.contentType,
-      'Content-Disposition': `inline; filename="${document.title}.pdf"`,
+      'Content-Disposition': buildContentDisposition(document.title),
     },
   })
 }

--- a/app/features/display-board/server/document.test.ts
+++ b/app/features/display-board/server/document.test.ts
@@ -7,8 +7,8 @@ vi.mock('./document-storage.server', () => ({
   getBoardFileBuffer: vi.fn(),
 }))
 
-const { deleteSectionWithFiles, deleteFile } = await import('./document.server')
-const { deleteBoardFile } = await import('./document-storage.server')
+const { deleteSectionWithFiles, deleteFile, getFileStream } = await import('./document.server')
+const { deleteBoardFile, getBoardFile } = await import('./document-storage.server')
 
 beforeEach(() => {
   vi.resetAllMocks()
@@ -84,5 +84,45 @@ describe('deleteSectionWithFiles', () => {
 
     expect(deleteBoardFile).not.toHaveBeenCalled()
     expect(mockDb.boardSection.delete).toHaveBeenCalled()
+  })
+})
+
+describe('getFileStream Content-Disposition header', () => {
+  beforeEach(() => {
+    vi.mocked(getBoardFile).mockResolvedValue({
+      body: new ReadableStream(),
+      contentType: 'application/pdf',
+    })
+  })
+
+  it('encodes non-ASCII titles using RFC 5987 filename* syntax', async () => {
+    const document = { uri: 'k', title: 'Programme — Mai 2026' } as never
+    const response = await getFileStream(document)
+    const header = response?.headers.get('Content-Disposition') ?? ''
+
+    expect(header).toContain("filename*=UTF-8''")
+    expect(header).toContain(encodeURIComponent('Programme — Mai 2026.pdf'))
+  })
+
+  it('provides an ASCII fallback that strips non-ASCII characters', async () => {
+    const document = { uri: 'k', title: 'Programme — Mai 2026' } as never
+    const response = await getFileStream(document)
+    const header = response?.headers.get('Content-Disposition') ?? ''
+
+    expect(header).toContain('filename="Programme _ Mai 2026.pdf"')
+  })
+
+  it('escapes double quotes in the ASCII fallback to keep the header parseable', async () => {
+    const document = { uri: 'k', title: 'Quote"Test' } as never
+    const response = await getFileStream(document)
+    const header = response?.headers.get('Content-Disposition') ?? ''
+
+    expect(header).toContain('filename="QuoteTest.pdf"')
+  })
+
+  it('does not throw when title contains characters outside the byte range', async () => {
+    const document = { uri: 'k', title: 'Réunion publique — printemps' } as never
+
+    await expect(getFileStream(document)).resolves.not.toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
Setting \`Content-Disposition\` with a raw document title containing characters above U+00FF (em dash, accented letters, etc.) crashes the response with \`Cannot convert argument to a ByteString because the character at index N has a value of X which is greater than 255\`. The board PDF route is then unreachable for any document whose title contains such characters.

This switches \`getFileStream\` to RFC 5987 \`filename*=UTF-8''\` encoding with a sanitized ASCII fallback for older clients.

## Test plan
- [ ] Open a board document whose title contains \`—\` or accented characters — request succeeds, PDF renders inline
- [ ] Download the same document — the saved file has a sensible name
- [ ] \`pnpm test:unit\` covers the new \`getFileStream\` header tests