### PR TITLE
fix(settings): backfill role-permission rows missed by #157

### DIFF
--- a/app/database/migrations/20260513000000_backfill_role_permissions/migration.sql
+++ b/app/database/migrations/20260513000000_backfill_role_permissions/migration.sql
@@ -1,0 +1,18 @@
+-- Phase 3 of the role epic (#157) added roles-viewer, roles-manager, and
+-- permissions-manager to the Permission enum but shipped no SQL migration to
+-- insert the rows. Fresh installs created them via seedPermissions(); upgrade
+-- deploys (which only run `prisma migrate deploy`) never gained them, so the
+-- new role-management UI shows an empty permission list for admins.
+--
+-- This migration backfills the three rows. Admin permission already implies
+-- every other permission (see app/shared/auth/permissions.server.ts), so
+-- existing admin users regain UI access as soon as the rows exist. Non-admin
+-- users need explicit grants via /settings/permissions.
+--
+-- Idempotent: safe to re-run.
+
+INSERT INTO "Permission" ("key") VALUES
+  ('roles-viewer'),
+  ('roles-manager'),
+  ('permissions-manager')
+ON CONFLICT ("key") DO NOTHING;


### PR DESCRIPTION
## Summary
- Phase 3 of the role epic (#157) added `roles-viewer`, `roles-manager`, and `permissions-manager` to the `Permission` enum but shipped no SQL migration to insert the rows.
- Fresh installs got them via `seedPermissions()`; upgrade deploys (which only run `prisma migrate deploy`) never gained them, so the role-management UI shows an empty permission list for admins.
- Adds an idempotent backfill migration. `Permission.Admin` already implies every other permission, so existing admins regain UI access as soon as the rows exist; non-admins need explicit grants via `/settings/permissions`.

## Test plan
- [x] `pnpm db:migrate` applies the new migration cleanly on the local dev DB
- [ ] After deploy in production, the three permissions appear in the role-permission picker
- [ ] Re-running the migration is a no-op (`ON CONFLICT DO NOTHING`)