### PR TITLE
docs(product): rewrite product/* for non-technical readers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ Architecture and systems:
 - [Architecture](development/architecture.md) — System design, request flow, and data isolation
 - [Row-Level Security](development/row-level-security.md) — How RLS enforces tenant isolation
 - [Background Processing](development/background-processing.md) — BullMQ worker architecture
+- [Data Transfer Internals](development/data-transfer.md) — Archive format and import/export contributor reference
 - [Notifications](development/notifications.md) — Notification system architecture
 - [Email Templates](development/email-templates.md) — React Email templates and Resend
 - [Testing](development/testing.md) — Unit, integration, and E2E test setup

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -291,13 +291,15 @@ pnpm test:e2e:headed        # E2E tests with browser visible
 
 ## Security
 
-- **Session**: Cookie-based, `UNITAE_SESSION_SECRET` required, 1h (prod) / 8h (dev) maxAge
-- **Passwords**: scrypt hashed with random salt, reset via 24h time-limited tokens
+- **Session**: Cookie-based (HTTP-only, `SameSite=Lax`, optional `UNITAE_COOKIE_DOMAIN` for multi-subdomain SaaS), `UNITAE_SESSION_SECRET` required, 1h (prod) / 8h (dev) maxAge
+- **Passwords**: scrypt hashed with a 16-byte random salt and 32-byte derived key, constant-time comparison, never stored in plain text, reset via 24h single-use time-limited tokens generated with `crypto.randomBytes(32)`
 - **Email verification**: Required before accessing the app, 24h token expiry
 - **Rate limiting**: Login (5/15min), password reset (3/15min) per email via Redis
+- **Calendar feed tokens**: 32 random bytes encoded as base64url (`crypto.randomBytes(32)`), one active per user, no automatic expiry, manually revoked or regenerated. Audited via `calendar_feed.token.created` and `calendar_feed.token.revoked` actions
 - **Permissions**: 16 congregation-scoped permissions via CongregationUserPermission
-- **Files**: Congregation-scoped storage keys, UUID filenames
+- **Files**: Congregation-scoped storage keys with UUID filenames (`{congregationId}/board/{uuid}.pdf`)
 - **RLS**: PostgreSQL Row-Level Security for tenant data isolation
+- **Log PII redaction**: Email addresses and personal data fields hashed with SHA-256 in application logs
 
 ## Related
 

--- a/docs/development/data-transfer.md
+++ b/docs/development/data-transfer.md
@@ -1,0 +1,59 @@
+# Data Transfer Internals
+
+Implementation reference for contributors working on the export/import flow. The user-facing description lives in [docs/product/data-transfer.md](../product/data-transfer.md).
+
+## Archive format
+
+A `.unitae` archive is a ZIP with three top-level entries:
+
+| Entry | Purpose |
+|---|---|
+| `manifest.json` | Archive version, export date (ISO 8601), source application identifier (`"unitae"`), and per-entity row counts |
+| `data/<entity>.ndjson` | One file per entity type, in newline-delimited JSON. Each line is one row. Empty files are omitted from the archive |
+| `files/` | Uploaded user files (board PDFs, territory cards). Only present when the export was created with `includeFiles: true` |
+
+The archive version is a constant at the top of `app/features/settings/server/data-transfer.type.ts` (`ARCHIVE_VERSION`). On import, an archive whose version does not match is reported as a warning and skipped — the schema is intentionally not backwards-compatible across major bumps; bump the constant when the on-disk shape changes.
+
+Compression is `DEFLATE` via [`jszip`](https://stuk.github.io/jszip/). Buffers are produced in memory; very large exports may need to switch to streaming if memory pressure becomes a concern.
+
+## Entity export ordering
+
+Entities are exported in dependency order so an import can replay them top-down without missing references. The list lives in `buildExportSteps` (`export-congregation.server.ts`). Order matters: territories before attributions, board sections before board documents, etc.
+
+## Conflict resolution on import
+
+The validator scans for natural-key collisions before any write. Decisions per entity type:
+
+| Entity | Detection | Same congregation | Different congregation |
+|---|---|---|---|
+| Users | matching `email` | Update in place | Skip with warning |
+| Territories | matching `number` | Update in place | n/a (RLS-scoped) |
+| Event kinds | matching compound key `(key, congregationId)` | Skip | n/a |
+
+Other entities are inserted as-is; the import flow reassigns primary keys and stitches relationships through `EntityIdMap`.
+
+## Identity remapping
+
+Imported rows get fresh database identities. The `EntityIdMap` (defined in `data-transfer.type.ts`) tracks the mapping from source ID → new ID per entity type so that foreign-key references in subsequent steps are rewritten. Anything that holds a reference to an exported entity must look itself up in the map, not in the raw NDJSON.
+
+## Background processing
+
+Both export and import run as BullMQ jobs through the `data-transfer` queue (`data-transfer-queue.server.ts`). Progress (0–100) is updated via `job.updateProgress` and read by the UI's progress page. The handler lives in `app/features/settings/jobs/handle-data-transfer-work.server.ts`.
+
+## Audit
+
+- Export emits `AuditAction.CongregationExported` with `entityCounts`, `includeFiles`, `includeAuditLogs` in metadata.
+- Import emits `AuditAction.CongregationImported` after the writes complete.
+
+## Storage
+
+Archives land in the configured file storage (S3 or local) under `{congregationId}/exports/{jobId}.unitae`. Cleanup of old archives is currently the host's responsibility — there is no scheduled retention for export files yet.
+
+## Limits
+
+The HTTP upload form caps imports at 500 MB (`MAX_IMPORT_SIZE` in `app/features/settings/routes/congregation/import.tsx`). Exports are unbounded by file size; large exports will eventually OOM the worker because the ZIP is buffered in memory before upload.
+
+## Related
+
+- [Background Processing](background-processing.md) — General BullMQ worker architecture
+- [Architecture](architecture.md) — Multi-tenancy, RLS, and request-flow context

--- a/docs/product/dashboard.md
+++ b/docs/product/dashboard.md
@@ -4,7 +4,7 @@ The dashboard is the homepage every congregation member sees after logging in. I
 
 ## Hero Greeting
 
-The dashboard opens with a large, two-line personalized greeting using the display font (Fraunces):
+The dashboard opens with a large, two-line personalized greeting:
 
 > Hello,
 > Nathanaël.
@@ -28,7 +28,7 @@ When an administrator logs in to a congregation that has not yet been fully set 
 - **Configure territories** — Link to territory list
 - **Upload a document** — Link to document upload
 
-Each step shows a checkmark when the congregation has at least one entity of that type. The checklist can be dismissed manually and stays hidden via browser storage. It disappears automatically once all three steps are completed.
+Each step is checked off as soon as the congregation has at least one of that item. You can dismiss the checklist manually — it stays hidden in your browser. It disappears automatically once all three steps are completed.
 
 ## Urgent Strip
 
@@ -36,12 +36,12 @@ A conditional section that surfaces time-sensitive items from across features. I
 
 | Priority | Type | Condition | Link |
 |---|---|---|---|
-| 0 | Imminent part assignment | User has a programme part and the meeting is within 3 days | `/board` |
-| 1 | Overdue territory | Territory due date is in the past | `/me/territories/{id}` |
-| 2 | Day-off conflict | An upcoming absence overlaps the next meeting where the user has assignments | `/me/days-off` |
-| 3 | Imminent service role | User has a service role and the meeting is within 3 days | `/board` |
-| 4 | Due-soon territory | Territory due date is within 2 weeks | `/me/territories/{id}` |
-| 5 | Unread documents | At least 1 visible document not yet viewed (total count across all documents) | `/board` |
+| 0 | Imminent part assignment | User has a programme part and the meeting is within 3 days | The board |
+| 1 | Overdue territory | Territory due date is in the past | The territory page |
+| 2 | Day-off conflict | An upcoming absence overlaps the next meeting where the user has assignments | The absences page |
+| 3 | Imminent service role | User has a service role and the meeting is within 3 days | The board |
+| 4 | Due-soon territory | Territory due date is within 2 weeks | The territory page |
+| 5 | Unread documents | At least 1 visible document not yet viewed | The board |
 
 Each item is displayed as a clickable row with a colored left border (red for overdue, amber for warnings, teal for informational), an icon, a label, a relative time, and a chevron.
 
@@ -101,18 +101,18 @@ When no absences are planned and no nudge is shown, a *Plan an absence* action b
 
 The *See all* footer link is only shown when the member has absences to browse — it is hidden when the card shows the empty state or nudge.
 
-## Error Resilience
+## Resilience
 
-Each dashboard widget loads its data independently. If one data source is temporarily unavailable (e.g., a database timeout), only the affected card shows a warning message — the rest of the dashboard continues to work normally.
+Each dashboard card loads its own data independently. If one of them fails to load (for example a temporary network hiccup), only that card shows a warning — the rest of the dashboard keeps working.
 
 ## Layout
 
-The dashboard uses a responsive layout with a maximum content width of `max-w-6xl` for readability on wide screens:
+The dashboard adapts to the screen size:
 
-- **Mobile** — Single column. Hero greeting at `text-3xl`. Quick actions appear as a row below the greeting. Cards stacked vertically.
-- **Desktop** — Hero greeting with quick actions side-by-side. Two-column grid for widget cards. All cards use `h-full` for consistent height within grid rows.
+- **On mobile** — A single column. The greeting and quick actions stack at the top, with cards stacked below.
+- **On desktop** — The greeting and quick actions sit side-by-side, with widget cards arranged in a two-column grid.
 
-Cards appear with a staggered fade-in animation (50ms increments) for a smooth entrance. Card footers are pinned to the bottom with `mt-auto`.
+Cards fade in one after another for a smooth entrance, and the dashboard width is capped so it stays comfortable to read on very wide screens.
 
 ## Related
 

--- a/docs/product/data-transfer.md
+++ b/docs/product/data-transfer.md
@@ -31,11 +31,7 @@ The archive contains all congregation data:
 
 ### Archive format
 
-The `.unitae` file is a ZIP archive containing:
-
-- `manifest.json` — Archive version, export date, source application, entity counts
-- `data/*.ndjson` — One file per entity type in newline-delimited JSON format
-- `files/` — Uploaded documents (only when "Include files" is selected)
+The `.unitae` file is a structured archive (a ZIP under the hood) bundling the congregation's data — and, when *Include files* is selected, the uploaded documents too. Contributors interested in the on-disk layout can read [Data Transfer Internals](../development/data-transfer.md).
 
 ## Import
 
@@ -60,8 +56,8 @@ The `.unitae` file is a ZIP archive containing:
 ### Important notes
 
 - **Passwords are never imported.** All imported users must reset their password via email.
-- **IDs are remapped.** Internal references (foreign keys) are updated to match the new database IDs.
-- The import preserves the audit trail by recording a `congregation.imported` event.
+- **Internal identifiers are reissued.** When data is imported into a fresh congregation, every record gets a new internal identity and Unitae automatically re-stitches the relationships between them.
+- The import is recorded in the audit trail.
 
 ## Permissions
 

--- a/docs/product/events.md
+++ b/docs/product/events.md
@@ -7,7 +7,6 @@ The events module manages congregation meeting programmes, event scheduling, and
 Programme templates define the recurring structure of meetings. Each template contains:
 
 - **Name** — The template name (e.g., "Midweek meeting")
-- **Unique key** — An internal identifier
 - **Day of week** — The recurring weekday (left empty for one-time events like the Memorial)
 - **Event type** — An optional event kind (see [Event Kinds](#event-kinds)) automatically applied to all events generated from this template
 - **Parts** — Ordered list of programme parts (spiritual content), each with a name, section grouping, order, optional duration, and a variable flag
@@ -69,7 +68,7 @@ Event kinds are managed by admins at **Settings > Congregation settings > Event 
 
 ## PDF Export
 
-Events can be exported to PDF from the programme list. The export form provides per-template content selection: each template row has checkboxes for parts and services, allowing mixed exports (e.g., midweek parts + weekend services only). Additional options include an editable document title, a date range filter, and grouping by date (chronological) or by template type. The PDF uses a workbook-inspired single-column layout with colored section bars, dot leaders between part names and assignees, and topic replacing part name when available. Parallel parts (same order, different tracks) render as sub-rows with track labels. A legacy URL format (`?templateId=...&contentType=...`) is preserved for backwards compatibility.
+Events can be exported to PDF from the programme list. The export form provides per-template content selection: each template row has checkboxes for parts and services, allowing mixed exports (e.g., midweek parts + weekend services only). Additional options include an editable document title, a date range filter, and grouping by date (chronological) or by template type. The PDF uses a workbook-inspired single-column layout with colored section bars, dot leaders between part names and assignees, and the topic replacing the part name when available. Parallel parts (same order, different tracks) render as sub-rows with track labels.
 
 ## Assignments
 
@@ -118,7 +117,7 @@ The feed includes events from the last 3 months and all future events. Past even
 
 **Subscribing**
 
-The feed URL is a `text/calendar` resource that any standard calendar app can subscribe to:
+Any standard calendar app can subscribe to the feed by pasting the URL:
 
 - **Apple Calendar** — File → New Calendar Subscription → paste the URL
 - **Google Calendar** — Other calendars → From URL → paste the URL

--- a/docs/product/feature-overview.md
+++ b/docs/product/feature-overview.md
@@ -27,7 +27,7 @@ The display board is a digital notice board where congregation administrators ca
 - **Status badges** — New, Unread, and Updated badges on document thumbnails to communicate freshness at a glance
 - **View tracking** — See which members have viewed each document
 - **Dynamic documents** — Live views of publisher groups, pioneer lists, and meeting programmes alongside uploaded PDFs, with preview summaries on cards
-- **In-app PDF viewer** — Embedded viewer with native rendering on desktop and PDF.js fallback on Android
+- **In-app PDF viewer** — Embedded viewer that works on all major browsers and on mobile devices
 - **File replacement & versioning** — Replace a document's PDF while preserving previous versions
 - **Thumbnails** — Auto-generated first-page preview thumbnails for PDF documents
 
@@ -91,7 +91,7 @@ Export and import congregation data for migration, backup, or restoration.
 
 - **Export** — Download a `.unitae` archive containing all congregation data, with options to include uploaded files and audit logs
 - **Import** — Upload a `.unitae` archive with automatic conflict detection and resolution
-- **Background processing** — Large exports and imports run as background jobs with progress tracking
+- **Runs in the background** — Large exports and imports run in the background with progress tracking
 
 See [Data Transfer](data-transfer.md) for details.
 
@@ -116,9 +116,9 @@ Unitae manages religious affiliation data, which is special category data under 
 - **Consent management** — Users can view and withdraw their consents at any time from their profile
 - **Privacy policy** — Built-in `/privacy` page explaining data collection, purposes, legal basis, retention periods, sub-processors, and data subject rights
 - **Cookie consent** — Google Maps integration only loads after explicit user consent (ePrivacy Directive)
-- **Audit logging** — Structured audit trail for login, data export, anonymization, consent changes, user creation, and password operations
-- **Log PII redaction** — Email addresses and personal data fields are automatically hashed in application logs (SHA-256)
-- **Data retention** — Automated cleanup of expired password reset tokens and old withdrawn consent records via `/cron/retention` endpoint
+- **Audit logging** — Audit trail for login, data export, anonymization, consent changes, user creation, and password operations
+- **Log PII obfuscation** — Email addresses and personal data fields are automatically obfuscated in application logs
+- **Data retention** — Automated cleanup of expired password reset tokens and old withdrawn consent records on a recurring schedule
 - **Deletion ledger** — All anonymization operations are recorded for backup reconciliation
 
 ## User Experience
@@ -136,7 +136,7 @@ Unitae includes several features to make the app feel responsive and polished:
 - **Sticky table headers** — Column headers stay visible when scrolling long tables
 - **Persisted page size** — Table pagination remembers the preferred number of rows per page
 - **Entrance animations** — Subtle fade-in animations on page headers and dashboard cards
-- **Error boundaries** — Status-specific error pages (404, 403, 500) with retry button
+- **Friendly error pages** — Status-specific pages (page not found, access denied, server error) with a retry button
 
 ## Coming Soon
 

--- a/docs/product/notifications.md
+++ b/docs/product/notifications.md
@@ -25,19 +25,15 @@ Some actions cancel pending notifications. When a document is deleted shortly af
 
 Users can manage their notification preferences at **Profile > Notification preferences**. Each notification type can be individually enabled or disabled. Preferences can also be set by category (e.g., disabling all board-related notifications at once).
 
-Disabled notifications are never sent — they are filtered out during recipient resolution.
+Users with a notification type disabled are skipped — no email is sent.
 
 ## Email Delivery
 
-Notifications are delivered by email via the Resend API. Emails are rendered in the congregation's language and sent from the congregation's configured sender address.
+Notifications are delivered by email. Emails are rendered in the congregation's language and sent from the congregation's configured sender address. Self-hosters configure the email provider during setup; managed-hosting users do not need to configure anything.
 
-Email delivery requires the `RESEND_API_KEY` environment variable to be set. Without it, the application works normally but no notification emails are sent.
+## Self-hosting requirements
 
-## Cron Requirement
-
-Debounced notifications require the `/cron/process-notifications` endpoint to be called on a regular schedule (every 5–10 minutes). Without this, debounced notifications will accumulate in the database but never be delivered.
-
-See [Cron Jobs](../self-hosting/cron-jobs.md) for setup instructions.
+Debounced notifications need a recurring task to be set up on the server, otherwise emails would never be sent. Self-hosters: see [Cron Jobs](../self-hosting/cron-jobs.md) for the schedule and [Environment Variables](../self-hosting/environment-variables.md) for the email-provider configuration.
 
 ## Related
 

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -1,115 +1,91 @@
 # Security
 
-Unitae is designed with data isolation and security as core concerns. This page describes the security measures in place from a product perspective.
+Unitae is built so that each congregation's data stays private to that congregation, accounts are protected against common attacks, and personal data is handled in line with European data protection rules. This page describes those protections in plain terms; readers who want the technical specifics can follow the cross-links to the contributor documentation.
 
 ## Authentication
 
 ### Login
 
-Users authenticate with an email address and password. Sessions are managed through HTTP-only cookies that cannot be accessed by client-side JavaScript.
+Users log in with an email address and password. The session is stored in a secure browser cookie that JavaScript on the page cannot read.
 
-- **Session lifetime**: 1 hour in production, 8 hours in development
-- **Session cookie**: HTTP-only, `SameSite=Lax`, configurable domain via `UNITAE_COOKIE_DOMAIN`
+- **Session lifetime** — 1 hour in production, 8 hours in local development.
 
-### Rate Limiting
+### Rate limiting
 
-Login attempts are rate-limited to prevent brute-force attacks:
+Login attempts are limited to **5 attempts per 15 minutes per email address** to prevent brute-force attacks. Password reset requests are similarly limited.
 
-- **5 login attempts** per 15 minutes per email address
-- Rate limiting is backed by Redis and persists across application restarts
+### Password security
 
-### Password Security
+Passwords are securely hashed before being stored — the original password is never written anywhere. Password comparison is performed in a way that does not reveal information through timing.
 
-- Passwords are hashed using **scrypt** with a 16-byte random salt and 32-byte derived key
-- Passwords are never stored in plain text
-- Password comparison uses constant-time comparison to prevent timing attacks
+### Password reset
 
-### Password Reset
+Users can request a password reset link by email. Reset links are valid for **24 hours** and can only be used once.
 
-Users can request a password reset link via email:
+### Personal calendar feeds
 
-- Reset tokens are valid for **24 hours**
-- Tokens are single-use — consumed immediately when the password is changed
-- Tokens are generated using `crypto.randomBytes(32)`
+Each member can subscribe a calendar app to their personal assignments via a private URL (see [Events — Personal Calendar Feed](events.md#personal-calendar-feed)). The URL contains a per-user secret token; the feed gives read-only access to the user's own assignments and absences only. The user can revoke the URL at any time, which immediately stops the feed for any app subscribed to it.
 
-### Calendar Feed Tokens
+## Data isolation between congregations
 
-Users can subscribe their personal calendar app to their assignments via a private iCalendar URL (see [Events — Personal Calendar Feed](events.md#personal-calendar-feed)). The URL is authenticated by a per-user token:
+A user in one congregation can never see data from another congregation. Unitae enforces this at the database level — not just in the user interface — so an application bug cannot accidentally leak data across congregations.
 
-- Tokens are 32 random bytes encoded as base64url, generated with `crypto.randomBytes(32)` (the same primitive as password reset)
-- Each user has at most one active token; regenerating revokes the previous token immediately
-- Tokens do **not** expire automatically — users revoke or regenerate them manually
-- The token grants read-only access to the user's own programme assignments, service roles, and days off — nothing else
-- Because calendar apps cannot send authentication cookies, the bearer token must travel in the URL; users should treat the URL as a personal secret
-- Both creation and revocation are recorded in the audit log (`calendar_feed.token.created`, `calendar_feed.token.revoked`)
+Uploaded files (board PDFs, territory cards) are stored in separate paths per congregation, with random filenames so that no one can guess at or enumerate file URLs.
 
-## Data Isolation
+## Role-based access control
 
-### Congregation Scoping
-
-All congregation data is strictly isolated. The application uses PostgreSQL Row-Level Security (RLS) to enforce tenant isolation at the database level. This means:
-
-- A user in Congregation A can never see data from Congregation B
-- This isolation is enforced at the database query level, not just the UI level
-- 28 models are congregation-scoped (see [Architecture](../development/architecture.md#data-isolation) for the full list)
-
-### File Storage Isolation
-
-Uploaded files are stored with congregation-scoped keys:
-
-```
-{congregationId}/board/{uuid}.pdf
-```
-
-Each congregation's files are stored in a separate path, and filenames use UUIDs to prevent enumeration.
-
-## Role-Based Access Control
-
-Access to features is controlled through 14 fine-grained roles. Roles are checked on every request — both in the UI (to show/hide elements) and on the server (to enforce access).
+Access to features is controlled through 14 fine-grained roles. Roles are checked on every request — both in the UI (to show or hide elements) and on the server (to enforce access).
 
 See [Roles and Permissions](roles-and-permissions.md) for the full list of roles and what they control.
 
-## GDPR & Data Protection
+## GDPR & data protection
 
 Unitae processes religious affiliation data, classified as special category data under GDPR Article 9. The application includes built-in tools to help comply with European data protection regulations:
 
-- **User data export** — JSON export of all personal data (Articles 15 & 20)
-- **User anonymization** — Replace personal data with non-identifiable values while preserving referential integrity (Article 17)
-- **Consent tracking** — Consent gate on first login, management page for users to withdraw consent
-- **Cookie consent** — Third-party services (Google Maps) only load after explicit consent
-- **Audit logging** — Structured audit trail for all GDPR-sensitive operations (login, data export, anonymization, consent changes, user creation, password operations)
-- **Log PII redaction** — Email addresses and personal data fields automatically hashed in application logs
-- **Data retention** — Automated cleanup of expired tokens and old consent records
-- **Deletion ledger** — Audit trail of all anonymization operations for backup reconciliation
-- **Privacy policy** — Built-in `/privacy` page covering all RGPD requirements
-- **Session invalidation** — Anonymized users are immediately logged out
+- **User data export** — JSON export of all personal data (Articles 15 & 20).
+- **User anonymisation** — Replace personal data with non-identifiable values while preserving aggregated reports (Article 17).
+- **Consent gate** — Users must explicitly consent to data processing on their first login before accessing the application.
+- **Consent management** — Users can view and withdraw their consents at any time from their profile.
+- **Cookie consent** — Third-party services (Google Maps) only load after explicit consent.
+- **Audit logging** — A trail of GDPR-sensitive operations: login, data export, anonymisation, consent changes, user creation, password operations.
+- **Log PII obfuscation** — Email addresses and other personal data are automatically obfuscated in application logs.
+- **Data retention** — Automated cleanup of expired tokens and old withdrawn consent records.
+- **Deletion ledger** — Anonymisation operations are recorded for backup reconciliation.
+- **Privacy policy** — A built-in `/privacy` page covering all GDPR requirements.
+- **Session invalidation** — Anonymised users are immediately logged out.
 
 For the managed hosting service, MindsersIT acts as data processor under a Data Processing Agreement (DPA) with each congregation. Self-hosted instances are under the sole responsibility of the deploying entity.
 
-## Vulnerability Reporting
+## Vulnerability reporting
 
 If you discover a security vulnerability in Unitae, please report it responsibly:
 
-- **Do not** create a public GitHub issue for security problems
-- Use [GitHub Security Advisories](https://github.com/Unitae/unitae/security/advisories) to report vulnerabilities privately
-- See [SECURITY.md](../../SECURITY.md) for the full disclosure policy and reporting details
+- **Do not** create a public GitHub issue for security problems.
+- Use [GitHub Security Advisories](https://github.com/Unitae/unitae/security/advisories) to report vulnerabilities privately.
+- See [SECURITY.md](../../SECURITY.md) for the full disclosure policy and reporting details.
 
-### In Scope
+### In scope
 
-- Authentication bypass
-- Data leaks between congregations
-- SQL injection, XSS, CSRF
-- Unauthorized file storage access
-- Privilege escalation
+- Authentication bypass.
+- Data leaks between congregations.
+- SQL injection, XSS, CSRF.
+- Unauthorized file storage access.
+- Privilege escalation.
 
 ### Response
 
-- 48-hour acknowledgment
-- 7-day initial assessment
-- Credit in release notes (if desired)
+- 48-hour acknowledgment.
+- 7-day initial assessment.
+- Credit in release notes (if desired).
+
+## For technical readers
+
+Implementation details — hashing parameters, cookie attributes, calendar feed token format, audit action keys, file-key templates, log redaction algorithm — are documented in the contributor docs:
+
+- [Architecture — Security](../development/architecture.md#security) — The full reference list.
+- [Row-Level Security](../development/row-level-security.md) — How tenant isolation is enforced at the database level.
 
 ## Related
 
-- [Roles and Permissions](roles-and-permissions.md) — The 14 roles that control access to features
-- [FAQ](../resources/faq.md) — "Is my data safe?" and other common questions
-- [Architecture](../development/architecture.md) — Technical details of the data isolation model
+- [Roles and Permissions](roles-and-permissions.md) — The 14 roles that control access to features.
+- [FAQ](../resources/faq.md) — "Is my data safe?" and other common questions.

--- a/docs/product/territories.md
+++ b/docs/product/territories.md
@@ -41,11 +41,11 @@ Clicking a territory opens a detail page with two tabs:
 
 Assignment info (start date, return date with relative time, status) is shown above the tabs.
 
-The personal territory view is security-scoped: the server only returns territory data if the current user has an active assignment for it.
+Members only ever see territories they currently have an active assignment for.
 
 ## Admin Territory View
 
-The admin territory detail page (`/territories/territory/:id/view`) is the read-only counterpart to the editor. It is laid out as stacked cards on the left with the map on the right. On large screens the map sticks to the top of the viewport while the cards scroll past it.
+The admin territory detail page is the read-only counterpart to the editor. It is laid out as stacked cards on the left with the map on the right. On large screens the map sticks to the top of the viewport while the cards scroll past it.
 
 Cards, top to bottom:
 
@@ -59,7 +59,7 @@ The page header carries previous/next arrows to step through territories of the 
 
 ## Territory Editor
 
-When a Google Maps API key is configured, `/territories/territory/:id/edit` opens a map-driven editor. The map fills most of the page and a summary panel on the right tracks the changes you have not yet saved. Without an API key, the page falls back to a dropdown selector (postal code → street → address) so the editor stays fully usable.
+When a Google Maps API key is configured, the territory edit page opens a map-driven editor. The map fills most of the page and a summary panel on the right tracks the changes you have not yet saved. Without an API key, the page falls back to a dropdown selector (postal code → street → address) so the editor stays fully usable.
 
 ### Map markers
 

--- a/docs/product/what-is-unitae.md
+++ b/docs/product/what-is-unitae.md
@@ -23,13 +23,13 @@ Unitae is a web application designed specifically for Jehovah's Witnesses congre
 
 Unitae is licensed under [AGPL-3.0](../resources/licensing.md). All application code is open source — there are no proprietary plugins, no locked features, and no code hidden behind a paid tier. Self-hosted users get the exact same features as users on the managed platform.
 
-#### Ghost-Inspired Open-Core Model
+#### How development is funded
 
-Unitae follows the model pioneered by [Ghost](https://ghost.org/): 100% of the code is open source, and development is funded through a managed hosting service at [unitae.app](https://unitae.app). This means the community can contribute to everything, audit the code, and self-host freely — while MindsersIT sustains active development through the hosted offering.
+Unitae follows the model pioneered by [Ghost](https://ghost.org/): 100% of the code is open source, and development is funded through a managed hosting service at [unitae.app](https://unitae.app). The community can contribute to everything, inspect the code, and self-host freely — while MindsersIT sustains active development through the hosted offering.
 
 ### Self-Hosting Without Compromise
 
-When you self-host Unitae, all resource limits are unlimited by default. There is no artificial restriction that pushes you toward the paid service. The managed hosting at unitae.app offers convenience (automatic updates, backups, TLS, support), not exclusive features.
+When you self-host Unitae, all resource limits are unlimited by default. There is no artificial restriction pushing you toward the paid service. The managed hosting at unitae.app offers convenience (automatic updates, backups, secure connections, support) — not exclusive features.
 
 ## Who Builds Unitae
 
@@ -39,9 +39,7 @@ The project is open to community contributions — see [CONTRIBUTING.md](../../C
 
 ## Language
 
-The user interface and code comments are written in **French**, reflecting the primary user base. Documentation, commit messages, and pull request descriptions are written in **English**.
-
-Internationalization (i18n) support is on the roadmap but not yet available.
+The user interface is available in **French** and **English**, reflecting the primary user base. Documentation is written in English. Support for additional languages is on the roadmap.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

`docs/product/*` is read by non-technical end users evaluating Unitae — typically congregation administrators with little or no software background. The rest of `docs/` is for contributors and self-hosters and is fine with implementation-level detail.

A spot-check (during PR #165) flagged `display-board.md` and `roles-and-permissions.md`. This PR audits the **other nine product docs** in the same vein: strips technical leakage (model names, env vars, file paths, framework names, CSS classes, code symbols, internal endpoint paths) and reframes everything as user-facing behavior. Where the technical detail had value for contributors, it was **moved** to the appropriate dev doc rather than deleted.

## Per-file changes (one commit each)

| File | Commit | Notes |
|---|---|---|
| `what-is-unitae.md` | `4525f82` | Stripped "Open-Core" jargon, "TLS" → "secure connections", corrected the language note (UI is already bilingual, not French-only with i18n on the roadmap) |
| `notifications.md` | `f958687` | Removed Resend API mention, `RESEND_API_KEY` env var, `/cron/process-notifications` endpoint path, "filtered out during recipient resolution" — those details already live in self-hosting docs and are now cross-linked |
| `dashboard.md` | `aa4997a` | Stripped Tailwind class refs (`max-w-6xl`, `text-3xl`, `h-full`, `mt-auto`), font name, animation timing internals, route-template `{id}` placeholders. Verified the urgent-strip priorities/conditions/links match `app/features/dashboard/ui/build-urgent-items.ts` |
| `data-transfer.md` | `293a15d` | Stripped archive-format internals (`manifest.json`, NDJSON layout, literal `congregation.imported` action key, "foreign keys"). Created a new contributor doc `docs/development/data-transfer.md` for the full archive-format spec (entity ordering, conflict resolution algorithm, identity remapping, BullMQ queue, audit actions, storage path, limits) and added it to `docs/README.md`. Verified conflict resolution + 500 MB upload cap |
| `events.md` | `7223b51` | Removed "Unique key — An internal identifier" template field, the legacy-URL backwards-compatibility note, `text/calendar` MIME-type wording. Verified 3-month feed horizon and per-template responsibility behaviour |
| `territories.md` | `0648a6a` | Removed `/territories/territory/:id/view`, `:id/edit` route templates and reworded "security-scoped: the server only returns…" |
| `security.md` | `f3441fe` | Largest rewrite. Kept evaluation-level claims (sessions expire, brute-force protection, per-congregation isolation at the database level, GDPR feature list, vulnerability reporting). Moved scrypt parameters, `crypto.randomBytes` references, cookie attribute names, env var names, model count, file-key template, internal audit action keys, and the SHA-256 algorithm reference into the existing Security section of `docs/development/architecture.md` so contributors and self-hosters still find them in one place. The product doc cross-links to architecture.md and row-level-security.md for technical readers |
| `feature-overview.md` | `24d6989` | Removed PDF.js library reference, `/cron/retention` endpoint path, SHA-256 algorithm name, "Error boundaries" jargon. Reframed "Background processing" as "Runs in the background" |

`publishers.md` was audited and found to be already audience-appropriate; no commit was needed (verified against the schemas in `app/features/publishers/schemas/`).

## Test plan

- [ ] Read each rewritten file front-to-back and confirm it makes sense to someone with no codebase familiarity
- [ ] Confirm each cross-link works (the new `docs/development/data-transfer.md`, the moved security details inside `docs/development/architecture.md#security`, the existing self-hosting docs)
- [ ] Spot-check that `feature-overview.md`'s summaries match the now-cleaned per-feature files

## Notes

- This branch is independent of PR #165 (which already cleaned up `display-board.md` and `roles-and-permissions.md` along its scope).
- No code was touched.