### PR TITLE
fix(settings): export the 11 feature tables missing from data-transfer (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,6 @@ await createTerritory(db, ...)
 
 ## Known gaps
 
-- **#170** — the data-transfer export (`ENTITY_FILES` in `app/features/settings/server/data-transfer.type.ts`) silently drops 11 feature tables added since the export feature shipped (custom roles, allowed-roles, external speakers, card overlays, perimeter, board section visibility). Bump `ARCHIVE_VERSION` if you fix it.
 - **Notification recipient resolver** (`app/features/notifications/server/resolve-recipients.server.ts`) reads `CongregationUserPermission` directly; users who hold a permission only via a custom role aren't picked up.
 
 ## Environment Configuration

--- a/app/features/settings/server/data-transfer.integration.test.ts
+++ b/app/features/settings/server/data-transfer.integration.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { PrismaClient } from '~/database/generated/client'
 import { EntranceKind } from '~/features/territories/model/entrance-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
+import { BUILT_IN_ROLE_KEYS } from '~/shared/domain/built-in-roles.server'
 import { PublisherType } from '~/shared/types/publisher-type'
 import { EntityIdMap, type ManifestJson } from './data-transfer.type'
 
@@ -194,7 +195,7 @@ beforeAll(async () => {
       },
     })
 
-    await tx.programmeServiceRoleAssignment.create({
+    const serviceRoleAssignment = await tx.programmeServiceRoleAssignment.create({
       data: {
         eventId: event.id,
         serviceRoleId: serviceRole.id,
@@ -226,20 +227,138 @@ beforeAll(async () => {
         congregationId: sourceId,
       },
     })
+
+    // v1.1 entities: roles, role-permissions, user-role-assignments,
+    // external speakers, territory card overlay/perimeter, allowed-role join rows,
+    // and a board section visibility role. Built-in roles are auto-seeded for
+    // congregations that existed at migration time only — this test creates fresh
+    // congregations, so seed them explicitly.
+    for (const key of BUILT_IN_ROLE_KEYS) {
+      await tx.role.create({
+        data: { key, isBuiltIn: true, congregationId: sourceId },
+      })
+    }
+    const elderRole = await tx.role.findFirst({ where: { key: 'elder' } })
+    if (elderRole == null) throw new Error('elder built-in role missing')
+
+    const customRole = await tx.role.create({
+      data: {
+        key: `custom-${ts}`,
+        name: 'Custom QA Reviewer',
+        description: 'Bench-tests programme drafts',
+        isBuiltIn: false,
+        congregationId: sourceId,
+      },
+    })
+
+    await tx.rolePermission.create({
+      data: { roleId: customRole.id, permissionId: adminPermissionId, congregationId: sourceId },
+    })
+
+    await tx.userRoleAssignment.create({
+      data: { userId: alice.id, roleId: customRole.id, congregationId: sourceId },
+    })
+
+    const externalSpeaker = await tx.externalSpeaker.create({
+      data: {
+        name: 'Frère Visiteur',
+        congregationName: 'Congrégation Voisine',
+        phone: '+33123456789',
+        email: 'visiteur@example.com',
+        notes: 'Speaks every quarter',
+        congregationId: sourceId,
+      },
+    })
+
+    // Wire the external speaker into the existing part-assignment so the FK link survives import.
+    const partAssignment = await tx.programmePartAssignment.findFirst({
+      where: { eventId: event.id },
+      select: { id: true },
+    })
+    if (partAssignment != null) {
+      await tx.programmePartAssignment.update({
+        where: { id: partAssignment.id },
+        data: { allowExternalSpeaker: true, externalSpeakerId: externalSpeaker.id, trackOrder: 2 },
+      })
+    }
+
+    // Set kindId on the template + trackOrder on the part to cover the adjacent leakage gaps.
+    await tx.programmeTemplate.update({
+      where: { id: template.id },
+      data: { kindId: eventKind.id },
+    })
+    await tx.programmeTemplatePart.update({
+      where: { id: part.id },
+      data: { trackOrder: 1 },
+    })
+
+    await tx.territoryCardOverlay.create({
+      data: { name: 'Quartier Nord', color: '#0066ff', paths: [{ lat: 48.8, lng: 2.3 }], congregationId: sourceId },
+    })
+
+    await tx.territoryPerimeter.create({
+      data: { paths: [[{ lat: 48.8, lng: 2.3 }]], congregationId: sourceId },
+    })
+
+    await tx.programmeTemplatePartAllowedRole.create({
+      data: { partId: part.id, roleId: elderRole.id, asKind: 'speaker', congregationId: sourceId },
+    })
+
+    await tx.programmeTemplateServiceRoleAllowedRole.create({
+      data: { serviceRoleId: serviceRole.id, roleId: elderRole.id, congregationId: sourceId },
+    })
+
+    if (partAssignment != null) {
+      await tx.programmePartAssignmentAllowedRole.create({
+        data: {
+          assignmentId: partAssignment.id,
+          roleId: elderRole.id,
+          asKind: 'speaker',
+          congregationId: sourceId,
+        },
+      })
+    }
+
+    await tx.programmeServiceRoleAssignmentAllowedRole.create({
+      data: { assignmentId: serviceRoleAssignment.id, roleId: elderRole.id, congregationId: sourceId },
+    })
+
+    await tx.boardSectionVisibilityRole.create({
+      data: { sectionId: section.id, roleId: elderRole.id, congregationId: sourceId },
+    })
   })
 
   const target = await testDb.congregation.create({
     data: { name: `Target ${ts}`, slug: `target-${ts}`, active: true },
   })
   targetId = target.id
+
+  // Pre-seed built-in roles in the target congregation, mirroring how production
+  // seedBuiltInRoles runs on congregation creation. Lets the import upsert source
+  // built-ins to the target's existing rows by key.
+  await withScope(targetId, async tx => {
+    for (const key of BUILT_IN_ROLE_KEYS) {
+      await tx.role.create({
+        data: { key, isBuiltIn: true, congregationId: targetId },
+      })
+    }
+  })
 })
 
 afterAll(async () => {
   for (const congId of [sourceId, targetId]) {
     if (!congId) continue
     await withScope(congId, async tx => {
+      // v1.1 join tables — must precede their parents. Most cascade on delete, but explicit
+      // ordering keeps cleanup deterministic across ad-hoc reruns.
+      await tx.boardSectionVisibilityRole.deleteMany({})
+      await tx.programmeServiceRoleAssignmentAllowedRole.deleteMany({})
+      await tx.programmePartAssignmentAllowedRole.deleteMany({})
+      await tx.programmeTemplateServiceRoleAllowedRole.deleteMany({})
+      await tx.programmeTemplatePartAllowedRole.deleteMany({})
       await tx.programmeServiceRoleAssignment.deleteMany({})
       await tx.programmePartAssignment.deleteMany({})
+      await tx.externalSpeaker.deleteMany({})
       await tx.programmeTemplateResponsible.deleteMany({})
       await tx.programmeTemplateServiceRole.deleteMany({})
       await tx.programmeTemplatePart.deleteMany({})
@@ -265,13 +384,21 @@ afterAll(async () => {
       }
       await tx.buildingEntrance.deleteMany({})
       await tx.building.deleteMany({})
+      await tx.territoryCardOverlay.deleteMany({})
+      await tx.territoryPerimeter.deleteMany({})
       await tx.territory.deleteMany({})
       await tx.setting.deleteMany({})
+      await tx.userRoleAssignment.deleteMany({})
+      await tx.rolePermission.deleteMany({})
+      await tx.role.deleteMany({})
       await tx.congregationUserPermission.deleteMany({})
       // Clear publisherGroupId FK on users before deleting groups
       await tx.user.updateMany({ data: { publisherGroupId: null } })
       await tx.publisherGroup.deleteMany({})
       await tx.user.deleteMany({})
+      // Audit logs accumulate from syncBuiltInRoleAssignments and other writes during the test —
+      // they hold a non-cascading FK to congregation, so clear them before deleting the row.
+      await tx.auditLog.deleteMany({})
     })
   }
   const idsToDelete = [sourceId, targetId].filter(id => id != null)
@@ -304,7 +431,7 @@ async function exportToZip(
   })
 
   const manifest: ManifestJson = {
-    version: '1.0',
+    version: '1.1',
     exportDate: new Date().toISOString(),
     sourceApp: 'unitae',
     entityCounts,
@@ -325,12 +452,18 @@ async function importFromZip(buffer: Buffer, congregationId: number): Promise<vo
   await withScope(congregationId, async db => {
     await mod.importSettings(zip, db, congregationId)
     await mod.importEventKinds(zip, db, idMap, congregationId)
+    await mod.importRoles(zip, db, idMap, congregationId)
+    await mod.importRolePermissions(zip, db, idMap, permissionKeyToId, congregationId)
     await mod.importUsers(zip, db, idMap, congregationId)
+    await mod.importUserRoleAssignments(zip, db, idMap, congregationId)
     await mod.importCongregationUserPermissions(zip, db, idMap, permissionKeyToId, congregationId)
     await mod.importPublisherGroups(zip, db, idMap, congregationId)
     await mod.updateUserPublisherGroups(zip, db, idMap)
     await mod.importPublisherActivities(zip, db, idMap, congregationId)
+    await mod.importExternalSpeakers(zip, db, idMap, congregationId)
     await mod.importTerritories(zip, db, idMap, congregationId)
+    await mod.importTerritoryCardOverlays(zip, db, idMap, congregationId)
+    await mod.importTerritoryPerimeter(zip, db, congregationId)
     await mod.importBuildings(zip, db, idMap, congregationId)
     await mod.importBuildingEntrances(zip, db, idMap, congregationId)
     await mod.importBuildingAccesses(zip, db, idMap, congregationId)
@@ -340,12 +473,17 @@ async function importFromZip(buffer: Buffer, congregationId: number): Promise<vo
     await mod.importAttributions(zip, db, idMap, congregationId)
     await mod.importProgrammeTemplates(zip, db, idMap, congregationId)
     await mod.importProgrammeTemplateParts(zip, db, idMap, congregationId)
+    await mod.importProgrammeTemplatePartAllowedRoles(zip, db, idMap, congregationId)
     await mod.importProgrammeTemplateServiceRoles(zip, db, idMap, congregationId)
+    await mod.importProgrammeTemplateServiceRoleAllowedRoles(zip, db, idMap, congregationId)
     await mod.importProgrammeTemplateResponsibles(zip, db, idMap, congregationId)
     await mod.importEvents(zip, db, idMap, congregationId)
     await mod.importProgrammePartAssignments(zip, db, idMap, congregationId)
+    await mod.importProgrammePartAssignmentAllowedRoles(zip, db, idMap, congregationId)
     await mod.importProgrammeServiceRoleAssignments(zip, db, idMap, congregationId)
+    await mod.importProgrammeServiceRoleAssignmentAllowedRoles(zip, db, idMap, congregationId)
     await mod.importBoardSections(zip, db, idMap, congregationId)
+    await mod.importBoardSectionVisibilityRoles(zip, db, idMap, congregationId)
     await mod.importBoardDocuments(zip, db, idMap, congregationId)
     await mod.importBoardDocumentVersions(zip, db, idMap, congregationId)
     await mod.importBoardDynamicDocumentSettings(zip, db, idMap, congregationId)
@@ -362,7 +500,7 @@ describe('Export/Import round-trip', () => {
     const manifestFile = zip.file('manifest.json')
     expect(manifestFile).not.toBeNull()
     const manifest: ManifestJson = JSON.parse(await manifestFile!.async('string'))
-    expect(manifest.version).toBe('1.0')
+    expect(manifest.version).toBe('1.1')
     expect(manifest.sourceApp).toBe('unitae')
 
     expect(entityCounts.users).toBe(2)
@@ -379,6 +517,19 @@ describe('Export/Import round-trip', () => {
     expect(entityCounts['consent-records']).toBe(1)
     expect(entityCounts.settings).toBe(1)
     expect(entityCounts['congregation-user-permissions']).toBe(1)
+
+    // v1.1 entities
+    expect(entityCounts.roles).toBe(8) // 7 built-ins + 1 custom
+    expect(entityCounts['role-permissions']).toBe(1)
+    expect(entityCounts['user-role-assignments']).toBe(1)
+    expect(entityCounts['external-speakers']).toBe(1)
+    expect(entityCounts['territory-card-overlays']).toBe(1)
+    expect(entityCounts['territory-perimeter']).toBe(1)
+    expect(entityCounts['programme-template-part-allowed-roles']).toBe(1)
+    expect(entityCounts['programme-template-service-role-allowed-roles']).toBe(1)
+    expect(entityCounts['programme-part-assignment-allowed-roles']).toBe(1)
+    expect(entityCounts['programme-service-role-assignment-allowed-roles']).toBe(1)
+    expect(entityCounts['board-section-visibility-roles']).toBe(1)
   })
 
   it('exported users do not contain passwords or sensitive fields', async () => {
@@ -417,8 +568,14 @@ describe('Export/Import round-trip', () => {
 
     // Delete source users so the emails are free for import (simulates cross-instance migration)
     await withScope(sourceId, async tx => {
+      await tx.boardSectionVisibilityRole.deleteMany({})
+      await tx.programmeServiceRoleAssignmentAllowedRole.deleteMany({})
+      await tx.programmePartAssignmentAllowedRole.deleteMany({})
+      await tx.programmeTemplateServiceRoleAllowedRole.deleteMany({})
+      await tx.programmeTemplatePartAllowedRole.deleteMany({})
       await tx.programmeServiceRoleAssignment.deleteMany({})
       await tx.programmePartAssignment.deleteMany({})
+      await tx.externalSpeaker.deleteMany({})
       await tx.programmeTemplateResponsible.deleteMany({})
       await tx.programmeTemplateServiceRole.deleteMany({})
       await tx.programmeTemplatePart.deleteMany({})
@@ -444,8 +601,13 @@ describe('Export/Import round-trip', () => {
       }
       await tx.buildingEntrance.deleteMany({})
       await tx.building.deleteMany({})
+      await tx.territoryCardOverlay.deleteMany({})
+      await tx.territoryPerimeter.deleteMany({})
       await tx.territory.deleteMany({})
       await tx.setting.deleteMany({})
+      await tx.userRoleAssignment.deleteMany({})
+      await tx.rolePermission.deleteMany({})
+      await tx.role.deleteMany({})
       await tx.congregationUserPermission.deleteMany({})
       await tx.user.updateMany({ data: { publisherGroupId: null } })
       await tx.publisherGroup.deleteMany({})
@@ -524,9 +686,12 @@ describe('Export/Import round-trip', () => {
       // Programme templates + parts + service roles + responsibles
       const templates = await tx.programmeTemplate.findMany({})
       expect(templates).toHaveLength(1)
+      // kindId remap: must point to the imported event kind, not the source's id.
+      expect(templates[0].kindId).toBe(eventKinds[0].id)
       const parts = await tx.programmeTemplatePart.findMany({})
       expect(parts).toHaveLength(1)
       expect(parts[0].templateId).toBe(templates[0].id)
+      expect(parts[0].trackOrder).toBe(1)
       const serviceRoles = await tx.programmeTemplateServiceRole.findMany({})
       expect(serviceRoles).toHaveLength(1)
       const responsibles = await tx.programmeTemplateResponsible.findMany({})
@@ -542,6 +707,8 @@ describe('Export/Import round-trip', () => {
       expect(partAssignments[0].assigneeId).toBe(alice.id)
       expect(partAssignments[0].assistantId).toBe(bob.id)
       expect(partAssignments[0].topic).toBe('Welcome')
+      expect(partAssignments[0].trackOrder).toBe(2)
+      expect(partAssignments[0].allowExternalSpeaker).toBe(true)
       const srAssignments = await tx.programmeServiceRoleAssignment.findMany({})
       expect(srAssignments).toHaveLength(1)
       expect(srAssignments[0].assigneeId).toBe(bob.id)
@@ -557,7 +724,147 @@ describe('Export/Import round-trip', () => {
       const consents = await tx.consentRecord.findMany({})
       expect(consents).toHaveLength(1)
       expect(consents[0].userId).toBe(alice.id)
+
+      // v1.1: Roles — 7 built-ins (pre-seeded) + 1 custom.
+      const roles = await tx.role.findMany({})
+      expect(roles).toHaveLength(8)
+      const customRoleOnTarget = roles.find(r => r.key.startsWith('custom-'))
+      expect(customRoleOnTarget).toBeDefined()
+      expect(customRoleOnTarget?.name).toBe('Custom QA Reviewer')
+      expect(customRoleOnTarget?.isBuiltIn).toBe(false)
+
+      // RolePermission — 1 grant on the custom role
+      const rolePerms = await tx.rolePermission.findMany({ where: { roleId: customRoleOnTarget?.id } })
+      expect(rolePerms).toHaveLength(1)
+      expect(rolePerms[0].permissionId).toBe(adminPermissionId)
+
+      // UserRoleAssignment — Alice is a member of the custom role on the target.
+      const customRoleAssignments = await tx.userRoleAssignment.findMany({
+        where: { roleId: customRoleOnTarget?.id },
+      })
+      expect(customRoleAssignments).toHaveLength(1)
+      expect(customRoleAssignments[0].userId).toBe(alice.id)
+
+      // ExternalSpeaker remapped onto the part assignment.
+      const speakers = await tx.externalSpeaker.findMany({})
+      expect(speakers).toHaveLength(1)
+      expect(speakers[0].name).toBe('Frère Visiteur')
+      expect(partAssignments[0].externalSpeakerId).toBe(speakers[0].id)
+
+      // Territory card overlay + perimeter
+      const overlays = await tx.territoryCardOverlay.findMany({})
+      expect(overlays).toHaveLength(1)
+      expect(overlays[0].name).toBe('Quartier Nord')
+      const perimeter = await tx.territoryPerimeter.findMany({})
+      expect(perimeter).toHaveLength(1)
+
+      // Allowed-role join rows — anchor onto the elder built-in role on target.
+      const elderOnTarget = roles.find(r => r.key === 'elder')!
+      const partAllowed = await tx.programmeTemplatePartAllowedRole.findMany({})
+      expect(partAllowed).toHaveLength(1)
+      expect(partAllowed[0].partId).toBe(parts[0].id)
+      expect(partAllowed[0].roleId).toBe(elderOnTarget.id)
+      expect(partAllowed[0].asKind).toBe('speaker')
+
+      const serviceRoleAllowed = await tx.programmeTemplateServiceRoleAllowedRole.findMany({})
+      expect(serviceRoleAllowed).toHaveLength(1)
+      expect(serviceRoleAllowed[0].serviceRoleId).toBe(serviceRoles[0].id)
+
+      const partAssignmentAllowed = await tx.programmePartAssignmentAllowedRole.findMany({})
+      expect(partAssignmentAllowed).toHaveLength(1)
+      expect(partAssignmentAllowed[0].assignmentId).toBe(partAssignments[0].id)
+      expect(partAssignmentAllowed[0].asKind).toBe('speaker')
+
+      const serviceRoleAssignmentAllowed = await tx.programmeServiceRoleAssignmentAllowedRole.findMany({})
+      expect(serviceRoleAssignmentAllowed).toHaveLength(1)
+      expect(serviceRoleAssignmentAllowed[0].assignmentId).toBe(srAssignments[0].id)
+
+      // Board section visibility role
+      const visibility = await tx.boardSectionVisibilityRole.findMany({})
+      expect(visibility).toHaveLength(1)
+      expect(visibility[0].sectionId).toBe(sections[0].id)
+      expect(visibility[0].roleId).toBe(elderOnTarget.id)
     })
+  })
+})
+
+describe('v1.0 archive backward compatibility', () => {
+  it('accepts a v1.0 manifest and routes legacy congregation-user-roles.ndjson via permission keys', async () => {
+    const congregation = await testDb.congregation.create({
+      data: { name: `Legacy ${ts}`, slug: `legacy-${ts}`, active: true },
+    })
+    const congId = congregation.id
+
+    try {
+      // Build a minimal v1.0 archive manually: just a user + the legacy permission file shape
+      // (`congregation-user-roles.ndjson` with `roleKey`). The fallback in
+      // importCongregationUserPermissions should treat `roleKey` as a Permission key.
+      const zip = new JsZip()
+      const dataDir = zip.folder('data')!
+      const sourceUserId = 9001
+      dataDir.file(
+        'users.ndjson',
+        `${JSON.stringify({
+          id: sourceUserId,
+          firstname: 'Legacy',
+          lastname: 'User',
+          email: `legacy-${ts}@test.com`,
+          active: true,
+          isPublisher: false,
+          type: PublisherType.Normal,
+          isMale: null,
+          phone: null,
+          address: null,
+          birthDate: null,
+          baptismDate: null,
+          isHelder: false,
+          isServant: false,
+          isAnointed: false,
+          anonymizedAt: null,
+          publisherGroupId: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })}\n`,
+      )
+      dataDir.file('congregation-user-roles.ndjson', `${JSON.stringify({ userId: sourceUserId, roleKey: 'admin' })}\n`)
+      const manifest: ManifestJson = {
+        version: '1.0',
+        exportDate: new Date().toISOString(),
+        sourceApp: 'unitae',
+        entityCounts: { users: 1, 'congregation-user-roles': 1 },
+      }
+      zip.file('manifest.json', JSON.stringify(manifest, null, 2))
+
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' })
+
+      const mod = await import('./import-congregation.server')
+      const allPermissions = await testDb.permission.findMany({ select: { id: true, key: true } })
+      const permissionKeyToId = new Map(allPermissions.map(p => [p.key, p.id]))
+      const idMap = new EntityIdMap()
+      const loadedZip = await JsZip.loadAsync(buffer)
+
+      await withScope(congId, async tx => {
+        await mod.importUsers(loadedZip, tx, idMap, congId)
+        await mod.importCongregationUserPermissions(loadedZip, tx, idMap, permissionKeyToId, congId)
+      })
+
+      await withScope(congId, async tx => {
+        const users = await tx.user.findMany({})
+        expect(users).toHaveLength(1)
+        const grants = await tx.congregationUserPermission.findMany({})
+        expect(grants).toHaveLength(1)
+        expect(grants[0].permissionId).toBe(adminPermissionId)
+        expect(grants[0].userId).toBe(users[0].id)
+      })
+    } finally {
+      await withScope(congId, async tx => {
+        await tx.congregationUserPermission.deleteMany({})
+        await tx.userRoleAssignment.deleteMany({})
+        await tx.user.deleteMany({})
+        await tx.auditLog.deleteMany({})
+      })
+      await testDb.congregation.delete({ where: { id: congId } })
+    }
   })
 })
 

--- a/app/features/settings/server/data-transfer.type.test.ts
+++ b/app/features/settings/server/data-transfer.type.test.ts
@@ -75,8 +75,8 @@ describe('EntityIdMap', () => {
 })
 
 describe('ARCHIVE_VERSION', () => {
-  it('is a non-empty string', () => {
-    expect(ARCHIVE_VERSION).toBe('1.0')
+  it('is the current 1.1 schema version', () => {
+    expect(ARCHIVE_VERSION).toBe('1.1')
   })
 })
 
@@ -114,5 +114,39 @@ describe('ENTITY_FILES', () => {
     const eventsIndex = ENTITY_FILES.indexOf('events')
 
     expect(kindsIndex).toBeLessThan(eventsIndex)
+  })
+
+  it('has roles before role-permissions (dependency order)', () => {
+    expect(ENTITY_FILES.indexOf('roles')).toBeLessThan(ENTITY_FILES.indexOf('role-permissions'))
+  })
+
+  it('has roles and users before user-role-assignments (dependency order)', () => {
+    const userRoleAssignmentsIndex = ENTITY_FILES.indexOf('user-role-assignments')
+    expect(ENTITY_FILES.indexOf('roles')).toBeLessThan(userRoleAssignmentsIndex)
+    expect(ENTITY_FILES.indexOf('users')).toBeLessThan(userRoleAssignmentsIndex)
+  })
+
+  it('has external-speakers before programme-part-assignments (dependency order)', () => {
+    expect(ENTITY_FILES.indexOf('external-speakers')).toBeLessThan(
+      ENTITY_FILES.indexOf('programme-part-assignments'),
+    )
+  })
+
+  it('has board-sections and roles before board-section-visibility-roles (dependency order)', () => {
+    const visibilityIndex = ENTITY_FILES.indexOf('board-section-visibility-roles')
+    expect(ENTITY_FILES.indexOf('board-sections')).toBeLessThan(visibilityIndex)
+    expect(ENTITY_FILES.indexOf('roles')).toBeLessThan(visibilityIndex)
+  })
+
+  it('has programme-template-parts before programme-template-part-allowed-roles (dependency order)', () => {
+    expect(ENTITY_FILES.indexOf('programme-template-parts')).toBeLessThan(
+      ENTITY_FILES.indexOf('programme-template-part-allowed-roles'),
+    )
+  })
+
+  it('has programme-part-assignments before programme-part-assignment-allowed-roles (dependency order)', () => {
+    expect(ENTITY_FILES.indexOf('programme-part-assignments')).toBeLessThan(
+      ENTITY_FILES.indexOf('programme-part-assignment-allowed-roles'),
+    )
   })
 })

--- a/app/features/settings/server/data-transfer.type.ts
+++ b/app/features/settings/server/data-transfer.type.ts
@@ -1,4 +1,11 @@
-export const ARCHIVE_VERSION = '1.0'
+export const ARCHIVE_VERSION = '1.1'
+
+// Older archive versions an import will still accept. v1.0 archives miss every
+// post-shipping feature table (custom roles, allowed-roles, external speakers,
+// card overlays, perimeter, board section visibility) — the import path warns
+// and proceeds. v1.0 archives created before PR #152 also use the legacy
+// `congregation-user-roles.ndjson` filename; the import handles that fallback.
+export const SUPPORTED_ARCHIVE_VERSIONS = ['1.0', '1.1'] as const
 
 export interface ManifestJson {
   version: string
@@ -30,11 +37,17 @@ export const ENTITY_FILES = [
   'congregation',
   'settings',
   'event-kinds',
+  'roles',
+  'role-permissions',
   'users',
+  'user-role-assignments',
   'congregation-user-permissions',
   'publisher-groups',
   'publisher-activities',
+  'external-speakers',
   'territories',
+  'territory-card-overlays',
+  'territory-perimeter',
   'buildings',
   'building-entrances',
   'building-accesses',
@@ -44,12 +57,17 @@ export const ENTITY_FILES = [
   'attributions',
   'programme-templates',
   'programme-template-parts',
+  'programme-template-part-allowed-roles',
   'programme-template-service-roles',
+  'programme-template-service-role-allowed-roles',
   'programme-template-responsibles',
   'events',
   'programme-part-assignments',
+  'programme-part-assignment-allowed-roles',
   'programme-service-role-assignments',
+  'programme-service-role-assignment-allowed-roles',
   'board-sections',
+  'board-section-visibility-roles',
   'board-documents',
   'board-document-versions',
   'board-dynamic-document-settings',

--- a/app/features/settings/server/export-congregation.server.ts
+++ b/app/features/settings/server/export-congregation.server.ts
@@ -116,6 +116,25 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
         }),
     },
     {
+      name: 'roles',
+      export: () =>
+        db.role.findMany({
+          select: { id: true, key: true, name: true, description: true, isBuiltIn: true },
+        }),
+    },
+    {
+      name: 'role-permissions',
+      export: async () => {
+        const grants = await db.rolePermission.findMany({
+          select: {
+            roleId: true,
+            permission: { select: { key: true } },
+          },
+        })
+        return grants.map(g => ({ roleId: g.roleId, permissionKey: g.permission.key }))
+      },
+    },
+    {
       name: 'users',
       export: () =>
         db.user.findMany({
@@ -140,6 +159,13 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
             createdAt: true,
             updatedAt: true,
           },
+        }),
+    },
+    {
+      name: 'user-role-assignments',
+      export: () =>
+        db.userRoleAssignment.findMany({
+          select: { userId: true, roleId: true },
         }),
     },
     {
@@ -185,10 +211,39 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
         }),
     },
     {
+      name: 'external-speakers',
+      export: () =>
+        db.externalSpeaker.findMany({
+          select: {
+            id: true,
+            name: true,
+            congregationName: true,
+            phone: true,
+            email: true,
+            notes: true,
+            archivedAt: true,
+          },
+        }),
+    },
+    {
       name: 'territories',
       export: () =>
         db.territory.findMany({
           select: { id: true, number: true, type: true, notes: true },
+        }),
+    },
+    {
+      name: 'territory-card-overlays',
+      export: () =>
+        db.territoryCardOverlay.findMany({
+          select: { id: true, name: true, color: true, paths: true },
+        }),
+    },
+    {
+      name: 'territory-perimeter',
+      export: () =>
+        db.territoryPerimeter.findMany({
+          select: { paths: true },
         }),
     },
     {
@@ -294,7 +349,15 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
       name: 'programme-templates',
       export: () =>
         db.programmeTemplate.findMany({
-          select: { id: true, name: true, key: true, description: true, weekDay: true, isRecurring: true },
+          select: {
+            id: true,
+            name: true,
+            key: true,
+            description: true,
+            weekDay: true,
+            isRecurring: true,
+            kindId: true,
+          },
         }),
     },
     {
@@ -306,6 +369,7 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
             name: true,
             section: true,
             track: true,
+            trackOrder: true,
             order: true,
             durationMin: true,
             allowExternalSpeaker: true,
@@ -314,10 +378,24 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
         }),
     },
     {
+      name: 'programme-template-part-allowed-roles',
+      export: () =>
+        db.programmeTemplatePartAllowedRole.findMany({
+          select: { partId: true, roleId: true, asKind: true },
+        }),
+    },
+    {
       name: 'programme-template-service-roles',
       export: () =>
         db.programmeTemplateServiceRole.findMany({
           select: { id: true, name: true, key: true, templateId: true },
+        }),
+    },
+    {
+      name: 'programme-template-service-role-allowed-roles',
+      export: () =>
+        db.programmeTemplateServiceRoleAllowedRole.findMany({
+          select: { serviceRoleId: true, roleId: true },
         }),
     },
     {
@@ -356,13 +434,23 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
             name: true,
             section: true,
             track: true,
+            trackOrder: true,
             order: true,
             durationMin: true,
             eventId: true,
             partId: true,
             assigneeId: true,
             assistantId: true,
+            allowExternalSpeaker: true,
+            externalSpeakerId: true,
           },
+        }),
+    },
+    {
+      name: 'programme-part-assignment-allowed-roles',
+      export: () =>
+        db.programmePartAssignmentAllowedRole.findMany({
+          select: { assignmentId: true, roleId: true, asKind: true },
         }),
     },
     {
@@ -381,10 +469,24 @@ export function buildExportSteps(db: TransactionClient, congregationId: number, 
         }),
     },
     {
+      name: 'programme-service-role-assignment-allowed-roles',
+      export: () =>
+        db.programmeServiceRoleAssignmentAllowedRole.findMany({
+          select: { assignmentId: true, roleId: true },
+        }),
+    },
+    {
       name: 'board-sections',
       export: () =>
         db.boardSection.findMany({
           select: { id: true, name: true, order: true },
+        }),
+    },
+    {
+      name: 'board-section-visibility-roles',
+      export: () =>
+        db.boardSectionVisibilityRole.findMany({
+          select: { sectionId: true, roleId: true },
         }),
     },
     {

--- a/app/features/settings/server/import-congregation.server.ts
+++ b/app/features/settings/server/import-congregation.server.ts
@@ -10,11 +10,11 @@ import { buildStorageKey, getFileBuffer, uploadFile } from '~/shared/infra/file-
 import { createLogger } from '~/shared/infra/logger.server'
 import type { PublisherType } from '~/shared/types/publisher-type'
 import {
-  ARCHIVE_VERSION,
   EntityIdMap,
   type ImportConflict,
   type ImportSummary,
   type ManifestJson,
+  SUPPORTED_ARCHIVE_VERSIONS,
 } from './data-transfer.type'
 import type { DataTransferJobData } from './data-transfer-queue.server'
 
@@ -38,18 +38,29 @@ export async function validateImport(storageKey: string, congregationId: number)
   const zip = await JsZip.loadAsync(buffer)
   const manifest = await readManifest(zip)
 
-  if (manifest.version !== ARCHIVE_VERSION) {
+  if (!(SUPPORTED_ARCHIVE_VERSIONS as readonly string[]).includes(manifest.version)) {
     return {
       entityCounts: manifest.entityCounts,
       conflicts: [],
-      warnings: [`Version de l'archive non supportée : ${manifest.version} (attendue : ${ARCHIVE_VERSION})`],
+      warnings: [`Unsupported archive version: ${manifest.version} (expected one of: ${SUPPORTED_ARCHIVE_VERSIONS.join(', ')})`],
     }
   }
 
   const conflicts: ImportConflict[] = []
   const warnings: string[] = [
-    'Les mots de passe ne sont pas importés. Les utilisateurs devront réinitialiser leur mot de passe.',
+    'Passwords are not imported. Users will need to reset their password after import.',
   ]
+
+  if (manifest.version === '1.0') {
+    warnings.push(
+      'Archive predates v1.1 — custom roles, external speakers, territory card overlays, perimeter, and role-based gating will not be imported.',
+    )
+    if (zip.file('data/congregation-user-permissions.ndjson') == null && zip.file('data/congregation-user-roles.ndjson') != null) {
+      warnings.push(
+        'Archive predates the UserRole → Permission rename; permission assignments will be migrated automatically.',
+      )
+    }
+  }
 
   // Check user email conflicts
   const usersNdjson = await readNdjsonFile<{ email: string }>(zip, 'users')
@@ -160,7 +171,7 @@ export async function runImport(job: Job<ImportJobData>): Promise<void> {
   const permissionKeyToId = new Map(allPermissions.map(p => [p.key, p.id]))
 
   await withScope(congregationId, async db => {
-    const totalSteps = 27
+    const totalSteps = 38
     let step = 0
 
     const progress = async () => {
@@ -176,103 +187,148 @@ export async function runImport(job: Job<ImportJobData>): Promise<void> {
     await importEventKinds(zip, db, idMap, congregationId)
     await progress()
 
-    // 3. Users (upsert by email within same congregation, skip if in different congregation)
+    // 3. Roles (upsert by key — built-ins map to pre-seeded target rows; custom roles insert)
+    await importRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 4. Role permissions (depends on roles)
+    await importRolePermissions(zip, db, idMap, permissionKeyToId, congregationId)
+    await progress()
+
+    // 5. Users (upsert by email within same congregation, skip if in different congregation)
     await importUsers(zip, db, idMap, congregationId)
     await progress()
 
-    // 4. Congregation user roles
+    // 6. User role assignments (depends on users + roles; overlaps with syncBuiltInRoleAssignments
+    //    seeded during importUsers — composite PK absorbs duplicates).
+    await importUserRoleAssignments(zip, db, idMap, congregationId)
+    await progress()
+
+    // 7. Congregation user permissions (legacy filename fallback for pre-#152 archives)
     await importCongregationUserPermissions(zip, db, idMap, permissionKeyToId, congregationId)
     await progress()
 
-    // 5. Publisher groups (depends on users)
+    // 8. Publisher groups (depends on users)
     await importPublisherGroups(zip, db, idMap, congregationId)
     await progress()
 
-    // 6. Update user publisherGroupId (depends on groups)
+    // 9. Update user publisherGroupId (depends on groups)
     await updateUserPublisherGroups(zip, db, idMap)
     await progress()
 
-    // 7. Publisher activities (depends on users)
+    // 10. Publisher activities (depends on users)
     await importPublisherActivities(zip, db, idMap, congregationId)
     await progress()
 
-    // 8. Territories (upsert by number)
+    // 11. External speakers (must run before programme part assignments)
+    await importExternalSpeakers(zip, db, idMap, congregationId)
+    await progress()
+
+    // 12. Territories (upsert by number)
     await importTerritories(zip, db, idMap, congregationId)
     await progress()
 
-    // 9. Buildings (upsert by number+street+zip)
+    // 13. Territory card overlays
+    await importTerritoryCardOverlays(zip, db, idMap, congregationId)
+    await progress()
+
+    // 14. Territory perimeter (upsert by congregationId — single row)
+    await importTerritoryPerimeter(zip, db, congregationId)
+    await progress()
+
+    // 15. Buildings (upsert by number+street+zip)
     await importBuildings(zip, db, idMap, congregationId)
     await progress()
 
-    // 10. Building entrances
+    // 16. Building entrances
     await importBuildingEntrances(zip, db, idMap, congregationId)
     await progress()
 
-    // 11. Building accesses (depends on entrances)
+    // 17. Building accesses (depends on entrances)
     await importBuildingAccesses(zip, db, idMap, congregationId)
     await progress()
 
-    // 12. Building residential data (depends on buildings + entrances)
+    // 18. Building residential data (depends on buildings + entrances)
     await importBuildingResidentialData(zip, db, idMap, congregationId)
     await progress()
 
-    // 13. Territory-entrance links
+    // 19. Territory-entrance links
     await importTerritoryEntranceLinks(zip, db, idMap)
     await progress()
 
-    // 14. Building-entrance links
+    // 20. Building-entrance links
     await importBuildingEntranceLinks(zip, db, idMap)
     await progress()
 
-    // 15. Attributions (depends on users + territories)
+    // 21. Attributions (depends on users + territories)
     await importAttributions(zip, db, idMap, congregationId)
     await progress()
 
-    // 16. Programme templates (upsert by key)
+    // 22. Programme templates (upsert by key)
     await importProgrammeTemplates(zip, db, idMap, congregationId)
     await progress()
 
-    // 17. Programme template parts
+    // 23. Programme template parts
     await importProgrammeTemplateParts(zip, db, idMap, congregationId)
     await progress()
 
-    // 18. Programme template service roles
+    // 24. Programme template part allowed roles
+    await importProgrammeTemplatePartAllowedRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 25. Programme template service roles
     await importProgrammeTemplateServiceRoles(zip, db, idMap, congregationId)
     await progress()
 
-    // 19. Programme template responsibles
+    // 26. Programme template service role allowed roles
+    await importProgrammeTemplateServiceRoleAllowedRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 27. Programme template responsibles
     await importProgrammeTemplateResponsibles(zip, db, idMap, congregationId)
     await progress()
 
-    // 20. Events (depends on event kinds + templates + users)
+    // 28. Events (depends on event kinds + templates + users)
     await importEvents(zip, db, idMap, congregationId)
     await progress()
 
-    // 21. Programme part assignments
+    // 29. Programme part assignments
     await importProgrammePartAssignments(zip, db, idMap, congregationId)
     await progress()
 
-    // 22. Programme service role assignments
+    // 30. Programme part assignment allowed roles
+    await importProgrammePartAssignmentAllowedRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 31. Programme service role assignments
     await importProgrammeServiceRoleAssignments(zip, db, idMap, congregationId)
     await progress()
 
-    // 23. Board sections
+    // 32. Programme service role assignment allowed roles
+    await importProgrammeServiceRoleAssignmentAllowedRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 33. Board sections
     await importBoardSections(zip, db, idMap, congregationId)
     await progress()
 
-    // 24. Board documents (+ files)
+    // 34. Board section visibility roles
+    await importBoardSectionVisibilityRoles(zip, db, idMap, congregationId)
+    await progress()
+
+    // 35. Board documents (+ files)
     await importBoardDocuments(zip, db, idMap, congregationId)
     await progress()
 
-    // 25. Board document versions (+ files)
+    // 36. Board document versions (+ files)
     await importBoardDocumentVersions(zip, db, idMap, congregationId)
     await progress()
 
-    // 26. Board dynamic document settings
+    // 37. Board dynamic document settings
     await importBoardDynamicDocumentSettings(zip, db, idMap, congregationId)
     await progress()
 
-    // 27. Consent records
+    // 38. Consent records
     await importConsentRecords(zip, db, idMap, congregationId)
     await progress()
 
@@ -463,8 +519,20 @@ export async function importCongregationUserPermissions(
   permissionKeyToId: Map<string, number>,
   congregationId: number,
 ): Promise<void> {
+  // Pre-#152 archives use the legacy `congregation-user-roles.ndjson` shape with `roleKey`.
+  // The rename was a pure terminology change (UserRole table → Permission), so the keys are
+  // identical and route through the same `permissionKeyToId` map.
   const records = await readNdjsonFile<{ userId: number; permissionKey: string }>(zip, 'congregation-user-permissions')
-  for (const record of records) {
+  const legacyRecords =
+    records.length === 0
+      ? (await readNdjsonFile<{ userId: number; roleKey: string }>(zip, 'congregation-user-roles')).map(r => ({
+          userId: r.userId,
+          permissionKey: r.roleKey,
+        }))
+      : []
+  const merged = records.length > 0 ? records : legacyRecords
+
+  for (const record of merged) {
     const userId = idMap.getOptional('users', record.userId)
     const permissionId = permissionKeyToId.get(record.permissionKey)
     if (!userId || !permissionId) continue
@@ -834,9 +902,11 @@ export async function importProgrammeTemplates(
     description: string
     weekDay: number | null
     isRecurring: boolean
+    kindId?: number | null
   }>(zip, 'programme-templates')
 
   for (const record of records) {
+    const kindId = idMap.getOptional('event-kinds', record.kindId)
     const existing = await db.programmeTemplate.findFirst({ where: { key: record.key } })
     if (existing) {
       await db.programmeTemplate.update({
@@ -846,6 +916,7 @@ export async function importProgrammeTemplates(
           description: record.description,
           weekDay: record.weekDay,
           isRecurring: record.isRecurring,
+          kindId,
         },
       })
       idMap.set('programme-templates', record.id, existing.id)
@@ -857,6 +928,7 @@ export async function importProgrammeTemplates(
           description: record.description,
           weekDay: record.weekDay,
           isRecurring: record.isRecurring,
+          kindId,
           congregationId,
         },
       })
@@ -876,6 +948,7 @@ export async function importProgrammeTemplateParts(
     name: string
     section: string
     track: string
+    trackOrder?: number | null
     order: number
     durationMin: number | null
     allowExternalSpeaker: boolean
@@ -891,6 +964,7 @@ export async function importProgrammeTemplateParts(
         name: record.name,
         section: record.section,
         track: record.track,
+        trackOrder: record.trackOrder ?? null,
         order: record.order,
         durationMin: record.durationMin,
         allowExternalSpeaker: record.allowExternalSpeaker,
@@ -1008,12 +1082,15 @@ export async function importProgrammePartAssignments(
     name: string
     section: string
     track: string
+    trackOrder?: number | null
     order: number
     durationMin: number | null
     eventId: number
     partId: number | null
     assigneeId: number | null
     assistantId: number | null
+    allowExternalSpeaker?: boolean
+    externalSpeakerId?: number | null
   }>(zip, 'programme-part-assignments')
 
   for (const record of records) {
@@ -1028,12 +1105,15 @@ export async function importProgrammePartAssignments(
         name: record.name,
         section: record.section,
         track: record.track,
+        trackOrder: record.trackOrder ?? null,
         order: record.order,
         durationMin: record.durationMin,
         eventId,
         partId: idMap.getOptional('programme-template-parts', record.partId),
         assigneeId: idMap.getOptional('users', record.assigneeId),
         assistantId: idMap.getOptional('users', record.assistantId),
+        allowExternalSpeaker: record.allowExternalSpeaker ?? false,
+        externalSpeakerId: idMap.getOptional('external-speakers', record.externalSpeakerId),
         congregationId,
       },
     })
@@ -1061,7 +1141,7 @@ export async function importProgrammeServiceRoleAssignments(
     const eventId = idMap.getOptional('events', record.eventId)
     if (!eventId) continue
 
-    await db.programmeServiceRoleAssignment.create({
+    const created = await db.programmeServiceRoleAssignment.create({
       data: {
         note: record.note,
         hasConflict: record.hasConflict,
@@ -1072,6 +1152,7 @@ export async function importProgrammeServiceRoleAssignments(
         congregationId,
       },
     })
+    idMap.set('programme-service-role-assignments', record.id, created.id)
   }
 }
 
@@ -1347,5 +1428,285 @@ export async function importDataDeletionRecords(
         congregationId,
       },
     })
+  }
+}
+
+// --- v1.1 entities ---
+
+export async function importRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{
+    id: number
+    key: string
+    name: string | null
+    description: string | null
+    isBuiltIn: boolean
+  }>(zip, 'roles')
+
+  for (const record of records) {
+    const existing = await db.role.findFirst({ where: { key: record.key } })
+    if (existing) {
+      // Built-in roles are pre-seeded for every congregation; map source id to existing target id.
+      // Custom roles imported into a congregation that already has the same key get their
+      // metadata refreshed but keep the target's id.
+      await db.role.update({
+        where: { id: existing.id },
+        data: { name: record.name, description: record.description, isBuiltIn: record.isBuiltIn },
+      })
+      idMap.set('roles', record.id, existing.id)
+    } else {
+      const created = await db.role.create({
+        data: {
+          key: record.key,
+          name: record.name,
+          description: record.description,
+          isBuiltIn: record.isBuiltIn,
+          congregationId,
+        },
+      })
+      idMap.set('roles', record.id, created.id)
+    }
+  }
+}
+
+export async function importRolePermissions(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  permissionKeyToId: Map<string, number>,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ roleId: number; permissionKey: string }>(zip, 'role-permissions')
+  const data: { roleId: number; permissionId: number; congregationId: number }[] = []
+
+  for (const record of records) {
+    const roleId = idMap.getOptional('roles', record.roleId)
+    const permissionId = permissionKeyToId.get(record.permissionKey)
+    if (!roleId || !permissionId) continue
+    data.push({ roleId, permissionId, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.rolePermission.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importUserRoleAssignments(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ userId: number; roleId: number }>(zip, 'user-role-assignments')
+  const data: { userId: number; roleId: number; congregationId: number }[] = []
+
+  for (const record of records) {
+    const userId = idMap.getOptional('users', record.userId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!userId || !roleId) continue
+    data.push({ userId, roleId, congregationId })
+  }
+
+  if (data.length > 0) {
+    // syncBuiltInRoleAssignments inside importUsers already inserted built-in role rows
+    // matching each user's boolean flags. The composite (userId, roleId) PK absorbs duplicates;
+    // this call adds custom-role memberships and any built-in assignments the source had that
+    // the boolean-flag heuristic doesn't reproduce.
+    await db.userRoleAssignment.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importExternalSpeakers(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{
+    id: number
+    name: string
+    congregationName: string
+    phone: string | null
+    email: string | null
+    notes: string | null
+    archivedAt: string | null
+  }>(zip, 'external-speakers')
+
+  for (const record of records) {
+    const created = await db.externalSpeaker.create({
+      data: {
+        name: record.name,
+        congregationName: record.congregationName,
+        phone: record.phone,
+        email: record.email,
+        notes: record.notes,
+        archivedAt: record.archivedAt ? new Date(record.archivedAt) : null,
+        congregationId,
+      },
+    })
+    idMap.set('external-speakers', record.id, created.id)
+  }
+}
+
+export async function importTerritoryCardOverlays(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{
+    id: number
+    name: string | null
+    color: string
+    paths: unknown
+  }>(zip, 'territory-card-overlays')
+
+  for (const record of records) {
+    const created = await db.territoryCardOverlay.create({
+      data: {
+        name: record.name,
+        color: record.color,
+        paths: record.paths as never,
+        congregationId,
+      },
+    })
+    idMap.set('territory-card-overlays', record.id, created.id)
+  }
+}
+
+export async function importTerritoryPerimeter(
+  zip: JsZip,
+  db: TransactionClient,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ paths: unknown }>(zip, 'territory-perimeter')
+  const record = records[0]
+  if (!record) return
+
+  await db.territoryPerimeter.upsert({
+    where: { congregationId },
+    update: { paths: record.paths as never },
+    create: { paths: record.paths as never, congregationId },
+  })
+}
+
+export async function importBoardSectionVisibilityRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ sectionId: number; roleId: number }>(zip, 'board-section-visibility-roles')
+  const data: { sectionId: number; roleId: number; congregationId: number }[] = []
+
+  for (const record of records) {
+    const sectionId = idMap.getOptional('board-sections', record.sectionId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!sectionId || !roleId) continue
+    data.push({ sectionId, roleId, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.boardSectionVisibilityRole.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importProgrammeTemplatePartAllowedRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ partId: number; roleId: number; asKind: string }>(
+    zip,
+    'programme-template-part-allowed-roles',
+  )
+  const data: { partId: number; roleId: number; asKind: string; congregationId: number }[] = []
+
+  for (const record of records) {
+    const partId = idMap.getOptional('programme-template-parts', record.partId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!partId || !roleId) continue
+    data.push({ partId, roleId, asKind: record.asKind, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.programmeTemplatePartAllowedRole.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importProgrammeTemplateServiceRoleAllowedRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ serviceRoleId: number; roleId: number }>(
+    zip,
+    'programme-template-service-role-allowed-roles',
+  )
+  const data: { serviceRoleId: number; roleId: number; congregationId: number }[] = []
+
+  for (const record of records) {
+    const serviceRoleId = idMap.getOptional('programme-template-service-roles', record.serviceRoleId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!serviceRoleId || !roleId) continue
+    data.push({ serviceRoleId, roleId, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.programmeTemplateServiceRoleAllowedRole.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importProgrammePartAssignmentAllowedRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ assignmentId: number; roleId: number; asKind: string }>(
+    zip,
+    'programme-part-assignment-allowed-roles',
+  )
+  const data: { assignmentId: number; roleId: number; asKind: string; congregationId: number }[] = []
+
+  for (const record of records) {
+    const assignmentId = idMap.getOptional('programme-part-assignments', record.assignmentId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!assignmentId || !roleId) continue
+    data.push({ assignmentId, roleId, asKind: record.asKind, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.programmePartAssignmentAllowedRole.createMany({ data, skipDuplicates: true })
+  }
+}
+
+export async function importProgrammeServiceRoleAssignmentAllowedRoles(
+  zip: JsZip,
+  db: TransactionClient,
+  idMap: EntityIdMap,
+  congregationId: number,
+): Promise<void> {
+  const records = await readNdjsonFile<{ assignmentId: number; roleId: number }>(
+    zip,
+    'programme-service-role-assignment-allowed-roles',
+  )
+  const data: { assignmentId: number; roleId: number; congregationId: number }[] = []
+
+  for (const record of records) {
+    const assignmentId = idMap.getOptional('programme-service-role-assignments', record.assignmentId)
+    const roleId = idMap.getOptional('roles', record.roleId)
+    if (!assignmentId || !roleId) continue
+    data.push({ assignmentId, roleId, congregationId })
+  }
+
+  if (data.length > 0) {
+    await db.programmeServiceRoleAssignmentAllowedRole.createMany({ data, skipDuplicates: true })
   }
 }

--- a/docs/development/data-transfer.md
+++ b/docs/development/data-transfer.md
@@ -12,7 +12,7 @@ A `.unitae` archive is a ZIP with three top-level entries:
 | `data/<entity>.ndjson` | One file per entity type, in newline-delimited JSON. Each line is one row. Empty files are omitted from the archive |
 | `files/` | Uploaded user files (board PDFs, territory cards). Only present when the export was created with `includeFiles: true` |
 
-The archive version is a constant at the top of `app/features/settings/server/data-transfer.type.ts` (`ARCHIVE_VERSION`). On import, an archive whose version does not match is reported as a warning and skipped — the schema is intentionally not backwards-compatible across major bumps; bump the constant when the on-disk shape changes.
+The archive version is a constant at the top of `app/features/settings/server/data-transfer.type.ts` (`ARCHIVE_VERSION`, currently `1.1`). The list of accepted versions on import lives in `SUPPORTED_ARCHIVE_VERSIONS` in the same file — versions outside that list are reported as a warning and skipped. Bump the constant when the on-disk shape changes; add the previous value to `SUPPORTED_ARCHIVE_VERSIONS` when the format remains compatible enough to import-with-warning (most recent example: 1.0 archives import successfully, just without the post-1.0 entity tables).
 
 Compression is `DEFLATE` via [`jszip`](https://stuk.github.io/jszip/). Buffers are produced in memory; very large exports may need to switch to streaming if memory pressure becomes a concern.
 
@@ -20,11 +20,13 @@ Compression is `DEFLATE` via [`jszip`](https://stuk.github.io/jszip/). Buffers a
 
 Entities are exported in dependency order so an import can replay them top-down without missing references. The list lives in `buildExportSteps` (`export-congregation.server.ts`). Order matters: territories before attributions, board sections before board documents, etc.
 
-## What's not yet exported
+## Backward compatibility — pre-1.1 archives
 
-Several feature tables added since the export was first written are **not** yet enumerated in `ENTITY_FILES` and therefore not included in the archive — custom roles and their permission bundles, user role memberships, role gating on board sections, allowed-roles on programme parts/service roles, the external-speakers registry, territory card overlays, and the territory perimeter. An export+import round-trip on a congregation that uses these features silently drops them on the target side.
+`1.0` archives are missing every feature table added after the export first shipped (custom roles, role-permissions, user-role-assignments, board section visibility, allowed-roles on programme parts/service-roles and their per-event copies, external speakers, territory card overlays, territory perimeter). The import accepts them with a warning and proceeds — those tables stay empty on the target.
 
-Tracked in [#170](https://github.com/Unitae/unitae/issues/170). When extending `ENTITY_FILES`, also bump `ARCHIVE_VERSION` so older archives are rejected (or handled with an explicit "this archive predates feature X" warning) on import.
+A subset of `1.0` archives, created before [PR #152](https://github.com/Unitae/unitae/pull/152), use the legacy filename `data/congregation-user-roles.ndjson` with a `roleKey` field instead of `data/congregation-user-permissions.ndjson` with `permissionKey`. The rename was a pure terminology change (`UserRole` → `Permission`, key values preserved); `importCongregationUserPermissions` falls back to the legacy filename when the current one is missing.
+
+When extending `ENTITY_FILES`, bump `ARCHIVE_VERSION` and add the previous value to `SUPPORTED_ARCHIVE_VERSIONS` if you want existing archives to keep importing.
 
 ## Conflict resolution on import
 

--- a/docs/product/data-transfer.md
+++ b/docs/product/data-transfer.md
@@ -19,12 +19,15 @@ Unitae allows administrators to export and import entire congregation data as `.
 The archive contains all congregation data:
 
 - Users (without passwords — recipients must reset their password after import)
+- Roles, role memberships, and the permissions that each role grants
 - Territories, buildings, and building entrances with prospection data
+- Territory map overlays and the congregation perimeter
 - Territory attributions
 - Publisher groups and activity records
-- Events, event kinds, and programme templates with parts and service roles
-- Programme assignments
-- Board sections and documents (with optional uploaded files)
+- Events, event kinds, and programme templates with parts, service roles, and the role gating that decides who can be assigned
+- Programme assignments (including the same role gating, copied per event)
+- The visiting-speaker registry
+- Board sections (with role-based visibility) and documents (with optional uploaded files)
 - Settings and notification preferences
 - Consent records
 - Audit logs (optional)


### PR DESCRIPTION
## Summary

- Adds the 11 feature tables that the data-transfer export silently dropped (custom roles, role-permissions, user-role memberships, board section visibility, four allowed-role join tables, external speakers, territory card overlays, territory perimeter).
- Bumps \`ARCHIVE_VERSION\` to 1.1 and adds \`SUPPORTED_ARCHIVE_VERSIONS\` so 1.0 archives still import (with a warning); pre-#152 1.0 archives with the legacy \`congregation-user-roles.ndjson\` filename fall back through the same code path.
- Folds in adjacent leakage gaps: \`kindId\` on \`programme-templates\`, \`trackOrder\` on \`programme-template-parts\` and \`programme-part-assignments\`, and \`allowExternalSpeaker\` + \`externalSpeakerId\` on \`programme-part-assignments\`.

Fixes #170.

## Test plan

- [x] \`pnpm test:lint\` — clean (8 pre-existing warnings unrelated)
- [x] \`pnpm test:typecheck\` — passes
- [x] \`pnpm test:unit\` — 1028/1028 passes (added ordering assertions for new entities, ARCHIVE_VERSION expectation)
- [x] \`pnpm test:integration\` — 145/145 passes (round-trip asserts count + remapped FKs for every new entity; dedicated 1.0 backward-compat test exercises the legacy filename fallback)
- [ ] Manual smoke: export a congregation that uses custom roles + external speakers + card overlays + a perimeter + role-gated board sections, import into a fresh congregation, verify all five surfaces are intact on the target.