### PR TITLE
fix(db): add RLS policies for BoardDocumentVersion and BoardDynamicDocumentSettings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,6 @@ await createTerritory(db, ...)
 ## Known gaps
 
 - **#170** — the data-transfer export (`ENTITY_FILES` in `app/features/settings/server/data-transfer.type.ts`) silently drops 11 feature tables added since the export feature shipped (custom roles, allowed-roles, external speakers, card overlays, perimeter, board section visibility). Bump `ARCHIVE_VERSION` if you fix it.
-- **#171** — `BoardDocumentVersion` and `BoardDynamicDocumentSettings` carry `congregationId` but have no `CREATE POLICY` in any migration. They're reached only through scoped Prisma queries today; the database-side guarantee is missing.
 - **Notification recipient resolver** (`app/features/notifications/server/resolve-recipients.server.ts`) reads `CongregationUserPermission` directly; users who hold a permission only via a custom role aren't picked up.
 
 ## Environment Configuration

--- a/app/database/migrations/20260514000000_add_rls_to_board_versioning_and_dynamic_settings/migration.sql
+++ b/app/database/migrations/20260514000000_add_rls_to_board_versioning_and_dynamic_settings/migration.sql
@@ -1,0 +1,27 @@
+-- Backfill missing RLS policies for two tenant-scoped tables that were created
+-- without ENABLE ROW LEVEL SECURITY / CREATE POLICY (issue #171). Same shape as
+-- every other scoped table — see 20260426000000_fix_rls_policy_cast_safety for
+-- the rationale of the CASE form (guards the ::int cast against an empty string
+-- left over on a pooled connection after SET LOCAL is rolled back).
+
+-- BoardDocumentVersion
+ALTER TABLE "BoardDocumentVersion" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BoardDocumentVersion" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "BoardDocumentVersion" FOR ALL
+  USING (
+    CASE
+      WHEN NULLIF(current_setting('app.congregation_id', true), '') IS NULL THEN true
+      ELSE "congregationId" = current_setting('app.congregation_id', true)::int
+    END
+  );
+
+-- BoardDynamicDocumentSettings
+ALTER TABLE "BoardDynamicDocumentSettings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BoardDynamicDocumentSettings" FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "BoardDynamicDocumentSettings" FOR ALL
+  USING (
+    CASE
+      WHEN NULLIF(current_setting('app.congregation_id', true), '') IS NULL THEN true
+      ELSE "congregationId" = current_setting('app.congregation_id', true)::int
+    END
+  );

--- a/app/shared/infra/rls-board-versioning.integration.test.ts
+++ b/app/shared/infra/rls-board-versioning.integration.test.ts
@@ -1,0 +1,112 @@
+import { PrismaPg } from '@prisma/adapter-pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { PrismaClient } from '~/database/generated/client'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
+  max: 5,
+  connectionTimeoutMillis: 5000,
+})
+const testDb = new PrismaClient({ adapter })
+
+type Tx = Parameters<Parameters<typeof testDb.$transaction>[0]>[0]
+
+function withScope<T>(congregationId: number, fn: (tx: Tx) => Promise<T>): Promise<T> {
+  return testDb.$transaction(async tx => {
+    await tx.$executeRawUnsafe(`SET LOCAL app.congregation_id = '${String(congregationId)}'`)
+    return fn(tx)
+  })
+}
+
+const ts = Date.now()
+let congregationIdA: number
+let congregationIdB: number
+let versionIdA: number
+let versionIdB: number
+let dynamicSettingsIdA: number
+let dynamicSettingsIdB: number
+
+async function seedCongregation(name: string, slug: string) {
+  const cong = await testDb.congregation.create({ data: { name, slug, active: true } })
+
+  return withScope(cong.id, async tx => {
+    const section = await tx.boardSection.create({
+      data: { name: `Section ${name}`, order: 0, congregationId: cong.id },
+    })
+    const document = await tx.boardDocument.create({
+      data: { title: `Doc ${name}`, type: 'pdf', sectionId: section.id, order: 0, congregationId: cong.id },
+    })
+    const version = await tx.boardDocumentVersion.create({
+      data: { documentId: document.id, uri: `storage/${slug}.pdf`, versionNumber: 1, congregationId: cong.id },
+    })
+    const dynamic = await tx.boardDynamicDocumentSettings.create({
+      data: {
+        title: `Dyn ${name}`,
+        dynamicType: 'publisher-groups',
+        dynamicRef: null,
+        sectionId: section.id,
+        congregationId: cong.id,
+      },
+    })
+    return { congregationId: cong.id, versionId: version.id, dynamicSettingsId: dynamic.id }
+  })
+}
+
+beforeAll(async () => {
+  const a = await seedCongregation(`RLS Board A ${ts}`, `rls-board-a-${ts}`)
+  const b = await seedCongregation(`RLS Board B ${ts}`, `rls-board-b-${ts}`)
+  congregationIdA = a.congregationId
+  congregationIdB = b.congregationId
+  versionIdA = a.versionId
+  versionIdB = b.versionId
+  dynamicSettingsIdA = a.dynamicSettingsId
+  dynamicSettingsIdB = b.dynamicSettingsId
+})
+
+afterAll(async () => {
+  for (const congId of [congregationIdA, congregationIdB]) {
+    if (!congId) continue
+    await withScope(congId, async tx => {
+      await tx.boardDynamicDocumentSettings.deleteMany({})
+      await tx.boardDocumentVersion.deleteMany({})
+      await tx.boardDocument.deleteMany({})
+      await tx.boardSection.deleteMany({})
+    })
+  }
+  await testDb.congregation.deleteMany({ where: { id: { in: [congregationIdA, congregationIdB] } } })
+  await testDb.$disconnect()
+})
+
+describe('RLS isolation for BoardDocumentVersion', () => {
+  it('ne retourne que les versions de la congrégation A quand le scope est A', async () => {
+    const versions = await withScope(congregationIdA, tx => tx.boardDocumentVersion.findMany())
+
+    expect(versions.map(v => v.id)).toEqual([versionIdA])
+    expect(versions.every(v => v.congregationId === congregationIdA)).toBe(true)
+  })
+
+  it('empêche la congrégation A de voir les versions de la congrégation B', async () => {
+    const versions = await withScope(congregationIdA, tx =>
+      tx.boardDocumentVersion.findMany({ where: { id: versionIdB } }),
+    )
+
+    expect(versions).toHaveLength(0)
+  })
+})
+
+describe('RLS isolation for BoardDynamicDocumentSettings', () => {
+  it('ne retourne que les paramètres dynamiques de la congrégation A quand le scope est A', async () => {
+    const settings = await withScope(congregationIdA, tx => tx.boardDynamicDocumentSettings.findMany())
+
+    expect(settings.map(s => s.id)).toEqual([dynamicSettingsIdA])
+    expect(settings.every(s => s.congregationId === congregationIdA)).toBe(true)
+  })
+
+  it('empêche la congrégation A de voir les paramètres dynamiques de la congrégation B', async () => {
+    const settings = await withScope(congregationIdA, tx =>
+      tx.boardDynamicDocumentSettings.findMany({ where: { id: dynamicSettingsIdB } }),
+    )
+
+    expect(settings).toHaveLength(0)
+  })
+})

--- a/docs/development/row-level-security.md
+++ b/docs/development/row-level-security.md
@@ -74,15 +74,11 @@ The authoritative source is the set of `CREATE POLICY tenant_isolation` statemen
 
 **Tenant-scoped (RLS enforced):**
 
-Attribution, AuditLog, BoardDocument, BoardSection, BoardSectionVisibilityRole, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, CongregationUserPermission, ConsentRecord, DataDeletionRecord, Event, EventKind, ExternalSpeaker, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammePartAssignmentAllowedRole, ProgrammeServiceRoleAssignment, ProgrammeServiceRoleAssignmentAllowedRole, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplatePartAllowedRole, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, ProgrammeTemplateServiceRoleAllowedRole, PublisherActivity, PublisherGroup, Role, RolePermission, Setting, Territory, TerritoryCardOverlay, TerritoryPerimeter, User, UserRoleAssignment.
+Attribution, AuditLog, BoardDocument, BoardDocumentVersion, BoardDynamicDocumentSettings, BoardSection, BoardSectionVisibilityRole, Building, BuildingAccess, BuildingEntrance, BuildingResidentialData, CongregationUserPermission, ConsentRecord, DataDeletionRecord, Event, EventKind, ExternalSpeaker, NotificationEvent, NotificationPreference, ProgrammePartAssignment, ProgrammePartAssignmentAllowedRole, ProgrammeServiceRoleAssignment, ProgrammeServiceRoleAssignmentAllowedRole, ProgrammeTemplate, ProgrammeTemplatePart, ProgrammeTemplatePartAllowedRole, ProgrammeTemplateResponsible, ProgrammeTemplateServiceRole, ProgrammeTemplateServiceRoleAllowedRole, PublisherActivity, PublisherGroup, Role, RolePermission, Setting, Territory, TerritoryCardOverlay, TerritoryPerimeter, User, UserRoleAssignment.
 
 **Global (no `congregationId`, RLS not applicable):**
 
 Congregation, Permission, PasswordResetToken, EmailVerificationToken, CalendarFeedToken, BoardDynamicDocumentView.
-
-**Scoped column but no RLS policy yet:**
-
-`BoardDocumentVersion` and `BoardDynamicDocumentSettings`. Both carry `congregationId` and are reached today only through scoped Prisma queries (joined to their parent `BoardDocument` / `BoardSection`, which are themselves scoped), but no migration ever ran `CREATE POLICY` on them — so the database-side guarantee is missing. Tracked in [#171](https://github.com/Unitae/unitae/issues/171); a follow-up migration will bring them in line with the policy shape used everywhere else.
 
 ## Application Integration
 


### PR DESCRIPTION
## Summary

- Adds the missing `tenant_isolation` RLS policy on `BoardDocumentVersion` and `BoardDynamicDocumentSettings` (canonical `CASE` form, matching `20260426000000_fix_rls_policy_cast_safety`).
- Adds an integration test that proves a scoped query for congregation A cannot see B's rows on either table.
- Updates `docs/development/row-level-security.md` (moves both tables into the "Tenant-scoped (RLS enforced)" list, removes the "Scoped column but no RLS policy yet" bucket) and removes the `#171` entry from `CLAUDE.md` "Known gaps".

Closes #171.

## Test plan

- [x] `pnpm prisma migrate deploy` applies cleanly
- [x] `pnpm vitest run --config app/tests/vitest.config.integration.ts app/shared/infra/rls-board-versioning.integration.test.ts` — 4/4 pass
- [x] `pnpm test:typecheck` — exit 0
- [x] `pnpm test:lint` — no new warnings (pre-existing complexity warning unrelated)
- [x] Reviewer: spot-check the migration SQL against `20260503000000_add_territory_card_overlay/migration.sql` for shape parity