### PR TITLE
fix(dashboard): exclude days off from "next meeting" widget

### DIFF
--- a/app/features/dashboard/server/dashboard.integration.test.ts
+++ b/app/features/dashboard/server/dashboard.integration.test.ts
@@ -1,6 +1,7 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { PrismaClient } from '~/database/generated/client'
+import { EventKind } from '~/features/events/model/event-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import { PublisherType } from '~/shared/types/publisher-type'
 
@@ -287,5 +288,34 @@ describe('getNextMeeting (integration)', () => {
   it('does not return past events', async () => {
     const result = await withScope(congregationId, tx => getNextMeeting(tx, aliceId))
     expect(result?.id).not.toBe(pastEventId)
+  })
+
+  it("ignores another user's day off when picking the next meeting", async () => {
+    const offEventId = await withScope(congregationId, async tx => {
+      const offKind = await tx.eventKind.create({
+        data: { name: 'Absence', key: EventKind.Off, color: '#888888', congregationId },
+      })
+      const off = await tx.event.create({
+        data: {
+          name: 'Absence',
+          kindId: offKind.id,
+          startDate: new Date('2027-05-01T00:00:00Z'),
+          endDate: new Date('2027-05-03T00:00:00Z'),
+          createdById: bobAccountId,
+          congregationId,
+        },
+      })
+      return off.id
+    })
+
+    try {
+      const result = await withScope(congregationId, tx => getNextMeeting(tx, aliceId))
+      expect(result?.name).toBe(`Future Meeting ${ts}`)
+    } finally {
+      await withScope(congregationId, async tx => {
+        await tx.event.delete({ where: { id_congregationId: { id: offEventId, congregationId } } })
+        await tx.eventKind.deleteMany({ where: { key: EventKind.Off, congregationId } })
+      })
+    }
   })
 })

--- a/app/features/dashboard/server/dashboard.server.ts
+++ b/app/features/dashboard/server/dashboard.server.ts
@@ -1,4 +1,5 @@
 // Intentional cross-feature import: dashboard aggregates data from events and the board for the overview
+import { EventKind } from '~/features/events/model/event-kind.type'
 import { getNextDaysOffs } from '~/features/events/server/days-off.server'
 import { resolveEffectiveRoleIds } from '~/shared/auth/permissions.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
@@ -251,7 +252,10 @@ export async function getNextMeeting(db: TransactionClient, userId: number) {
   const now = new Date()
 
   const event = await db.event.findFirst({
-    where: { startDate: { gte: now } },
+    where: {
+      startDate: { gte: now },
+      kind: { key: { not: EventKind.Off } },
+    },
     select: {
       id: true,
       name: true,


### PR DESCRIPTION
## Summary

- \`getNextMeeting\` had no \`kind\` filter, so any user's day off (stored as an \`Event\` with \`kind.key = 'off'\`) surfaced as the "next meeting" for everyone in the congregation — producing an empty card and leaking absence dates.
- Added \`kind: { key: { not: EventKind.Off } }\` to the query. \`EventKind.Other\` events still appear (assemblies, special events).
- Added a regression integration test asserting that another user's day off does not displace the real next meeting.

## Test plan

- [x] \`pnpm test:typecheck\`
- [x] \`pnpm test:lint\`
- [x] \`pnpm test:unit\`
- [x] \`pnpm test:integration\` (new case + existing dashboard cases)
- [x] Mutation check: reverted the fix locally, confirmed the new test fails with \`Received: "Absence"\`, restored
- [ ] Manual: create a day off as user A with start before next seeded meeting; load dashboard as user B in same congregation; "Prochaine réunion" shows the real next meeting

## Follow-up

#186 — admin setting to choose which event kinds appear in the widget.