### PR TITLE
docs: second-pass accuracy fixes

### DIFF
--- a/docs/development/data-transfer.md
+++ b/docs/development/data-transfer.md
@@ -20,6 +20,12 @@ Compression is `DEFLATE` via [`jszip`](https://stuk.github.io/jszip/). Buffers a
 
 Entities are exported in dependency order so an import can replay them top-down without missing references. The list lives in `buildExportSteps` (`export-congregation.server.ts`). Order matters: territories before attributions, board sections before board documents, etc.
 
+## What's not yet exported
+
+Several feature tables added since the export was first written are **not** yet enumerated in `ENTITY_FILES` and therefore not included in the archive — custom roles and their permission bundles, user role memberships, role gating on board sections, allowed-roles on programme parts/service roles, the external-speakers registry, territory card overlays, and the territory perimeter. An export+import round-trip on a congregation that uses these features silently drops them on the target side.
+
+Tracked in [#170](https://github.com/Unitae/unitae/issues/170). When extending `ENTITY_FILES`, also bump `ARCHIVE_VERSION` so older archives are rejected (or handled with an explicit "this archive predates feature X" warning) on import.
+
 ## Conflict resolution on import
 
 The validator scans for natural-key collisions before any write. Decisions per entity type:

--- a/docs/development/row-level-security.md
+++ b/docs/development/row-level-security.md
@@ -70,13 +70,19 @@ The `true` parameter in `current_setting(...)` makes it return `NULL` instead of
 
 ## Tables with RLS
 
+The authoritative source is the set of `CREATE POLICY tenant_isolation` statements in `app/database/migrations/`. Three buckets:
+
 **Tenant-scoped (RLS enforced):**
 
-Attribution, AuditLog, BoardDocument, BoardDocumentVersion, BoardDynamicDocumentSettings, BoardSection, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, ConsentRecord, CongregationUserPermission, DataDeletionRecord, Event, EventKind, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammeServiceRoleAssignment, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, PublisherActivity, PublisherGroup, Setting, Territory, User
+Attribution, AuditLog, BoardDocument, BoardSection, BoardSectionVisibilityRole, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, CongregationUserPermission, ConsentRecord, DataDeletionRecord, Event, EventKind, ExternalSpeaker, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammePartAssignmentAllowedRole, ProgrammeServiceRoleAssignment, ProgrammeServiceRoleAssignmentAllowedRole, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplatePartAllowedRole, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, ProgrammeTemplateServiceRoleAllowedRole, PublisherActivity, PublisherGroup, Role, RolePermission, Setting, Territory, TerritoryCardOverlay, TerritoryPerimeter, User, UserRoleAssignment.
 
-**Global (no RLS):**
+**Global (no `congregationId`, RLS not applicable):**
 
-Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView
+Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView.
+
+**Scoped column but no RLS policy yet:**
+
+`BoardDocumentVersion` and `BoardDynamicDocumentSettings`. Both carry `congregationId` and are reached today only through scoped Prisma queries (joined to their parent `BoardDocument` / `BoardSection`, which are themselves scoped), but no migration ever ran `CREATE POLICY` on them — so the database-side guarantee is missing. Tracked in [#171](https://github.com/Unitae/unitae/issues/171); a follow-up migration will bring them in line with the policy shape used everywhere else.
 
 ## Application Integration
 

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -34,9 +34,9 @@ Uploaded files (board PDFs, territory cards) are stored in separate paths per co
 
 ## Role-based access control
 
-Access to features is controlled through 14 fine-grained roles. Roles are checked on every request — both in the UI (to show or hide elements) and on the server (to enforce access).
+Access to features is controlled through 20 fine-grained permissions, bundled into roles. Every request is checked — both in the UI (to show or hide elements) and on the server (to enforce access).
 
-See [Roles and Permissions](roles-and-permissions.md) for the full list of roles and what they control.
+See [Roles and Permissions](roles-and-permissions.md) for the full list of permissions and the built-in and custom roles that group them.
 
 ## GDPR & data protection
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -53,6 +53,10 @@ The user interface is currently in French only. Internationalization (i18n) is o
 
 Currently, only the French BANO (Base Adresse Nationale Ouverte) is supported. Congregations in other countries need to enter building data manually. See [Open Data Sync](../self-hosting/open-data-sync.md).
 
+### Is my personal calendar feed private?
+
+The link is per-user and protected by a long random token. Only people you give the link to can read your assignments and absences. Regenerate or revoke the link from your profile if it leaks. See [Calendar Feed](../product/calendar-feed.md).
+
 ### Do I need a Google Maps API key?
 
 No. Maps are optional. Without an API key, territory management works normally — you just won't see interactive maps or map images in PDF exports. See [Environment Variables](../self-hosting/environment-variables.md).

--- a/docs/self-hosting/cron-jobs.md
+++ b/docs/self-hosting/cron-jobs.md
@@ -14,7 +14,9 @@ If `UNITAE_CRON_SECRET` is not set, all cron endpoints return `401 Unauthorized`
 
 ## Endpoints
 
-### `GET /cron/retention`
+Each endpoint accepts both `GET` and `POST`. Use `POST` from cron schedulers that need to disable response caching; otherwise either is fine.
+
+### `/cron/retention`
 
 Cleans up expired data to comply with retention policies:
 
@@ -23,13 +25,13 @@ Cleans up expired data to comply with retention policies:
 
 **Recommended schedule**: Once per day (e.g., `0 3 * * *`)
 
-### `GET /cron/board-expirations`
+### `/cron/board-expirations`
 
 Checks for display board documents approaching their visibility end date and sends notification emails to board validators.
 
 **Recommended schedule**: Once per day (e.g., `0 7 * * *`)
 
-### `GET /cron/process-notifications`
+### `/cron/process-notifications`
 
 Flushes settled notification events. Notifications with a debounce window are buffered in the database; this endpoint picks up events whose debounce period has elapsed, resolves recipients based on notification preferences, and pushes email jobs to the background queue.
 


### PR DESCRIPTION
## Summary

Follow-up to #169 — five smaller doc gaps the first pass missed, plus links to two code-bug issues uncovered by the re-audit.

- `product/security.md` — replaces the obsolete "14 fine-grained roles" claim.
- `development/row-level-security.md` — rebuilds the table lists from the actual migration set; adds a third bucket for two tables that carry `congregationId` but have no `CREATE POLICY` (links to #171).
- `development/data-transfer.md` — adds a "What's not yet exported" subsection so contributors know the export silently drops the 11 feature tables added since the data-transfer feature first shipped (links to #170).
- `self-hosting/cron-jobs.md` — clarifies that cron endpoints accept both `GET` and `POST` (the handlers always have).
- `resources/faq.md` — adds a calendar feed privacy Q&A.

No code changes. Issues opened during the audit:

- #170 — data-transfer export missing 11 feature tables
- #171 — RLS policies missing on `BoardDocumentVersion` and `BoardDynamicDocumentSettings`

## Test plan

- [ ] `rg "14 (?:R|r)oles?" docs/` returns nothing.
- [ ] `docs/development/row-level-security.md` lists the new tables under "Tenant-scoped" and the two unpolicied tables under their own bucket with a link to #171.
- [ ] `docs/development/data-transfer.md` shows the new "What's not yet exported" subsection linking to #170.
- [ ] `docs/self-hosting/cron-jobs.md` no longer says `GET /cron/...`; the new note about both methods is visible.
- [ ] `docs/resources/faq.md` has a "Is my personal calendar feed private?" entry under Features.
- [ ] Issues #170 and #171 are open with descriptive titles.