### PR TITLE
fix(programs): use absolute URLs for parts reorder fetcher

### DIFF
--- a/app/features/events/routes/programs/events/edit.tsx
+++ b/app/features/events/routes/programs/events/edit.tsx
@@ -399,7 +399,7 @@ export default function EditEventPage({ loaderData }: Route.ComponentProps) {
 
     reorderFetcher.submit(
       { orderedIds: reordered },
-      { method: 'POST', action: `./reorder-parts`, encType: 'application/json' },
+      { method: 'POST', action: `/programs/events/${event.id}/reorder-parts`, encType: 'application/json' },
     )
   }
 

--- a/app/features/events/ui/SortableRow.tsx
+++ b/app/features/events/ui/SortableRow.tsx
@@ -14,7 +14,7 @@ export function SortableRow({ id, children }: { id: number; children: ReactNode 
   }
 
   return (
-    <TableRow ref={setNodeRef} style={style}>
+    <TableRow ref={setNodeRef} style={style} data-sortable="">
       <TableCell className="w-8">
         <button type="button" className="cursor-grab touch-none text-muted-foreground" {...attributes} {...listeners}>
           <GripVertical className="size-4" />

--- a/app/features/settings/routes/congregation/templates/edit.tsx
+++ b/app/features/settings/routes/congregation/templates/edit.tsx
@@ -296,7 +296,7 @@ export default function TemplateEditPage({ loaderData }: Route.ComponentProps) {
 
     reorderFetcher.submit(
       { orderedIds: reordered },
-      { method: 'POST', action: './reorder-parts', encType: 'application/json' },
+      { method: 'POST', action: `/settings/congregation/templates/${template.id}/reorder-parts`, encType: 'application/json' },
     )
   }
 

--- a/app/tests/e2e/programme-reorder.spec.ts
+++ b/app/tests/e2e/programme-reorder.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+import { login } from './helpers/auth'
+
+const MANAGER_EMAIL = process.env.E2E_PROGRAM_MANAGER_EMAIL
+const MANAGER_PASSWORD = process.env.E2E_PROGRAM_MANAGER_PASSWORD
+const REORDER_EVENT_ID = process.env.E2E_REORDER_EVENT_ID
+
+const REORDER_PARTS_RE = /\/reorder-parts$/
+const TEMPLATE_REORDER_URL_RE = /\/settings\/congregation\/templates\/\d+\/reorder-parts$/
+const EVENT_REORDER_URL_RE = /\/programs\/events\/\d+\/reorder-parts$/
+const TEMPLATE_EDIT_URL_RE = /\/settings\/congregation\/templates\/\d+\/edit/
+const NOT_FOUND_RE = /404|page introuvable/i
+const TEMPLATE_EDIT_LINK_RE = /modifier|edit/i
+
+test.describe('Programme parts drag-drop reorder (regression: #134)', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!MANAGER_EMAIL || !MANAGER_PASSWORD) test.skip()
+    const loggedIn = await login(page, MANAGER_EMAIL ?? '', MANAGER_PASSWORD ?? '')
+    if (!loggedIn) test.skip()
+  })
+
+  test('template edit POSTs to reorder-parts (no 404)', async ({ page }) => {
+    await page.goto('/settings/congregation/templates')
+    await page.waitForLoadState('networkidle')
+
+    const firstTemplateLink = page.getByRole('link', { name: TEMPLATE_EDIT_LINK_RE }).first()
+    if ((await firstTemplateLink.count()) === 0) test.skip()
+    await firstTemplateLink.click()
+    await expect(page).toHaveURL(TEMPLATE_EDIT_URL_RE)
+
+    const sortableRows = page.locator('tbody tr[data-sortable]')
+    const rowsBefore = await sortableRows.allTextContents()
+    if (rowsBefore.length < 2) test.skip()
+
+    const responsePromise = page.waitForResponse(
+      r => REORDER_PARTS_RE.test(r.url()) && r.request().method() === 'POST',
+    )
+
+    await page.locator('button[aria-roledescription="sortable"]').first().focus()
+    await page.keyboard.press('Space')
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Space')
+
+    const response = await responsePromise
+    expect(response.ok()).toBeTruthy()
+    expect(response.url()).toMatch(TEMPLATE_REORDER_URL_RE)
+
+    await expect(page.getByText(NOT_FOUND_RE)).toHaveCount(0)
+
+    await page.reload()
+    const rowsAfter = await page.locator('tbody tr[data-sortable]').allTextContents()
+    expect(rowsAfter[0]).toBe(rowsBefore[1])
+    expect(rowsAfter[1]).toBe(rowsBefore[0])
+  })
+
+  test('event edit POSTs to reorder-parts (no 404)', async ({ page }) => {
+    if (!REORDER_EVENT_ID) test.skip()
+    await page.goto(`/programs/events/${REORDER_EVENT_ID}/edit`)
+    await page.waitForLoadState('networkidle')
+
+    const sortableRows = page.locator('tbody tr[data-sortable]')
+    const rowsBefore = await sortableRows.allTextContents()
+    if (rowsBefore.length < 2) test.skip()
+
+    const responsePromise = page.waitForResponse(
+      r => REORDER_PARTS_RE.test(r.url()) && r.request().method() === 'POST',
+    )
+
+    await page.locator('button[aria-roledescription="sortable"]').first().focus()
+    await page.keyboard.press('Space')
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('Space')
+
+    const response = await responsePromise
+    expect(response.ok()).toBeTruthy()
+    expect(response.url()).toMatch(EVENT_REORDER_URL_RE)
+
+    await expect(page.getByText(NOT_FOUND_RE)).toHaveCount(0)
+
+    await page.reload()
+    const rowsAfter = await page.locator('tbody tr[data-sortable]').allTextContents()
+    expect(rowsAfter[0]).toBe(rowsBefore[1])
+    expect(rowsAfter[1]).toBe(rowsBefore[0])
+  })
+})


### PR DESCRIPTION
Closes #134.

## Summary

- Drag-drop reorder on `/programs/events/:eventId/edit` and `/settings/congregation/templates/:templateId/edit` rendered a 404 with no network request because both fetchers submitted to a relative `./reorder-parts` action that React Router resolved against the matched route id (`…/edit/reorder-parts`), which matches no route.
- Switch both fetchers to absolute URLs — same pattern as `display-board/routes/sections/list.tsx` (`/board/sections/...`).
- Add `app/tests/e2e/programme-reorder.spec.ts`: drives the reorder via dnd-kit's keyboard sensor (Space → ArrowDown → Space) on the drag handle, asserts a POST to `…/reorder-parts` returns 200, the error UI never appears, and the new order persists after reload. Template test uses seed data; event test is env-gated on `E2E_REORDER_EVENT_ID` (consistent with `program-permissions.spec.ts`).
- `SortableRow` now sets `data-sortable=""` so the spec can target sortable rows distinctly from section header rows.

## Test plan

- [x] `pnpm test:lint`
- [x] `pnpm test:typecheck`
- [x] `pnpm test:unit` (1022/1022)
- [ ] Manual: drag a part on `/programs/events/:eventId/edit` — no 404, URL unchanged, DevTools shows `POST /programs/events/:eventId/reorder-parts` 200, order persists after reload
- [ ] Manual: same on `/settings/congregation/templates/:templateId/edit`
- [ ] Sanity: `/board/sections` drag-drop still works (no regression)
- [ ] `pnpm test:e2e --grep "drag-drop reorder"` (requires `E2E_PROGRAM_MANAGER_EMAIL` / `E2E_PROGRAM_MANAGER_PASSWORD`; event spec also needs `E2E_REORDER_EVENT_ID`)