### PR TITLE
docs: bring docs/ back in sync with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ app/
 | Route definitions | `app/routes.ts` |
 | Shared UI components | `app/shared/ui/` |
 | AppError classes | `app/shared/errors/app-error.server.ts` |
-| Role enum | `app/shared/types/role.ts` |
+| Permission enum | `app/shared/types/permission.ts` |
+| Role helpers (display names, built-in keys, custom-role CRUD) | `app/shared/types/role.ts`, `app/shared/domain/built-in-roles.server.ts`, `app/shared/domain/roles.server.ts` |
 
 ## Build and Test Commands
 
@@ -215,16 +216,16 @@ return withScopeFromContext(context, async db => {
 ### Authentication & authorization
 
 ```typescript
-// Layout route
-export const middleware = [requireAuth([Role.Admin, Role.TerritoriesManager, /* ALL 14 roles */])]
+// Layout route — the _required arg is deprecated and ignored
+export const middleware = [requireAuth()]
 
 // Route loader/action
 const user = context.get(userContext)
 const permissions = context.get(permissionsContext)
-if (!permissions.has(Role.TerritoriesManager)) throw redirect('/dashboard')
+if (!permissions.has(Permission.TerritoriesManager)) throw redirect('/dashboard')
 ```
 
-**Critical:** `requireAuth()` only resolves roles explicitly listed. Omitting a role means `permissions.has(Role.X)` always returns `false` — silently hiding features. All 14 roles must be listed in `_authenticated-layout.tsx`.
+**Auth model:** `Permission` (20 entries, in `app/shared/types/permission.ts`) is the unit of access. **Roles** (DB table) bundle permissions and are assigned to users — built-in roles plus custom roles a Roles Manager creates. `requireAuth()` runs `resolveEffectivePermissions` and stores the user's full granted set in `permissionsContext`; the legacy `_required` parameter is retained for call-site compatibility but no longer filters anything. See `docs/development/permissions-and-roles.md`.
 
 ### Form validation
 
@@ -301,6 +302,19 @@ await createTerritory(db, ...)
 - ❌ **Don't use `congregationId: <real value>` in `db.*.create()`** — Use `congregationId: 0 as number`; RLS injects the real value at runtime
 - ❌ **Don't use `any` type** — TypeScript strict mode is enforced everywhere except explicit `noExplicitAny` suppressions
 - ❌ **Don't create circular imports between features** — Features must be independent; use `shared/` for cross-feature utilities
+
+## Gotchas
+
+- **`.env` files are not readable** via the Read tool or `cat` — derive env vars by grepping `process.env\.` in `app/`.
+- **Job handlers** live in `app/features/{feature}/jobs/handle-*-work.server.ts`, not under `server/`. Worker imports them from `app/workers/worker.server.ts`.
+- **Email templates** are colocated per feature (`app/features/{feature}/emails/*.tsx`); the `pnpm start:emails` dev server is configured with `--dir app/features`.
+- **Built-in role memberships are auto-synced** from `User` boolean fields. After editing `isPublisher`, `isMale`, `baptismDate`, `isAnointed`, `isHelder`, or `isServant`, call `syncBuiltInRoleAssignments` (`app/shared/domain/built-in-roles.server.ts`).
+
+## Known gaps
+
+- **#170** — the data-transfer export (`ENTITY_FILES` in `app/features/settings/server/data-transfer.type.ts`) silently drops 11 feature tables added since the export feature shipped (custom roles, allowed-roles, external speakers, card overlays, perimeter, board section visibility). Bump `ARCHIVE_VERSION` if you fix it.
+- **#171** — `BoardDocumentVersion` and `BoardDynamicDocumentSettings` carry `congregationId` but have no `CREATE POLICY` in any migration. They're reached only through scoped Prisma queries today; the database-side guarantee is missing.
+- **Notification recipient resolver** (`app/features/notifications/server/resolve-recipients.server.ts`) reads `CongregationUserPermission` directly; users who hold a permission only via a custom role aren't picked up.
 
 ## Environment Configuration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Start here to understand the product, its features, and how it works.
 
 - [What is Unitae?](product/what-is-unitae.md) — The problem it solves, how it differs, who builds it
 - [Feature Overview](product/feature-overview.md) — A glance at all features
-- [Roles and Permissions](product/roles-and-permissions.md) — The 14 roles and access control system
+- [Roles and Permissions](product/roles-and-permissions.md) — Permissions, built-in roles, and custom roles
 - [Security](product/security.md) — How your data is protected (includes GDPR & data protection)
 
 Feature deep dives:
@@ -20,7 +20,9 @@ Feature deep dives:
 - [Territories](product/territories.md) — Geographic areas, attributions, prospection, and statistics
 - [Publishers](product/publishers.md) — Profiles, groups, and activity tracking
 - [Events](product/events.md) — Meeting programmes, assignments, and days off
+- [Calendar Feed](product/calendar-feed.md) — Subscribe your personal assignments and absences from any calendar app
 - [Notifications](product/notifications.md) — Email notifications with debouncing and preferences
+- [Settings](product/settings.md) — Users, roles, congregation preferences, data transfer, audit log
 - [Data Transfer](product/data-transfer.md) — Export and import congregation data
 
 ### Use the managed hosting service
@@ -55,6 +57,7 @@ Getting started:
 Architecture and systems:
 
 - [Architecture](development/architecture.md) — System design, request flow, and data isolation
+- [Permissions and Roles](development/permissions-and-roles.md) — The Permission enum, the Role layer, and how `requireAuth` resolves them
 - [Row-Level Security](development/row-level-security.md) — How RLS enforces tenant isolation
 - [Background Processing](development/background-processing.md) — BullMQ worker architecture
 - [Data Transfer Internals](development/data-transfer.md) — Archive format and import/export contributor reference

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -43,7 +43,7 @@
 │  │  Board Docs     │  │  Board Docs      │              │
 │  └─────────────────┘  └──────────────────┘              │
 │                                                         │
-│  Global: Permission (16 permission definitions)         │
+│  Global: Permission (20 permission definitions)         │
 │  Global: PasswordResetToken, EmailVerificationToken,    │
 │          CalendarFeedToken                              │
 └─────────────────────────────────────────────────────────┘
@@ -53,16 +53,17 @@
 
 1. **Reverse Proxy** (Traefik/Nginx) routes incoming requests to web pods
 2. **React Router** matches route, runs middleware then loader/action
-3. **`requireAuth(permissions)`** middleware (from `app/shared/middleware/auth.server.ts`) authenticates user, resolves permissions, checks GDPR consent, and sets typed context
+3. **`requireAuth()`** middleware (from `app/shared/auth/middleware.server.ts`) authenticates user, resolves the full effective permission set, checks GDPR consent, and sets typed context. The `_required` parameter on the function signature is retained for call-site compatibility but no longer used — see [Permissions and Roles](permissions-and-roles.md)
 4. **Loader/action** reads context via `context.get(userContext)`, `context.get(congregationContext)`, `context.get(permissionsContext)`
 5. **`withScopeFromContext(context, fn)`** opens a PostgreSQL transaction with `SET LOCAL` for Row-Level Security
 6. **Service functions** (`features/*/server/`) receive the scoped `TransactionClient` and handle business logic
 7. **Route component** renders with loader data
 
 ```
-Middleware → requireAuth([Permission.X, Permission.Y])
-           → verifySession(request)              // authenticates user, returns congregation
-           → verifyPermission(request, perm)     // checks permissions (via Promise.all)
+Middleware → requireAuth()
+           → verifySession(request)                          // authenticates user, returns congregation
+           → resolveEffectivePermissions(userId, congId)     // unions direct + role-mediated permissions
+           → enforceGdprConsent(userId)                      // redirects to /consent if not granted
            → context.set(userContext, currentUser)
            → context.set(congregationContext, congregation)
            → context.set(permissionsContext, permissions)
@@ -101,17 +102,19 @@ When to use each:
 | Background workers | `withScope(congregationId, ...)` or `unscopedDb` | Sync jobs use `withScope`, email jobs use `unscopedDb` with explicit `where` |
 | Platform admin | `unscopedDb` | Cross-congregation queries |
 
-**Scoped models** (30 — all carry `congregationId` and are isolated by RLS):
-- **Auth**: User, CongregationUserPermission
-- **Board**: BoardSection, BoardDocument, BoardDocumentVersion, BoardDynamicDocumentSettings
+**Scoped models** (all carry `congregationId` and are isolated by RLS):
+- **Auth**: User, CongregationUserPermission, Role, RolePermission, UserRoleAssignment
+- **Board**: BoardSection, BoardSectionVisibilityRole, BoardDocument, BoardDocumentVersion, BoardDynamicDocumentSettings
 - **Territories**: Territory, Attribution, Building, BuildingEntrance, BuildingAccess, BuildingResidentialData, TerritoryCardOverlay, TerritoryPerimeter
 - **Publishers**: PublisherGroup, PublisherActivity
-- **Events**: Event, EventKind, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplateServiceRole, ProgrammePartAssignment, ProgrammeServiceRoleAssignment, ProgrammeTemplateResponsible
+- **Events**: Event, EventKind, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplateServiceRole, ProgrammePartAssignment, ProgrammeServiceRoleAssignment, ProgrammeTemplateResponsible, ExternalSpeaker
 - **Settings**: Setting
 - **Notifications**: NotificationEvent, NotificationPreference
 - **GDPR / Audit**: AuditLog, DataDeletionRecord, ConsentRecord
 
-**Global models** (6 — no `congregationId`, not scoped by RLS): Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView
+**Global models** (no `congregationId`, not scoped by RLS): Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView
+
+The authoritative list lives in `app/database/schema.prisma`.
 
 ## Authentication & Permission Flow
 
@@ -120,9 +123,12 @@ Login → validateCredentials(email, password)
       → set session cookie (userId)
       → redirect to /
 
-Protected Route → requireAuth([permissions]) middleware on layout route
+Protected Route → requireAuth() middleware on layout route
                 → verifySession: fetch user (unscopedDb), check suspension/trial/email
-                → verifyPermission: check CongregationUserPermission (unscopedDb, via Promise.all)
+                → resolveEffectivePermissions: union direct grants
+                  (CongregationUserPermission) + role-mediated grants
+                  (RolePermission joined to UserRoleAssignment); expands Admin
+                  to every Permission value
                 → context.set(userContext, currentUser)
                 → context.set(congregationContext, congregation)
                 → context.set(permissionsContext, Set<Permission>)
@@ -130,6 +136,8 @@ Protected Route → requireAuth([permissions]) middleware on layout route
 Permission Check → context.get(permissionsContext).has(Permission.TerritoriesViewer) → boolean
                 (resolved during requireAuth middleware, no extra DB query)
 ```
+
+The end-to-end model — Permission enum, Role/RolePermission/UserRoleAssignment tables, built-in vs custom roles — is documented in [Permissions and Roles](permissions-and-roles.md).
 
 ## Redis Architecture
 
@@ -212,7 +220,7 @@ export async function loader({ params, context }: Route.LoaderArgs) {
 
 | Route | File | Description |
 |-------|------|-------------|
-| `GET /territories/territory/:id/pdf` | `territories/routes/territory/pdf-download.tsx` | Individual territory card — accessible to `TerritoriesViewer` or the attributed publisher |
+| `GET /territories/territory/:id/pdf` | `territories/routes/territory/pdf-download.tsx` | Individual territory card — accessible to anyone with `Permission.TerritoriesViewer` or the attributed publisher |
 | `GET /publishers/:id/activity/pdf` | `publishers/routes/publishers/activity-pdf.tsx` | Publisher S-21 activity report |
 | `GET /territories/attributions/export/:year/pdf` | `territories/routes/attributions/pdf-export.tsx` | S-13 annual attribution report |
 | `GET /programs/export-pdf/download` | `events/routes/programs/export-pdf-download.tsx` | Programme PDF export |
@@ -261,9 +269,14 @@ Bulk operations (`bulkDeleteBoardItems`, `bulkMoveBoardItems`) and high-frequenc
 
 ### Covered actions
 
+The full list lives in the `AuditAction` map in `app/shared/domain/audit.server.ts`. As of writing it covers:
+
 | Domain | When fired |
 |---|---|
 | Authentication | Login, logout, failed login |
+| User management | User created/updated/anonymized, direct permission grants, role assignments synced and changed |
+| Roles | Role created/updated/deleted, role-permission set changed, allowed-roles changed (programme parts, service roles) |
+| Calendar feed | Personal token created and revoked |
 | Consent | Granted, withdrawn |
 | Passwords | Reset requested, changed |
 | Territories | Created, updated, deleted |
@@ -273,7 +286,10 @@ Bulk operations (`bulkDeleteBoardItems`, `bulkMoveBoardItems`) and high-frequenc
 | Publisher groups | Created, deleted |
 | Publisher activity | Created, updated, deleted |
 | Board documents | Created, updated, deleted |
-| Board sections | Created, updated |
+| Board sections | Created, updated, visibility role list changed |
+| Territory card overlays | Created, updated, deleted |
+| Territory perimeter | Updated, cleared |
+| External speakers | Created, updated, archived, unarchived |
 | Congregation settings | Updated |
 | Data transfer | Export, import |
 | Platform admin | All cross-congregation operations |
@@ -296,7 +312,7 @@ pnpm test:e2e:headed        # E2E tests with browser visible
 - **Email verification**: Required before accessing the app, 24h token expiry
 - **Rate limiting**: Login (5/15min), password reset (3/15min) per email via Redis
 - **Calendar feed tokens**: 32 random bytes encoded as base64url (`crypto.randomBytes(32)`), one active per user, no automatic expiry, manually revoked or regenerated. Audited via `calendar_feed.token.created` and `calendar_feed.token.revoked` actions
-- **Permissions**: 16 congregation-scoped permissions via CongregationUserPermission
+- **Permissions**: 20 congregation-scoped permissions, granted directly via `CongregationUserPermission` or through `Role` membership (see [Permissions and Roles](permissions-and-roles.md))
 - **Files**: Congregation-scoped storage keys with UUID filenames (`{congregationId}/board/{uuid}.pdf`)
 - **RLS**: PostgreSQL Row-Level Security for tenant data isolation
 - **Log PII redaction**: Email addresses and personal data fields hashed with SHA-256 in application logs

--- a/docs/development/background-processing.md
+++ b/docs/development/background-processing.md
@@ -45,7 +45,7 @@ export const QUEUE_NAMES = {
 Imports and processes open data (BANO addresses) for territory management.
 
 - **Producer**: `app/features/territories/server/sync-queue.server.ts`
-- **Handler**: `app/features/territories/server/handle-sync-work.server.ts`
+- **Handler**: `app/features/territories/jobs/handle-sync-work.server.ts`
 - **Concurrency**: 1 (CPU/IO-intensive import)
 - **Retries**: 3 attempts, exponential backoff (10s base)
 - **Tenant isolation**: Uses `withScope(congregationId, ...)` for RLS-scoped DB access
@@ -73,7 +73,7 @@ Job types (discriminated union on `type`):
 Generates PDF thumbnails asynchronously after document upload.
 
 - **Producer**: `app/features/display-board/server/thumbnail-queue.server.ts`
-- **Handler**: `app/features/display-board/server/handle-thumbnail-work.server.ts`
+- **Handler**: `app/features/display-board/jobs/handle-thumbnail-work.server.ts`
 - **Concurrency**: 2 (CPU-bound `pdftoppm` subprocess)
 - **Retries**: 3 attempts, exponential backoff (5s base)
 - **Job data**: `{ congregationId, documentId, pdfStorageKey }`
@@ -86,7 +86,7 @@ Documents are created with `thumbnailUri: null` and updated asynchronously when 
 Handles congregation data export and import as background jobs.
 
 - **Producer**: `app/features/settings/server/data-transfer-queue.server.ts`
-- **Handler**: `app/features/settings/server/handle-data-transfer-work.server.ts`
+- **Handler**: `app/features/settings/jobs/handle-data-transfer-work.server.ts`
 - **Concurrency**: 1 (IO-intensive archive creation/extraction)
 - **Retries**: None (1 attempt only)
 - **Tenant isolation**: Uses `withScope(congregationId, ...)` for RLS-scoped DB access
@@ -145,7 +145,7 @@ The worker is only needed if you're working on territory sync, document uploads,
 
 1. Add queue name to `QUEUE_NAMES` in `app/shared/infra/queues.server.ts`
 2. Create queue producer: `app/features/{feature}/server/{name}-queue.server.ts`
-3. Create handler: `app/features/{feature}/server/handle-{name}-work.server.ts`
+3. Create handler: `app/features/{feature}/jobs/handle-{name}-work.server.ts` (handlers live in a per-feature `jobs/` directory, separate from `server/`)
    - For scoped DB access: use `withScope(congregationId, ...)`
    - For cross-tenant queries: use `unscopedDb` with explicit `where: { congregationId }`
    - For email rendering: wrap in `runWithLocale(congregation.locale, ...)`

--- a/docs/development/data-transfer.md
+++ b/docs/development/data-transfer.md
@@ -20,6 +20,12 @@ Compression is `DEFLATE` via [`jszip`](https://stuk.github.io/jszip/). Buffers a
 
 Entities are exported in dependency order so an import can replay them top-down without missing references. The list lives in `buildExportSteps` (`export-congregation.server.ts`). Order matters: territories before attributions, board sections before board documents, etc.
 
+## What's not yet exported
+
+Several feature tables added since the export was first written are **not** yet enumerated in `ENTITY_FILES` and therefore not included in the archive — custom roles and their permission bundles, user role memberships, role gating on board sections, allowed-roles on programme parts/service roles, the external-speakers registry, territory card overlays, and the territory perimeter. An export+import round-trip on a congregation that uses these features silently drops them on the target side.
+
+Tracked in [#170](https://github.com/Unitae/unitae/issues/170). When extending `ENTITY_FILES`, also bump `ARCHIVE_VERSION` so older archives are rejected (or handled with an explicit "this archive predates feature X" warning) on import.
+
 ## Conflict resolution on import
 
 The validator scans for natural-key collisions before any write. Decisions per entity type:

--- a/docs/development/email-templates.md
+++ b/docs/development/email-templates.md
@@ -6,16 +6,22 @@ Unitae uses **React Email** for email templates and **Resend** as the delivery p
 
 ## File Structure
 
+Email templates are colocated with the feature that triggers them — there is no centralized `app/emails/` directory.
+
 ```
-app/emails/
-├── reset-password.tsx                    # Password reset link
-├── reset-password-required.tsx           # Forced password reset notification
-├── verify-email.tsx                      # Email verification link
-└── notifications/
-    ├── new-document-in-board.tsx          # New document uploaded to board
-    ├── documents-expiring.tsx            # Documents approaching expiration
-    └── buildings-sync-done.tsx           # Territory sync completion
+app/features/
+├── authentication/emails/
+│   ├── reset-password.tsx                # Password reset link
+│   ├── reset-password-required.tsx       # Forced password reset notification
+│   └── verify-email.tsx                  # Email verification link
+├── notifications/emails/
+│   ├── new-document-in-board.tsx         # New document uploaded to board
+│   └── documents-expiring.tsx            # Documents approaching expiration
+└── territories/emails/
+    └── buildings-sync-done.tsx           # Open data sync completion
 ```
+
+The `pnpm start:emails` dev server is configured with `--dir app/features` (see `package.json`), so it finds templates anywhere under that tree.
 
 ## Template Pattern
 
@@ -73,7 +79,7 @@ Key conventions:
    emailQueue.add('new-document-notification', { congregationId, documentId })
    ```
 
-2. The worker picks up the job in `app/shared/infra/handle-email-work.server.tsx`
+2. The worker picks up the job in `app/features/notifications/jobs/handle-email-work.server.tsx`
 
 3. The handler wraps rendering in `runWithLocale()` for correct i18n:
    ```typescript
@@ -99,29 +105,11 @@ The sender address is per-congregation (`congregation.emailFrom`) with a fallbac
 
 ## Creating a New Email Template
 
-1. **Create the template** in `app/emails/` (or `app/emails/notifications/` for notification emails):
-   ```bash
-   app/emails/notifications/my-new-email.tsx
-   ```
-
-2. **Add i18n messages** for subject, body, etc. in `app/i18n/messages/en.json` and `app/i18n/messages/fr.json`
-
-3. **Add the job type** to `EmailJobData` in `app/shared/infra/email-queue.server.ts`:
-   ```typescript
-   | { type: 'my-new-email'; congregationId: number; myField: string }
-   ```
-
-4. **Add the handler case** in `app/shared/infra/handle-email-work.server.tsx`:
-   ```typescript
-   case 'my-new-email':
-     return handleMyNewEmail(job.data)
-   ```
-
-5. **Queue jobs** from business logic:
-   ```typescript
-   import { emailQueue } from '~/shared/infra/email-queue.server'
-   await emailQueue.add('my-new-email', { congregationId, myField: 'value' })
-   ```
+1. **Create the template** next to the feature that owns the trigger, under that feature's `emails/` directory — e.g. `app/features/territories/emails/my-new-email.tsx`. Don't add it to a centralized folder.
+2. **Add i18n messages** for subject, body, etc. in `app/i18n/messages/en.json` and `app/i18n/messages/fr.json`.
+3. **Add the job type** to `EmailJobData` in `app/shared/infra/email-queue.server.ts`.
+4. **Add the handler case** in `app/features/notifications/jobs/handle-email-work.server.tsx` (or split into a per-feature handler if the rendering logic is non-trivial — the dispatcher just routes by `type`).
+5. **Queue jobs** from business logic via `emailQueue.add(...)`.
 
 ## Development Server
 

--- a/docs/development/notifications.md
+++ b/docs/development/notifications.md
@@ -66,8 +66,8 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
 Each type has:
 
 - **`debounceMinutes`** — How long to buffer before sending. `0` = instant.
-- **`recipientStrategy`** — How to find recipients (`'role'`).
-- **`recipientRole`** — Which congregation role receives this notification.
+- **`recipientStrategy`** — How to find recipients (currently only `'role'`).
+- **`recipientRole`** — The **permission key** to query for recipients. Misnamed for historical reasons: `resolveRecipients` looks up users by `CongregationUserPermission` directly (see `app/features/notifications/server/resolve-recipients.server.ts`), so users who hold the permission only via a custom-role assignment are not currently picked up. Direct permission grants are required.
 - **`cancels`** (optional) — List of notification types this one supersedes. If pending events exist for those types + same entity, they are cancelled instead of sending a new email.
 - **`fallback`** (optional) — Config to use if no pending events were found to cancel.
 
@@ -126,10 +126,12 @@ Cancellation types (e.g., `board.document.deleted`) attempt to cancel pending de
 
 `resolveRecipients()` finds users who should receive a notification:
 
-1. Queries all active users with the required role in the congregation
+1. Queries active users in the congregation that hold the configured permission directly via `CongregationUserPermission`
 2. Loads `NotificationPreference` records for those users
 3. Filters out users who have disabled this notification type (exact match or wildcard `category.*`)
 4. Returns the filtered list of recipients
+
+The role layer (`Role` / `RolePermission` / `UserRoleAssignment`) is **not** consulted today. If you want a permission to grant notification eligibility through a role, the resolver needs an update — see the comment on `recipientRole` in the type registry.
 
 ## User Preferences
 
@@ -148,7 +150,7 @@ Wildcard preferences (e.g., `board.*`) disable all notifications in a category.
    },
    ```
 
-2. **Create an email template** in `app/emails/notifications/` (see [Email Templates](email-templates.md))
+2. **Create an email template** under the relevant feature's `emails/` directory (see [Email Templates](email-templates.md))
 
 3. **Add the rendering case** in `handle-notification-email.server.tsx`:
    ```typescript

--- a/docs/development/permissions-and-roles.md
+++ b/docs/development/permissions-and-roles.md
@@ -1,0 +1,81 @@
+# Permissions and Roles
+
+This page explains the authorization model that gates every authenticated route in the app: what a permission is, what a role is, how they're stored, how a user's effective set is resolved, and how to add a new permission.
+
+For the end-user view of the same system, see the product doc: [Roles and Permissions](../product/roles-and-permissions.md).
+
+## Two layers, distinct concepts
+
+- **Permission** — the unit of access. A finite, code-defined enum (20 entries) declared in `app/shared/types/permission.ts`. New permissions require code + migration changes.
+- **Role** — a named bundle of permissions assigned to users. Lives in the database (`Role` table), scoped to a congregation. Roles can be **built-in** (seeded, identity-stable) or **custom** (created at runtime by a Roles Manager).
+
+Users do not hold permissions directly through roles only — there is also a direct `CongregationUserPermission` table for one-off grants. Both sources are unioned at request time.
+
+## Where things live
+
+| Concern | Path |
+|---|---|
+| Permission enum (source of truth) | `app/shared/types/permission.ts` |
+| Built-in role keys + auto-assignment predicates | `app/shared/domain/built-in-roles.server.ts` |
+| Custom role CRUD (create/update/delete, permission sync, user assignment) | `app/shared/domain/roles.server.ts` |
+| Effective-permission resolver | `app/shared/auth/permissions.server.ts` |
+| Auth middleware that runs the resolver | `app/shared/auth/middleware.server.ts` |
+| Typed contexts (`userContext`, `congregationContext`, `permissionsContext`) | `app/shared/auth/route-context.server.ts` |
+| Role admin UI | `app/features/congregation/routes/roles/` |
+| User assignment UI | settings — see `app/features/settings/` |
+
+Database schema is in `app/database/schema.prisma`. The relevant tables are `Permission`, `Role`, `RolePermission`, `UserRoleAssignment`, and `CongregationUserPermission`.
+
+## Resolution flow
+
+When a request hits an authenticated layout:
+
+1. `requireAuth()` middleware runs (`app/shared/auth/middleware.server.ts`). It calls `verifySession`, then `resolveEffectivePermissions(userId, congregationId)`, then enforces GDPR consent.
+2. `resolveEffectivePermissions` (`app/shared/auth/permissions.server.ts`) reads two sources in parallel:
+   - direct grants from `CongregationUserPermission`
+   - role-mediated grants from `RolePermission` joined to roles the user is a member of (`UserRoleAssignment`)
+   It unions both, and if the result contains `Permission.Admin`, expands it to every value of the enum.
+3. The middleware sets `permissionsContext` to the resulting `Set<Permission>`.
+4. Loaders/actions read `context.get(permissionsContext)` and call `requirePermission(permissions, Permission.X)` (which redirects on failure) or `permissions.has(...)` for conditional UI.
+
+The `_required` parameter on `requireAuth(_required: Permission[] = [])` is **retained for call-site compatibility but no longer used**. The set in `permissionsContext` is always the full granted set, so layout routes don't need to enumerate the permissions their children might check. New code may pass `[]`.
+
+## Built-in roles
+
+Defined by `BUILT_IN_ROLE_KEYS` in `app/shared/domain/built-in-roles.server.ts`:
+
+- `male`, `female`, `publisher`, `baptized`, `anointed`, `elder`, `assistant-servant`
+
+Membership is computed from boolean fields on the user (`isPublisher`, `isMale`, `baptismDate`, `isAnointed`, `isHelder`, `isServant`) by `BUILT_IN_ROLE_PREDICATES`. After any change to those fields, call `syncBuiltInRoleAssignments(db, userId, congregationId, actorId)` — it diffs the desired vs current `UserRoleAssignment` rows for built-in roles and audits the change.
+
+Built-in roles ship with **no permissions attached**; their primary purpose is to label users for things like board section visibility and programme assignment filtering. Admins can attach permissions to built-in roles if they want them to grant access too.
+
+Built-in roles cannot be renamed or deleted. Their identity is sourced from i18n via `getRoleDisplayName` (`app/shared/types/role.ts`).
+
+## Custom roles
+
+Created and edited through `app/shared/domain/roles.server.ts`:
+
+- `createRole` — slugifies the name into a key, ensures uniqueness within the congregation, audits as `RoleCreated`
+- `updateRoleIdentity` — edits name/description (forbidden on built-ins)
+- `updateRolePermissions` → `syncRolePermissions` — diff-based add/remove on `RolePermission`, audits as `RolePermissionChanged`
+- `addUserToRole` / `removeUserFromRole` / `setUserCustomRoleAssignments` — manage `UserRoleAssignment` for non-built-in roles, audits as `UserRoleAssignmentChanged`
+- `deleteRole` — forbidden on built-ins; cascades to memberships and permission rows
+
+The corresponding routes live in `app/features/congregation/routes/roles/`.
+
+## Adding a new permission
+
+1. **Enum entry.** Add the new value to `Permission` in `app/shared/types/permission.ts`. Use `kebab-case` for the value (it's the DB key).
+2. **Migration.** Insert a row into `Permission` for every existing congregation. Optionally pre-attach it to specific built-in roles via `RolePermission`. Use `prisma migrate diff` + a manual SQL file under `app/database/migrations/` (do not run `migrate dev` in CI).
+3. **Display label.** Add a translated label in `app/shared/types/permission-display.ts` (or wherever the display map is referenced from the role-edit UI) and provide messages in `app/i18n/messages/{en,fr}.json` for the role-edit screen.
+4. **Route guard.** In the loader/action that gates the new feature, call `requirePermission(permissions, Permission.X)` after `withScopeFromContext`. For UI gating, use `permissions.has(Permission.X)` to hide buttons/links.
+5. **Tests.** Cover the new guard in unit tests for the route, and add an integration test for the resolver if the permission has any non-trivial assignment path.
+
+Audit actions exist for every role/permission mutation already (`RoleCreated`, `RoleUpdated`, `RoleDeleted`, `RolePermissionChanged`, `UserRoleAssignmentChanged`, `UserPermissionsChanged`, `RoleAssignmentsSynced`). New permissions don't need new audit actions unless the user-facing action they gate is itself a new auditable event.
+
+## Related
+
+- [Architecture](architecture.md) — request flow and middleware
+- [Row-Level Security](row-level-security.md) — the orthogonal tenant-isolation layer
+- [Coding conventions](coding-conventions.md) — service-layer rules

--- a/docs/development/row-level-security.md
+++ b/docs/development/row-level-security.md
@@ -70,13 +70,19 @@ The `true` parameter in `current_setting(...)` makes it return `NULL` instead of
 
 ## Tables with RLS
 
+The authoritative source is the set of `CREATE POLICY tenant_isolation` statements in `app/database/migrations/`. Three buckets:
+
 **Tenant-scoped (RLS enforced):**
 
-Attribution, AuditLog, BoardDocument, BoardDocumentVersion, BoardDynamicDocumentSettings, BoardSection, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, ConsentRecord, CongregationUserPermission, DataDeletionRecord, Event, EventKind, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammeServiceRoleAssignment, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, PublisherActivity, PublisherGroup, Setting, Territory, User
+Attribution, AuditLog, BoardDocument, BoardSection, BoardSectionVisibilityRole, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, CongregationUserPermission, ConsentRecord, DataDeletionRecord, Event, EventKind, ExternalSpeaker, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammePartAssignmentAllowedRole, ProgrammeServiceRoleAssignment, ProgrammeServiceRoleAssignmentAllowedRole, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplatePartAllowedRole, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, ProgrammeTemplateServiceRoleAllowedRole, PublisherActivity, PublisherGroup, Role, RolePermission, Setting, Territory, TerritoryCardOverlay, TerritoryPerimeter, User, UserRoleAssignment.
 
-**Global (no RLS):**
+**Global (no `congregationId`, RLS not applicable):**
 
-Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView
+Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView.
+
+**Scoped column but no RLS policy yet:**
+
+`BoardDocumentVersion` and `BoardDynamicDocumentSettings`. Both carry `congregationId` and are reached today only through scoped Prisma queries (joined to their parent `BoardDocument` / `BoardSection`, which are themselves scoped), but no migration ever ran `CREATE POLICY` on them — so the database-side guarantee is missing. Tracked in [#171](https://github.com/Unitae/unitae/issues/171); a follow-up migration will bring them in line with the policy shape used everywhere else.
 
 ## Application Integration
 

--- a/docs/managed-hosting/self-hosting-vs-managed.md
+++ b/docs/managed-hosting/self-hosting-vs-managed.md
@@ -13,7 +13,7 @@ Unitae can be self-hosted on your own infrastructure or used through the managed
 | **Data location** | MindsersIT infrastructure (EU) | Your infrastructure |
 | **Features** | All features | All features (same code) |
 | **GDPR compliance** | DPA provided by MindsersIT | Your responsibility (built-in tools included) |
-| **Resource limits** | Per plan | Unlimited by default |
+| **Resource limits** | Per plan | No plan-based limits enforced |
 | **Multi-congregation** | Built-in | Enable with `UNITAE_MULTI_TENANT=true` |
 | **Support** | Included | Community / self |
 | **Cost** | Monthly subscription | Your infrastructure costs |

--- a/docs/product/calendar-feed.md
+++ b/docs/product/calendar-feed.md
@@ -1,0 +1,50 @@
+# Personal Calendar Feed
+
+Every member can subscribe to their own programme assignments and absences from any standard calendar app — Apple Calendar, Google Calendar, Outlook, Fantastical, etc. — without keeping Unitae open. The feed is private to that member and updates automatically as assignments change.
+
+## What's in the feed
+
+- Programme part assignments where the member is the speaker or the reader
+- Service role assignments where the member is the assignee
+- Days off the member has recorded
+
+The feed contains all future events plus events from the last three months. Anything older is dropped to keep calendar apps responsive.
+
+## Subscribing
+
+The link is generated and managed in **Profile → My calendar**:
+
+1. Click *Generate link* the first time. Unitae creates a private URL.
+2. Click *Copy* to put the URL on your clipboard.
+3. Paste it into your calendar app:
+   - **Apple Calendar** — File → New Calendar Subscription → paste the URL
+   - **Google Calendar** — Other calendars → From URL → paste the URL
+   - **Outlook** — Add calendar → Subscribe from web → paste the URL
+
+Most calendar apps refresh subscribed feeds every few hours on their own — you don't need to do anything when assignments change.
+
+## Privacy
+
+The link contains a long random token. Anyone holding the URL can read your assignments and absences, so treat it like a personal password: don't post it publicly, don't share it, and use the regenerate / revoke options below if it leaks.
+
+The feed is read-only — nobody can use it to change your data or impersonate you.
+
+## Managing the link
+
+From **Profile → My calendar**, you can:
+
+- **Generate** — Create the link the first time you want to use the feed.
+- **Copy** — Put the current URL on your clipboard.
+- **Regenerate** — Replace the URL with a fresh one. Any calendar app subscribed to the old link stops receiving updates and needs to be re-subscribed with the new URL. Use this if the link has been accidentally shared.
+- **Revoke** — Delete the link entirely. Subscribed calendar apps stop receiving updates. You can generate a new link later if you change your mind.
+
+Regeneration and revocation are recorded in the audit log, so administrators can trace token activity if there's ever a concern.
+
+## Permissions
+
+Any member with an active account can use this feature for themselves — no special permission is required. The link is always personal: you can never see another member's feed.
+
+## Related
+
+- [Events](events.md) — How programme assignments and days off feed into the calendar
+- [Security](security.md) — How tokens and personal data are protected

--- a/docs/product/dashboard.md
+++ b/docs/product/dashboard.md
@@ -18,7 +18,7 @@ The greeting is sized for a warm, app-like feel.
 On the right side of the greeting (below on mobile), contextual action buttons provide shortcuts to frequent tasks:
 
 - **Plan an absence** — Link to the absence creation form (all users)
-- **Assign territory** — Link to the territory list (visible only to `Admin` and `TerritoriesManager` roles)
+- **Assign territory** — Link to the territory list (visible only to members with the Admin or Territories Manager permission)
 
 ## Admin Onboarding Checklist
 

--- a/docs/product/data-transfer.md
+++ b/docs/product/data-transfer.md
@@ -31,7 +31,7 @@ The archive contains all congregation data:
 
 ### Archive format
 
-The `.unitae` file is a structured archive (a ZIP under the hood) bundling the congregation's data — and, when *Include files* is selected, the uploaded documents too. Contributors interested in the on-disk layout can read [Data Transfer Internals](../development/data-transfer.md).
+The export produces a single `.unitae` file that bundles your congregation's data — and the uploaded documents too, when *Include files* is selected. Treat it as a self-contained backup: keep it somewhere safe, and import it back whenever you need to restore.
 
 ## Import
 
@@ -61,7 +61,7 @@ The `.unitae` file is a structured archive (a ZIP under the hood) bundling the c
 
 ## Permissions
 
-Only users with the `Admin` role can access the data transfer features.
+Only members with the Admin permission can run an export or an import.
 
 ## Related
 

--- a/docs/product/display-board.md
+++ b/docs/product/display-board.md
@@ -2,9 +2,13 @@
 
 The display board is a digital notice board for sharing documents with congregation members. Think of it as the digital equivalent of the physical bulletin board in the Kingdom Hall.
 
+## Who can see the board
+
+Opening the board requires the **Board Viewer** permission. Members without it cannot reach the board, its documents, or the in-app PDF viewer. By default the built-in Publisher role does not include Board Viewer — an admin attaches it to whichever roles should see the board (typically Publisher, or a more restricted role like Elder).
+
 ## Board View
 
-The main board page (`/board`) shows all visible documents organized by section. A page header displays the title and quick-access buttons to the management pages: validators see both the *Manage sections* and *Manage documents* buttons; uploaders see only the *Manage documents* button (their entry point to the upload form).
+The main board page shows all visible documents organized by section. A page header displays the title and quick-access buttons to the management pages: validators see both the *Manage sections* and *Manage documents* buttons; uploaders see only the *Manage documents* button (their entry point to the upload form).
 
 ### Highlighted Section
 
@@ -50,8 +54,17 @@ Documents are organized into **sections** — named folders that group related d
 - Create as many sections as needed
 - Reorder sections to control how they appear on the board
 - Each section shows a count of its documents
+- Restrict each section to a chosen list of roles when needed (see "Section visibility" below)
 
-**Required role**: `BoardValidator` or `Admin`
+**Required permission**: Board Validator or Admin
+
+### Section visibility
+
+Each section can be restricted to specific roles. From the section's edit page, pick the roles allowed to see it — for example, "Elders" or a custom "Service committee" role you've created. Members who don't hold any of those roles see neither the section nor its documents on the board.
+
+By default a section has no role restrictions and is visible to anyone with the Board Viewer permission.
+
+This works with both built-in roles (Elder, Anointed, Publisher, …) and custom roles you've defined in Settings.
 
 ## Documents
 
@@ -61,11 +74,11 @@ Upload PDF documents to any section on the board. Each document has:
 
 - **Name** — A display name for the document
 - **Section** — Which section the document belongs to
-- **File to upload** — The PDF file
+- **File to upload** — The PDF file (must be a real PDF, up to 20 MB)
 
-Documents are stored in the configured file storage backend (local filesystem or S3-compatible storage).
+Larger files are rejected at upload with a clear error message — split or re-export the PDF and try again.
 
-**Required role**: `BoardUploader`, `BoardValidator`, or `Admin`
+**Required permission**: Board Uploader, Board Validator, or Admin
 
 ### File Replacement
 
@@ -86,20 +99,20 @@ Control when a document appears on the board:
 
 Documents outside their visibility window are not shown on the board. This lets you prepare documents in advance and schedule them to appear at the right time.
 
-**Required role**: `BoardValidator` or `Admin`
+**Required permission**: Board Validator or Admin
 
 ### Highlighting
 
 Important documents can be featured on the board using the *Feature this document on the board* option. Featured documents appear in the "Featured" section at the top of the board with a distinct visual container.
 
-**Required role**: `BoardValidator` or `Admin`
+**Required permission**: Board Validator or Admin
 
 ## In-App PDF Viewer
 
 Clicking a document opens an in-app viewer page that keeps the sidebar and navigation visible:
 
 - **Desktop / iOS** — Uses the browser's native PDF embed with a clean toolbar-less view
-- **Android** — Lazy-loads a PDF.js canvas renderer (~500 KB, loaded on demand) for inline viewing
+- **Android** — Falls back to an in-app renderer that loads on demand to keep the page lightweight
 
 The viewer includes a back button to the board and a download button. Document viewing is tracked server-side when the page loads.
 
@@ -123,20 +136,20 @@ Dynamic documents support the same visibility, highlighting, ordering, and secti
 
 For PDFs, the unread badge disappears once a member opens the document. For dynamic documents, the badge **reappears when the underlying data changes** — e.g., when a new publisher is added to a group or a programme assignment is updated. This ensures members are notified of fresh content.
 
-**Required role**: `BoardValidator` or `Admin` to add/configure. Any authenticated user can view.
+**Required permission**: Board Validator or Admin to add/configure. Members with Board Viewer can read them.
 
-## Permissions
+## Permissions summary
 
-| Role | Can do |
-|------|--------|
-| `BoardUploader` | Upload new documents. On documents they uploaded: edit title/section/file, delete, view and restore versions. **Cannot** set visibility window or highlight (those stay validator-controlled, even on the uploader's own documents) |
-| `BoardValidator` | Everything an uploader can do, on any document. Manage sections. Set visibility window and highlighting. Add and configure dynamic documents |
-| `Admin` | Everything |
-| Any authenticated user | View the board, its visible documents, and dynamic documents |
+| Permission | What it grants on the board |
+|---|---|
+| Board Viewer | Open the board, read documents (filtered by section visibility) |
+| Board Uploader | Everything Viewer grants, plus: upload new documents, and on documents they uploaded — edit title/section/file, delete, view and restore versions. **Cannot** set the visibility window or highlight a document |
+| Board Validator | Everything Uploader grants, plus: edit/delete any document, manage sections and their visibility, set the visibility window, highlight, and add/configure dynamic documents |
+| Admin | Everything |
 
 Whether an uploader counts as the "owner" of a document depends on whether the system has recorded them as the original uploader. Documents that pre-date this tracking have no recorded uploader and can only be edited by validators.
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles across all features.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions across all features.
 
 ## Related
 

--- a/docs/product/events.md
+++ b/docs/product/events.md
@@ -87,6 +87,14 @@ Programme managers assign publishers to parts and service roles for each event.
 
 For parts with a student/householder format (ministry school), both a **Speaker** and a **Reader** can be assigned.
 
+### Restricting who can be assigned
+
+Each programme part and service role can be limited to a chosen list of roles — for example, "only Elders are eligible to give the public talk", or "only baptized publishers can read on the platform". Set the allowed roles on the template (so every event generated from that template inherits the restriction) or override them on a single event when needed.
+
+When the allowed-roles list is empty, the system defaults to all active publishers. The assignment dropdown only shows people who match.
+
+This works with built-in roles (Publisher, Baptized, Elder, …) and with any custom roles you've created in Settings.
+
 ### Conflict detection
 
 - **On assignment**: if the publisher has a day-off overlapping the event, the assignment is **blocked** with an error message
@@ -105,58 +113,47 @@ Programme managers can see all congregation absences at **Programmes > Absences*
 
 ## Personal Calendar Feed
 
-Each member can subscribe to a private iCalendar (`.ics`) feed containing their own programme assignments and absences. The feed is read-only and lives at a unique, per-user URL — no Unitae login required for the calendar app to fetch it.
+Each member can subscribe to their own programme assignments and absences from any calendar app (Apple Calendar, Google Calendar, Outlook…) via a private link managed in **Profile → My calendar**. See [Calendar Feed](calendar-feed.md) for the full description.
 
-**What's in the feed**
+## External Speakers
 
-- Programme part assignments where the member is the speaker or the reader
-- Service role assignments where the member is the assignee
-- Days off the member has recorded
+Visiting speakers (and any other regular non-publisher contributors) live in their own registry, separate from publishers. Each entry has:
 
-The feed includes events from the last 3 months and all future events. Past events older than 3 months are excluded to keep calendar apps responsive.
+- **Name**
+- **Originating congregation** (optional)
+- **Phone** (optional)
+- **Notes** (optional)
 
-**Subscribing**
+When assigning a programme part — typically the public talk — managers can pick a speaker from this list instead of (or alongside) a publisher. External speakers don't show up in publisher screens, statistics, or activity reports; they exist only to be referenced in programme assignments.
 
-Any standard calendar app can subscribe to the feed by pasting the URL:
+Speakers no longer needed can be **archived** (kept in history but hidden from new-assignment pickers) and unarchived later.
 
-- **Apple Calendar** — File → New Calendar Subscription → paste the URL
-- **Google Calendar** — Other calendars → From URL → paste the URL
-- **Outlook** — Add calendar → Subscribe from web → paste the URL
+**Permissions**
 
-Most calendar apps refresh subscribed feeds every few hours automatically; the user does not need to take any action when assignments change.
-
-**Privacy**
-
-The URL contains a long random token that authenticates the request. Anyone with the URL can read the user's assignments and absences, so it should be treated as a personal secret — not posted publicly or shared.
-
-**Managing the link**
-
-The feed is managed from `/me/profile` → **My calendar**:
-
-- **Generate link** — Creates the feed URL on first use.
-- **Copy** — Copies the URL to the clipboard for pasting into the calendar app.
-- **Regenerate link** — Creates a new URL and breaks any existing subscription using the previous URL. Use this if the URL has been accidentally shared.
-- **Revoke** — Deletes the URL completely; calendar apps subscribed to it stop receiving updates.
+- *External Speaker Viewer* — open the registry and pick speakers when assigning a part
+- *External Speaker Manager* — also add, edit, archive, and unarchive entries
 
 ## Per-Template Responsibility
 
-A **manager** can be assigned to each template. This person gains write access to that template's events (assign publishers, edit structure) without needing the full `ProgramManager` role.
+A **manager** can be assigned to each template. This person gains write access to that template's events (assign publishers, edit structure) without needing the full Program Manager permission.
 
 This is useful for delegating: "this elder manages the midweek meeting programme, that one manages the weekend programme."
 
-If no responsible is set, only users with `ProgramManager` or `Admin` role can edit.
+If no responsible is set, only users with the Program Manager or Admin permission can edit.
 
 ## Permissions
 
-| Role | Can do |
-|------|--------|
+| Permission | Can do |
+|---|---|
 | Any authenticated user | View and manage their own days off; generate, copy, regenerate, and revoke their personal calendar feed |
-| `ProgramViewer` | View events, programmes, and template list |
-| `ProgramManager` | Create, edit, and delete events. Assign publishers. Manage templates |
+| Program Viewer | View events, programmes, and template list |
+| Program Manager | Create, edit, and delete events. Assign publishers. Manage templates |
+| External Speaker Viewer | Open the external speaker registry and pick from it |
+| External Speaker Manager | Add, edit, archive, and unarchive external speakers |
 | Template responsible | Edit events and assign publishers for their template only |
-| `Admin` | Everything, including creating new templates |
+| Admin | Everything, including creating new templates |
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles across all features.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions across all features.
 
 ## Related
 

--- a/docs/product/feature-overview.md
+++ b/docs/product/feature-overview.md
@@ -42,8 +42,9 @@ Manage the congregation's geographic territories and track assignments to publis
 - **Map-driven territory editing** — When a Google Maps API key is set, managers edit a territory by clicking markers on the map (add green, remove blue, reassign grey) with an in-place address search, marker clustering, and an atomic Save that audits each cross-territory reassignment
 - **Attributions** — Assign territories to publishers with start, end, and late dates
 - **Building prospection** — Maintain a database of individual buildings with address, entrance type, and prospection data
-- **Open data sync** — Automatically import building addresses from the French national address database (BANO) — see [Open Data Sync](../self-hosting/open-data-sync.md)
+- **Open data sync** — Automatically import building addresses from the French national address database — see [Open Data Sync](../self-hosting/open-data-sync.md)
 - **Maps** — Interactive Google Maps integration for building locations and territory visualization (optional)
+- **Card overlays & perimeter** — Draw colored zones and a territory boundary that print on every territory card; useful for orienting publishers in unfamiliar areas
 - **Statistics** — Coverage metrics, attribution frequency, overdue rates, monthly evolution
 - **Exports** — S-13 report, PDF territory cards (with optional map page), CSV export
 
@@ -69,9 +70,10 @@ Manage congregation meeting programmes, event scheduling, and publisher assignme
 - **Event generation** — Auto-generate events from templates, or create one-time events from templates or freeform. Events are listed from the start of the current month onward
 - **Publisher assignments** — Assign speakers, readers, and service roles with a dynamic info card showing availability, conflicts, and rotation history
 - **Conflict detection** — Days-off conflicts block assignments in real time and retroactively flag existing ones
-- **Per-template responsibility** — Delegate programme management to specific elders without granting full `ProgramManager` role
+- **Per-template responsibility** — Delegate programme management to specific elders without granting the full Program Manager permission
 - **Days off** — Members record their upcoming absences so programme organizers can plan accordingly
-- **Personal calendar feed** — Each member can subscribe to their own assignments and absences from any calendar app (Apple Calendar, Google Calendar, Outlook…) via a private iCalendar URL managed from their profile
+- **External speakers** — Maintain a registry of guest speakers (with congregation, phone, notes) and pick from it when assigning a programme part — kept separate from regular publishers
+- **Personal calendar feed** — Each member can subscribe to their own assignments and absences from any calendar app (Apple Calendar, Google Calendar, Outlook…) via a private iCalendar URL managed from their profile. See [Calendar Feed](calendar-feed.md)
 
 See [Events](events.md) for details.
 
@@ -100,11 +102,12 @@ See [Data Transfer](data-transfer.md) for details.
 Configure the congregation and manage users.
 
 - **Users** — Create, edit, and deactivate user accounts and assign roles
+- **Roles** — Use the built-in roles or create custom ones bundling exactly the permissions your congregation needs
 - **Congregation settings** — Display name, publisher profile options, programme template management
 - **Territory settings** — Allowed postal codes for open data sync, phone territory toggle
 - **Carte de l'assemblée** — Draw your assembly's overall preaching territory and its named/colored zones on a Google Map (or import them from a GeoJSON file). The perimeter decides which addresses are inside the assembly's territory; the zones are printed on every territory card to help publishers locate themselves
 
-See [Roles and Permissions](roles-and-permissions.md) for how access control works.
+See [Settings](settings.md) for the full list of what you can manage there, and [Roles and Permissions](roles-and-permissions.md) for how access control works.
 
 ## Privacy & GDPR
 

--- a/docs/product/notifications.md
+++ b/docs/product/notifications.md
@@ -4,12 +4,12 @@ Unitae sends email notifications to keep congregation members informed about eve
 
 ## Notification Types
 
-| Type | Trigger | Recipients | Debounce |
-|------|---------|-----------|----------|
-| **New document on board** | A document is uploaded to the display board | Users with the `BoardValidator` role | 10 minutes |
-| **Document deletion** | A document is removed from the board | Users with the `BoardValidator` role | Instant (cancels pending "new document" notifications) |
-| **Documents expiring** | Board documents are approaching their visibility end date | Users with the `BoardValidator` role | Instant |
-| **Territory sync completed** | The open data (BANO) import finishes | The user who triggered the sync | Instant |
+| Type | Trigger | Recipients | Delay |
+|------|---------|-----------|-------|
+| **New document on board** | A document is uploaded to the display board | Members with Board Validator | 10 minutes |
+| **Document deletion** | A document is removed from the board | Members with Board Validator | Instant (cancels pending "new document" notifications) |
+| **Documents expiring** | Board documents are approaching their visibility end date | Members with Board Validator | Instant |
+| **Territory sync completed** | The open-data import finishes | The member who triggered the sync | Instant |
 
 ## How Debouncing Works
 

--- a/docs/product/publishers.md
+++ b/docs/product/publishers.md
@@ -33,7 +33,7 @@ The *Publisher type* field offers:
 
 The publisher profile displays the list of territories currently assigned to the publisher. For each active assignment, the view shows:
 
-- **Number** — The territory number (links to the territory view if the user has the `TerritoriesViewer` role)
+- **Number** — The territory number (links to the territory view for members with the Territories Viewer permission)
 - **Type** — The territory type (Door to door, Businesses, etc.)
 - **Checkout date** — When the assignment started
 - **Status** — Whether the assignment is on time or overdue
@@ -77,15 +77,15 @@ Activity statistics follow the **theocratic year**, which runs from September to
 
 ## Permissions
 
-| Role | Can do |
-|------|--------|
-| `PublisherViewer` | View publisher profiles and group information |
-| `PublisherManager` | Create, edit, and deactivate publishers. Manage groups |
-| `ActivityViewer` | View activity reports and statistics |
-| `ActivityManager` | Record, edit, and export publisher activity |
-| `Admin` | Everything |
+| Permission | Can do |
+|---|---|
+| Publisher Viewer | View publisher profiles and group information |
+| Publisher Manager | Create, edit, and deactivate publishers. Manage groups |
+| Activity Viewer | View activity reports and statistics |
+| Activity Manager | Record, edit, and export publisher activity |
+| Admin | Everything |
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles across all features.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions across all features.
 
 ## Related
 

--- a/docs/product/roles-and-permissions.md
+++ b/docs/product/roles-and-permissions.md
@@ -1,78 +1,111 @@
 # Roles and Permissions
 
-Unitae uses a fine-grained role system to control who can access and manage each feature. Roles are assigned per user and scoped to the congregation.
+Unitae lets you decide, precisely, who in the congregation can see what and who can change what. Two ideas work together:
 
-## The 14 Roles
+- **Permissions** are the small units of access — for example, *manage territories*, *upload documents to the board*, *view publishers*. There are 20 of them, each tied to one feature.
+- **Roles** are named bundles of permissions you assign to a person — for example, *Elder*, *Pioneer team lead*, or anything else you want to call it. A user can hold several roles, and gets the union of their permissions.
 
-| Role | Access granted |
-|------|---------------|
-| `Admin` | Full access to all features within the congregation |
-| `BoardUploader` | Upload documents to the display board, and edit/delete/restore versions of documents they themselves uploaded (cannot set visibility or highlight) |
-| `BoardValidator` | Manage any board document: edit, delete, set visibility, highlight. Manage sections. Add dynamic documents |
-| `TerritoriesViewer` | View territory list, attributions, and statistics |
-| `TerritoriesManager` | Create, edit, and delete territories. Manage attributions. Trigger open data sync |
-| `ProspectionViewer` | View building prospection data |
-| `ProspectionManager` | Edit buildings, update prospection data, manage building status |
-| `SettingsUserManager` | Create, edit, and deactivate users. Assign roles |
-| `PublisherViewer` | View publisher profiles and group information |
-| `PublisherManager` | Create, edit, and deactivate publishers. Manage groups |
-| `ActivityViewer` | View activity reports and statistics |
-| `ActivityManager` | Record, edit, and export publisher activity |
-| `ProgramViewer` | View events, programmes, and template list |
-| `ProgramManager` | Create, edit, and delete events. Assign publishers. Manage programme templates |
+You can keep things simple and stick to the built-in roles, or you can create your own roles when the built-ins don't fit how your congregation is organised.
 
-## How Roles Work
+## Built-in roles
 
-### Multiple Roles Per User
+These roles ship with every congregation. The system assigns and removes them automatically based on the publisher status fields on the user's profile (publisher, baptized, anointed, elder, etc.) — you don't manage their membership by hand.
 
-A user can have any combination of roles. For example, an elder might have `TerritoriesManager`, `PublisherManager`, `ActivityManager`, and `ProgramManager` — giving them access to manage territories, publishers, activity, and programs without full admin access.
+| Role | Who gets it |
+|---|---|
+| Publisher | Anyone marked as an active publisher |
+| Male | Active publishers whose profile is marked male |
+| Female | Active publishers whose profile is marked female |
+| Baptized | Active publishers with a baptism date |
+| Anointed | Active publishers marked as anointed |
+| Elder | Active publishers marked as elder |
+| Assistant servant | Active publishers marked as assistant servant |
 
-### Admin Role
+These roles come **without permissions attached by default**. Their main job is to let you **target communications and assignments** — for example, restricting a board section so only elders can see it, or filtering programme assignments to baptized publishers only.
 
-The `Admin` role grants access to everything. Users with this role bypass all other role checks. It also grants access to congregation settings (display name, territory configuration, programme templates).
+If you want a built-in role to actually grant access (say, give every elder the right to validate board documents), open the role and tick the permissions you want it to carry.
 
-### Template Responsible
+## Custom roles
 
-In addition to roles, a **template responsible** can be assigned per programme template. This grants write access (assign publishers, edit event structure) scoped to that template's events only — without needing the full `ProgramManager` role.
+You can create as many roles of your own as you need. A custom role has:
 
-Typically, only a few trusted users should have the Admin role.
+- A name (and an optional description, useful for explaining the role to other admins)
+- Any combination of the 20 permissions
+- The list of users who hold it
 
-### Viewer vs Manager Roles
+Typical examples: *Service committee*, *PR coordinator*, *Group overseer*. Whatever names match how your congregation actually works.
 
-Most features have a **viewer** and a **manager** role:
+To create a role: **Settings → Roles → New role**. Pick the permissions, save, then assign users from their profile.
 
-- **Viewer** roles grant read-only access (view lists, read details, see reports)
-- **Manager** roles grant full access (create, edit, delete, export)
+You can edit, rename, and delete custom roles at any time. Built-in roles cannot be renamed or deleted (the system depends on their identity).
 
-Manager roles implicitly include viewer access — you don't need to assign both.
+## The 20 permissions
 
-## Managing Roles
+Permissions are grouped by area of the app. Most areas come in two flavours: **Viewer** (read-only) and **Manager** (full access). Holding a Manager permission already includes everything a Viewer permission would grant — you don't need to assign both.
 
-Roles are assigned through **Settings > Users**. To manage user roles, you need either the `SettingsUserManager` or `Admin` role.
+### Display board
+- **Board Viewer** — open the board and read documents
+- **Board Uploader** — add new documents to the board, edit or delete versions of documents you uploaded
+- **Board Validator** — manage any board document (edit, delete, set visibility, highlight), manage sections and their visibility rules, add dynamic documents
 
-From the user management page, you can:
+### Territories
+- **Territories Viewer** — open the territory list, attributions, and statistics
+- **Territories Manager** — create, edit and delete territories, manage attributions, trigger the open-data sync
+- **Prospection Viewer** — open the building prospection screens
+- **Prospection Manager** — edit buildings and update prospection data
 
-1. View all users in the congregation
-2. Select a user to see their current roles
-3. Add or remove roles
-4. Create new users with initial role assignments
+### Publishers
+- **Publisher Viewer** — open publisher profiles and group information
+- **Publisher Manager** — create, edit, deactivate publishers, manage groups
+- **Activity Viewer** — read the monthly activity reports and statistics
+- **Activity Manager** — record, edit, and export publisher activity
 
-## Default Access
+### Programme & events
+- **Program Viewer** — open the events list, programmes, and templates
+- **Program Manager** — create and edit events, assign publishers, manage programme templates
+- **External Speaker Viewer** — open the external speaker registry
+- **External Speaker Manager** — add, edit, archive speakers in the registry
 
-Every authenticated user can:
+### Settings
+- **Settings User Manager** — create, edit, deactivate users; assign roles to users
+- **Roles Viewer** — open the list of roles in the congregation
+- **Roles Manager** — create, edit, delete custom roles and choose which permissions they carry
+- **Permissions Manager** — adjust which permissions are attached to a role
 
-- View the display board (visible documents)
-- Record their own days off
-- Access their own profile
+### Admin
+- **Admin** — full access to everything in the congregation, plus congregation-wide settings (display name, configuration, programme templates). Bypasses every other permission check.
 
-Everything else requires at least one role assignment.
+Keep the **Admin** permission to a small handful of trusted users.
+
+## How a person ends up with a permission
+
+The flow is:
+
+1. The person holds one or more roles (built-in roles assigned automatically, custom roles assigned by an admin).
+2. Each role carries a set of permissions.
+3. The person's effective permissions are the union of all their roles' permissions.
+
+So to give someone access to a feature, you don't grant the permission directly — you put them in a role that already has it (or create a new role that does).
+
+## Programme template responsible
+
+Independently of roles, each programme template can have a **template responsible** assigned. That person can edit and assign publishers for the events that come from that template, without needing the broader Program Manager permission. Useful for delegating one programme (e.g. midweek meeting) without handing over the rest.
+
+## Default access
+
+Users who have no roles assigned still have a small baseline:
+
+- They can see and edit their own profile
+- They can record their own days off
+- They can subscribe to their personal calendar feed
+
+Everything else — including viewing the board, territories, or publishers — requires the matching permission.
 
 ## Related
 
-Each feature page documents which roles apply to it:
-
-- [Display Board](display-board.md) — `BoardUploader`, `BoardValidator`
-- [Territories](territories.md) — `TerritoriesViewer`/`Manager`, `ProspectionViewer`/`Manager`
-- [Publishers](publishers.md) — `PublisherViewer`/`Manager`, `ActivityViewer`/`Manager`
-- [Events](events.md) — `ProgramViewer`, `ProgramManager`
-- [Security](security.md) — How roles are enforced at the server level
+- [Display Board](display-board.md) — section visibility and the Board Viewer / Uploader / Validator permissions
+- [Territories](territories.md) — Territories and Prospection permissions
+- [Publishers](publishers.md) — Publisher and Activity permissions
+- [Events](events.md) — Program and External Speaker permissions
+- [Settings](settings.md) — where to assign roles and create new ones
+- [Security](security.md) — how access checks are enforced

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -34,9 +34,9 @@ Uploaded files (board PDFs, territory cards) are stored in separate paths per co
 
 ## Role-based access control
 
-Access to features is controlled through 14 fine-grained roles. Roles are checked on every request — both in the UI (to show or hide elements) and on the server (to enforce access).
+Access to features is controlled through 20 fine-grained permissions, bundled into roles. Every request is checked — both in the UI (to show or hide elements) and on the server (to enforce access).
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles and what they control.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions and the built-in and custom roles that group them.
 
 ## GDPR & data protection
 

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -87,5 +87,5 @@ Implementation details — hashing parameters, cookie attributes, calendar feed 
 
 ## Related
 
-- [Roles and Permissions](roles-and-permissions.md) — The 14 roles that control access to features.
+- [Roles and Permissions](roles-and-permissions.md) — Permissions, built-in roles, and custom roles you can define yourself.
 - [FAQ](../resources/faq.md) — "Is my data safe?" and other common questions.

--- a/docs/product/settings.md
+++ b/docs/product/settings.md
@@ -1,0 +1,68 @@
+# Settings
+
+The **Settings** area is where administrators configure the congregation, manage users and access, and run data-level tasks like exports and imports. Most members never need to open it — it's where the people responsible for the platform set things up.
+
+## Users
+
+Create, edit and deactivate the people who can sign in to your congregation's Unitae.
+
+- Add users by email; they receive a verification email and set their own password
+- Edit a user's profile (name, email, publisher status fields)
+- Deactivate a user when they leave the congregation — their assignments and history stay intact
+- Anonymize a user (right to erasure) — replaces personal data with placeholders while preserving statistical history
+
+Permission required: *Settings User Manager* or *Admin*.
+
+## Roles
+
+Decide what each member can see and do.
+
+- Browse the **built-in roles** (Publisher, Elder, Anointed, etc.) and tick which permissions they should grant
+- Create your own **custom roles** — for example, *Service committee* or *PR coordinator* — bundling exactly the permissions you need
+- Assign one or many roles to each member from their profile
+
+For the full conceptual picture, see [Roles and Permissions](roles-and-permissions.md).
+
+Permission required: *Roles Viewer* to read; *Roles Manager* and *Permissions Manager* to change.
+
+## Congregation settings
+
+Top-level preferences for the whole congregation:
+
+- **Display name** — How the congregation appears in the app and emails
+- **Publisher profile fields** — Which fields are shown on publisher profiles
+- **Programme templates** — Define the recurring meeting structures (see [Events](events.md))
+- **Event types** — Custom categories with colors used to highlight events on the programme list
+- **Default sender address** — The "from" address used for outgoing notification emails (when configurable)
+
+Permission required: *Admin*.
+
+## Territory settings
+
+Tune how the territory module behaves for your congregation:
+
+- **Allowed postal codes** for the open-data sync (controls which addresses get imported)
+- **Phone territories** toggle — show or hide the *Phones* territory type in the UI
+- **Carte de l'assemblée** — draw your assembly's preaching territory perimeter and its named/colored zones (see [Territories](territories.md) for what they print on)
+
+Permission required: *Admin*.
+
+## Data transfer
+
+Run a full export or import of the congregation's data — useful for migrating between Unitae instances, taking a manual backup, or restoring data after an incident.
+
+See [Data Transfer](data-transfer.md) for what's included and the import-conflict workflow.
+
+Permission required: *Admin*.
+
+## Audit log
+
+Every meaningful change in the congregation — sign-ins, role assignments, document uploads, territory edits, exports, and so on — is recorded with the actor, the time, and the affected entity. The audit log viewer is the place to look up "who did what, when".
+
+Permission required: *Admin*.
+
+## Related
+
+- [Roles and Permissions](roles-and-permissions.md) — How permissions are bundled into roles and assigned
+- [Data Transfer](data-transfer.md) — Export and import the congregation
+- [Security](security.md) — How user data, passwords, and the audit log are protected

--- a/docs/product/territories.md
+++ b/docs/product/territories.md
@@ -143,7 +143,7 @@ Each building record includes:
 
 ### Open Data Sync
 
-For congregations in France, building addresses can be automatically imported from the national address database (BANO). See [Open Data Sync](../self-hosting/open-data-sync.md) for details.
+For congregations in France, building addresses can be automatically imported from the national address database. See [Open Data Sync](../self-hosting/open-data-sync.md) for details.
 
 ## Split Tool
 
@@ -238,15 +238,15 @@ Statistics follow the **theocratic year** (September to August).
 
 ## Permissions
 
-| Role | Can do |
-|------|--------|
-| `TerritoriesViewer` | View territory list, assignments, and statistics |
-| `TerritoriesManager` | Create, edit, and delete territories. Manage assignments. Trigger open data sync. Cross-territory reassignments performed in the map editor are recorded in the audit log |
-| `ProspectionViewer` | View building prospection data |
-| `ProspectionManager` | Edit buildings, update prospection data, manage building status |
-| `Admin` | Everything |
+| Permission | Can do |
+|---|---|
+| Territories Viewer | View territory list, assignments, and statistics |
+| Territories Manager | Create, edit, and delete territories. Manage assignments. Trigger open-data sync. Cross-territory reassignments performed in the map editor are recorded in the audit log |
+| Prospection Viewer | View building prospection data |
+| Prospection Manager | Edit buildings, update prospection data, manage building status |
+| Admin | Everything |
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles across all features.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions across all features.
 
 ## Related
 

--- a/docs/product/what-is-unitae.md
+++ b/docs/product/what-is-unitae.md
@@ -15,7 +15,7 @@ Unitae is a web application designed specifically for Jehovah's Witnesses congre
 - **Publisher management** — Track publisher profiles, organize them into groups, and record monthly field service activity
 - **Virtual display board** — Upload and organize PDF documents for congregation members, with visibility scheduling and highlighting
 - **Event management** — Plan programs, track event kinds, and manage personal days off
-- **Fine-grained access control** — 14 roles to control who can view and manage each feature
+- **Fine-grained access control** — 20 permissions, bundled into built-in or custom roles, to control who can view and manage each feature
 
 ## How Unitae Differs
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -37,7 +37,14 @@ Alternatively, use [managed hosting](../managed-hosting/getting-started.md) whic
 
 ### Do I need the background worker?
 
-The worker is needed for the [open data sync](../self-hosting/open-data-sync.md) feature (importing building addresses from the French national database). If you don't use this feature, the app works fine without the worker — all other features are synchronous.
+Yes — the worker is what processes any task that doesn't return a response immediately:
+
+- Sending emails (password resets, board notifications, sync completion, document expiry warnings)
+- Generating PDF thumbnails after a document is uploaded to the board
+- Running congregation exports and imports
+- Importing addresses from open-data sources
+
+You can run Unitae without it for local exploration, but for any real deployment the worker should be running alongside the web process.
 
 ### Is self-hosting too much work for me?
 
@@ -47,11 +54,11 @@ If managing a server, database, and backups feels overwhelming, consider [manage
 
 ### Is Unitae available in English?
 
-The user interface is currently in French only. Internationalization (i18n) is on the roadmap but not yet available. Documentation is in English.
+Yes. The interface ships in both French and English; users can switch language from their profile. Documentation is in English.
 
 ### Does the open data sync work outside France?
 
-Currently, only the French BANO (Base Adresse Nationale Ouverte) is supported. Congregations in other countries need to enter building data manually. See [Open Data Sync](../self-hosting/open-data-sync.md).
+Currently the sync only supports the French national address dataset. Congregations in other countries can still use Unitae fully — they just enter building addresses manually. See [Open Data Sync](../self-hosting/open-data-sync.md).
 
 ### Do I need a Google Maps API key?
 
@@ -69,7 +76,7 @@ See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full guide. In short: open 
 
 ### Can I submit code in English?
 
-UI text and code comments should be in French (the primary user language). Commit messages, PR descriptions, and documentation should be in English. See [Coding Conventions](../development/coding-conventions.md).
+Yes. Code, comments, commit messages, PR descriptions, and documentation are all in English. Only the UI strings users actually see are translated to French (and English) through the i18n message files. See [Coding Conventions](../development/coding-conventions.md).
 
 ### How do I report a security issue?
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -60,6 +60,10 @@ Yes. The interface ships in both French and English; users can switch language f
 
 Currently the sync only supports the French national address dataset. Congregations in other countries can still use Unitae fully — they just enter building addresses manually. See [Open Data Sync](../self-hosting/open-data-sync.md).
 
+### Is my personal calendar feed private?
+
+The link is per-user and protected by a long random token. Only people you give the link to can read your assignments and absences. Regenerate or revoke the link from your profile if it leaks. See [Calendar Feed](../product/calendar-feed.md).
+
 ### Do I need a Google Maps API key?
 
 No. Maps are optional. Without an API key, territory management works normally — you just won't see interactive maps or map images in PDF exports. See [Environment Variables](../self-hosting/environment-variables.md).

--- a/docs/self-hosting/cron-jobs.md
+++ b/docs/self-hosting/cron-jobs.md
@@ -14,7 +14,9 @@ If `UNITAE_CRON_SECRET` is not set, all cron endpoints return `401 Unauthorized`
 
 ## Endpoints
 
-### `GET /cron/retention`
+Each endpoint accepts both `GET` and `POST`. Use `POST` from cron schedulers that need to disable response caching; otherwise either is fine.
+
+### `/cron/retention`
 
 Cleans up expired data to comply with retention policies:
 
@@ -23,13 +25,13 @@ Cleans up expired data to comply with retention policies:
 
 **Recommended schedule**: Once per day (e.g., `0 3 * * *`)
 
-### `GET /cron/board-expirations`
+### `/cron/board-expirations`
 
 Checks for display board documents approaching their visibility end date and sends notification emails to board validators.
 
 **Recommended schedule**: Once per day (e.g., `0 7 * * *`)
 
-### `GET /cron/process-notifications`
+### `/cron/process-notifications`
 
 Flushes settled notification events. Notifications with a debounce window are buffered in the database; this endpoint picks up events whose debounce period has elapsed, resolves recipients based on notification preferences, and pushes email jobs to the background queue.
 

--- a/docs/self-hosting/environment-variables.md
+++ b/docs/self-hosting/environment-variables.md
@@ -17,7 +17,7 @@ Complete reference for all configuration variables used by Unitae.
 | `UNITAE_COOKIE_DOMAIN` | — | Session cookie domain. Set in production to match your domain |
 | `UNITAE_MULTI_TENANT` | `false` | Enable multi-congregation mode. Set to `true` to allow multiple congregations |
 | `UNITAE_LOG_LEVEL` | `info` | Winston log level (`error`, `warn`, `info`, `debug`) |
-| `UNITAE_WEB_PORT` | `8080` | HTTP server port |
+| `UNITAE_WEB_PORT` | — | HTTP server port. Read by `pnpm start`; falls back to `PORT`, then to `3000` if neither is set. The official Docker images set this to `8080`, which is what the rest of this doc assumes |
 | `UNITAE_CRON_SECRET` | — | Bearer token for authenticating cron endpoint requests (`/cron/*`). When unset, all cron endpoints reject with 401 |
 | `UNITAE_WORKER_HEALTH_PORT` | `9090` | HTTP port for the background worker's health check endpoint |
 

--- a/docs/self-hosting/open-data-sync.md
+++ b/docs/self-hosting/open-data-sync.md
@@ -42,7 +42,7 @@ If you define a geographic polygon for your congregation's territory boundaries,
 ## Running a Sync
 
 1. Go to the territories section
-2. Click the sync button (requires `TerritoriesManager` role)
+2. Click the sync button (requires the *Territories Manager* permission)
 3. The sync runs as a background job — you can continue using the app while it processes
 4. Progress is tracked from 0% to 100%
 5. An email notification is sent when the sync completes


### PR DESCRIPTION
## Summary

- Rewrites the Roles & Permissions product page around the Permission/Role split (20 permissions, built-in roles, custom roles) and replaces the obsolete "14 roles" framing wherever it appeared.
- Adds three new docs: `development/permissions-and-roles.md` (dev reference for the auth model), `product/calendar-feed.md` (personal `.ics` subscription), and `product/settings.md` (Settings area overview).
- Fixes outdated paths (`/server/handle-*-work` → `/jobs/handle-*-work`, `app/emails/` → per-feature `emails/`) and stale claims (`requireAuth` parameter, "any authenticated user can view the board", "16 permission definitions", "worker only needed for sync", "UI in French only").
- Documents end-user features that had shipped without product docs: Board Viewer permission and section visibility, role-gated programme assignment eligibility, external speakers registry, custom roles in Settings.
- Cleans up tone across `docs/product/**` — backticked code-style permission names replaced with plain English for the non-technical audience.
- Flags one code-side discrepancy (not fixed in this PR): the notifications recipient resolver consults direct permission grants only, ignoring the role layer.

## Test plan

- [ ] Re-run grep checks: no hits for `14 [Rr]oles?`, `16 permission`, `app/emails/`, `/server/handle-.*-work`, or backticked Permission names under `docs/product/`.
- [ ] Open each modified product page and read it as a non-technical user — flag anything that still leaks code paths, env vars, or jargon.
- [ ] Click through the new pages against the running app: Profile → My calendar (calendar-feed.md), Settings → Roles (roles-and-permissions.md, settings.md), board access blocked for users without Board Viewer (display-board.md).
- [ ] Confirm `docs/README.md` links every file under `docs/**.md`.