### PR TITLE
fix(worker): give each BullMQ Queue/Worker its own Redis connection

### DIFF
--- a/app/features/display-board/server/thumbnail-queue.server.ts
+++ b/app/features/display-board/server/thumbnail-queue.server.ts
@@ -1,9 +1,9 @@
 import { Queue } from 'bullmq'
 import { QUEUE_NAMES } from '~/shared/infra/queues.server'
-import { redis } from '~/shared/infra/redis.server'
+import { getBullMQConnection } from '~/shared/infra/redis.server'
 
 export const thumbnailQueue = new Queue(QUEUE_NAMES.thumbnail, {
-  connection: redis,
+  connection: getBullMQConnection(),
   defaultJobOptions: {
     attempts: 3,
     backoff: {

--- a/app/features/settings/server/data-transfer-queue.server.ts
+++ b/app/features/settings/server/data-transfer-queue.server.ts
@@ -1,10 +1,10 @@
 import { Queue } from 'bullmq'
 import { QUEUE_NAMES } from '~/shared/infra/queues.server'
-import { redis } from '~/shared/infra/redis.server'
+import { getBullMQConnection } from '~/shared/infra/redis.server'
 import type { ExportOptions } from './data-transfer.type'
 
 export const dataTransferQueue = new Queue(QUEUE_NAMES.dataTransfer, {
-  connection: redis,
+  connection: getBullMQConnection(),
   defaultJobOptions: {
     attempts: 1,
     removeOnComplete: 10,

--- a/app/features/territories/server/sync-queue.server.ts
+++ b/app/features/territories/server/sync-queue.server.ts
@@ -1,9 +1,9 @@
 import { Queue } from 'bullmq'
 import { QUEUE_NAMES } from '~/shared/infra/queues.server'
-import { redis } from '~/shared/infra/redis.server'
+import { getBullMQConnection } from '~/shared/infra/redis.server'
 
 export const syncQueue = new Queue(QUEUE_NAMES.sync, {
-  connection: redis,
+  connection: getBullMQConnection(),
   defaultJobOptions: {
     attempts: 3,
     backoff: {

--- a/app/shared/infra/email-queue.server.ts
+++ b/app/shared/infra/email-queue.server.ts
@@ -1,9 +1,9 @@
 import { Queue } from 'bullmq'
 import { QUEUE_NAMES } from '~/shared/infra/queues.server'
-import { redis } from '~/shared/infra/redis.server'
+import { getBullMQConnection } from '~/shared/infra/redis.server'
 
 export const emailQueue = new Queue(QUEUE_NAMES.email, {
-  connection: redis,
+  connection: getBullMQConnection(),
   defaultJobOptions: {
     attempts: 3,
     backoff: {

--- a/app/shared/infra/redis.server.ts
+++ b/app/shared/infra/redis.server.ts
@@ -9,6 +9,20 @@ const redisConfig = {
   lazyConnect: true,
 }
 
+// Each BullMQ Queue and Worker must own its own connection — sharing one ioredis
+// instance across multiple Workers causes their duplicated blocking clients to
+// race at boot, leaving some Workers "ready" but never actually subscribed via
+// BZPOPMIN. Returning a fresh options object per call lets BullMQ manage the
+// lifecycle without a shared parent.
+export function getBullMQConnection() {
+  return {
+    host: process.env.REDIS_HOST || 'localhost',
+    port: Number(process.env.REDIS_PORT) || 6379,
+    password: process.env.REDIS_PASSWORD,
+    maxRetriesPerRequest: null,
+  }
+}
+
 export const redis = new Redis({
   ...redisConfig,
   maxRetriesPerRequest: null, // Allow retries for BullMQ

--- a/app/workers/worker.server.ts
+++ b/app/workers/worker.server.ts
@@ -8,7 +8,7 @@ import { handleDataTransferWork } from '~/features/settings/jobs/handle-data-tra
 import { handleSyncWork } from '~/features/territories/jobs/handle-sync-work.server'
 import { createLogger } from '~/shared/infra/logger.server'
 import { QUEUE_NAMES } from '~/shared/infra/queues.server'
-import { redis } from '~/shared/infra/redis.server'
+import { getBullMQConnection } from '~/shared/infra/redis.server'
 
 const logger = createLogger('worker')
 const HEALTH_PORT = Number(process.env.UNITAE_WORKER_HEALTH_PORT ?? '9090')
@@ -39,28 +39,28 @@ function setupWorkerEvents(worker: Worker, name: string) {
 }
 
 const syncWorker = new Worker(QUEUE_NAMES.sync, handleSyncWork, {
-  connection: redis,
+  connection: getBullMQConnection(),
   concurrency: 1,
   removeOnComplete: { count: 100 },
   removeOnFail: { count: 50 },
 })
 
 const emailWorker = new Worker(QUEUE_NAMES.email, handleEmailWork, {
-  connection: redis,
+  connection: getBullMQConnection(),
   concurrency: 5,
   removeOnComplete: { count: 50 },
   removeOnFail: { count: 20 },
 })
 
 const thumbnailWorker = new Worker(QUEUE_NAMES.thumbnail, handleThumbnailWork, {
-  connection: redis,
+  connection: getBullMQConnection(),
   concurrency: 2,
   removeOnComplete: { count: 50 },
   removeOnFail: { count: 20 },
 })
 
 const dataTransferWorker = new Worker(QUEUE_NAMES.dataTransfer, handleDataTransferWork, {
-  connection: redis,
+  connection: getBullMQConnection(),
   concurrency: 1,
   removeOnComplete: { count: 10 },
   removeOnFail: { count: 10 },


### PR DESCRIPTION
## Summary
- All four Queues and four Workers were sharing one lazy `ioredis` singleton. At worker boot, BullMQ's `.duplicate()` calls raced on first connect; the losing duplicates emitted `Worker is ready` but were never actually subscribed to `BZPOPMIN`. Result in production: exports and PDF thumbnails sat in `bull:<queue>:wait` forever with no errors logged anywhere.
- Introduce `getBullMQConnection()` in `app/shared/infra/redis.server.ts` returning a fresh `{ host, port, password, maxRetriesPerRequest: null }` per call (no `lazyConnect`), and use it at every Queue/Worker construction site so BullMQ owns each connection's lifecycle.
- Leave the existing `redis` and `redisRateLimit` exports alone — `shell/health.tsx` and `features/authentication/server/rate-limit.server.ts` don't run blocking commands and aren't affected by the race.

## Test plan
- [x] `pnpm test:unit` (1028/1028 pass)
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint` (no new findings in touched files)
- [ ] After deploy: `docker compose exec redis sh -c 'redis-cli -a "$REDIS_PASSWORD" --no-auth-warning CLIENT LIST' | grep -c 'cmd=bzpopmin'` must return **4**
- [ ] After deploy: submit a fresh export — status page advances off "waiting" within seconds and worker logs show `Starting data transfer job <id>`
- [ ] After deploy: upload a board PDF — `bull:thumbnailQueue:wait` drains and the thumbnail renders
- [ ] Post-deploy recovery: `force-recreate worker`, then obliterate the orphaned `dataTransferQueue` / `thumbnailQueue` state via the BullMQ `Queue.obliterate({ force: true })` snippet so users stop seeing perma-"waiting" pages