### PR TITLE
fix(dashboard): surface day-off conflicts on all future assignments

### DIFF
--- a/app/features/dashboard/routes/index.tsx
+++ b/app/features/dashboard/routes/index.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, CalendarOff, CalendarPlus, ChevronRight, FileText, Info,
 import { Link } from 'react-router'
 
 import {
+  getConflictingAssignments,
   getNextMeeting,
   getRecentDocuments,
   getUnreadDocumentCount,
@@ -48,25 +49,30 @@ export function loader({ context }: Route.LoaderArgs) {
   // Member id; account-bound queries (documents/views) use the UserAccount id.
   const memberId = currentUser.member?.id ?? null
   return withScopeFromContext(context, async db => {
-    const [territories, recentDocuments, unreadDocumentCount, absences, nextMeeting] = await Promise.all([
-      memberId != null
-        ? safeQuery('territories', currentUser.id, () => getUserTerritories(db, memberId))
-        : Promise.resolve(null),
-      canViewBoard
-        ? safeQuery('documents', currentUser.id, () =>
-            getRecentDocuments(db, currentUser.id, currentUser.congregationId),
-          )
-        : Promise.resolve(null),
-      canViewBoard
-        ? safeQuery('unread-count', currentUser.id, () =>
-            getUnreadDocumentCount(db, currentUser.id, currentUser.congregationId),
-          )
-        : Promise.resolve(0),
-      safeQuery('absences', currentUser.id, () => getUpcomingAbsences(db, currentUser.id, currentUser.congregationId)),
-      memberId != null
-        ? safeQuery('next-meeting', currentUser.id, () => getNextMeeting(db, memberId))
-        : Promise.resolve(null),
-    ])
+    const memberSafeQuery = <T,>(label: string, run: (mid: number) => Promise<T>): Promise<T | null> => {
+      if (memberId == null) return Promise.resolve(null)
+      return safeQuery(label, currentUser.id, () => run(memberId))
+    }
+
+    const [territories, recentDocuments, unreadDocumentCount, absences, nextMeeting, dayoffConflict] =
+      await Promise.all([
+        memberSafeQuery('territories', mid => getUserTerritories(db, mid)),
+        canViewBoard
+          ? safeQuery('documents', currentUser.id, () =>
+              getRecentDocuments(db, currentUser.id, currentUser.congregationId),
+            )
+          : Promise.resolve(null),
+        canViewBoard
+          ? safeQuery('unread-count', currentUser.id, () =>
+              getUnreadDocumentCount(db, currentUser.id, currentUser.congregationId),
+            )
+          : Promise.resolve(0),
+        safeQuery('absences', currentUser.id, () =>
+          getUpcomingAbsences(db, currentUser.id, currentUser.congregationId),
+        ),
+        memberSafeQuery('next-meeting', mid => getNextMeeting(db, mid)),
+        memberSafeQuery('dayoff-conflict', mid => getConflictingAssignments(db, mid)),
+      ])
 
     // Onboarding: count entities for admin checklist
     let onboarding = null
@@ -92,6 +98,7 @@ export function loader({ context }: Route.LoaderArgs) {
       unreadDocumentCount,
       nextMeeting,
       absences,
+      dayoffConflict,
       onboarding,
       isAdmin,
       isTerritoriesManager,
@@ -127,6 +134,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
     unreadDocumentCount,
     nextMeeting,
     absences,
+    dayoffConflict,
     onboarding,
     isAdmin,
     isTerritoriesManager,
@@ -140,7 +148,7 @@ export default function Dashboard({ loaderData }: Route.ComponentProps) {
   })
 
   // Build urgent items from across features
-  const urgentItems = buildUrgentItems(territories, unreadDocumentCount, nextMeeting, absences?.upcoming ?? null)
+  const urgentItems = buildUrgentItems(territories, unreadDocumentCount, nextMeeting, dayoffConflict)
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-8">

--- a/app/features/dashboard/server/dashboard.integration.test.ts
+++ b/app/features/dashboard/server/dashboard.integration.test.ts
@@ -217,9 +217,9 @@ afterAll(async () => {
 
 // --- Import the module under test ---
 
-const { getUserTerritories, getRecentDocuments, getUnreadDocumentCount, getNextMeeting } = await import(
-  './dashboard.server'
-)
+const { getUserTerritories, getRecentDocuments, getUnreadDocumentCount, getNextMeeting, getConflictingAssignments } =
+  await import('./dashboard.server')
+const { refreshConflictFlags } = await import('~/features/events/server/programme-assignments.server')
 
 // --- Tests ---
 
@@ -315,6 +315,357 @@ describe('getNextMeeting (integration)', () => {
       await withScope(congregationId, async tx => {
         await tx.event.delete({ where: { id_congregationId: { id: offEventId, congregationId } } })
         await tx.eventKind.deleteMany({ where: { key: EventKind.Off, congregationId } })
+      })
+    }
+  })
+})
+
+describe('getConflictingAssignments (integration)', () => {
+  type SeedOpts = {
+    name: string
+    startDate: Date
+    endDate?: Date
+    parts?: { assigneeId?: number | null; assistantId?: number | null; hasConflict?: boolean; name?: string }[]
+    serviceRoles?: { assigneeId: number; hasConflict?: boolean; name?: string }[]
+    cong?: number
+    createdById?: number
+  }
+
+  function seedEvent(opts: SeedOpts) {
+    const cong = opts.cong ?? congregationId
+    return withScope(cong, async tx => {
+      const eventKind = await tx.eventKind.findFirstOrThrow({
+        where: { congregationId: cong, key: { not: EventKind.Off } },
+      })
+      const event = await tx.event.create({
+        data: {
+          name: opts.name,
+          kindId: eventKind.id,
+          startDate: opts.startDate,
+          endDate: opts.endDate ?? new Date(opts.startDate.getTime() + 2 * 60 * 60 * 1000),
+          createdById: opts.createdById ?? aliceAccountId,
+          congregationId: cong,
+        },
+      })
+      const partIds = await Promise.all(
+        (opts.parts ?? []).map(async (p, i) => {
+          const created = await tx.programmePartAssignment.create({
+            data: {
+              eventId: event.id,
+              assigneeId: p.assigneeId ?? null,
+              assistantId: p.assistantId ?? null,
+              name: p.name ?? `Part ${i}`,
+              section: 'main',
+              order: i,
+              hasConflict: p.hasConflict ?? false,
+              congregationId: cong,
+            },
+          })
+          return created.id
+        }),
+      )
+      const serviceRoleIds = await Promise.all(
+        (opts.serviceRoles ?? []).map(async sr => {
+          const created = await tx.programmeServiceRoleAssignment.create({
+            data: {
+              eventId: event.id,
+              assigneeId: sr.assigneeId,
+              name: sr.name ?? 'Service',
+              hasConflict: sr.hasConflict ?? false,
+              congregationId: cong,
+            },
+          })
+          return created.id
+        }),
+      )
+      return { eventId: event.id, partIds, serviceRoleIds }
+    })
+  }
+
+  async function cleanupEvent(eventId: number, cong: number = congregationId) {
+    await withScope(cong, async tx => {
+      await tx.programmeServiceRoleAssignment.deleteMany({ where: { eventId, congregationId: cong } })
+      await tx.programmePartAssignment.deleteMany({ where: { eventId, congregationId: cong } })
+      await tx.event.delete({ where: { id_congregationId: { id: eventId, congregationId: cong } } })
+    })
+  }
+
+  it('returns the conflict when the user is the part assignee', async () => {
+    const seeded = await seedEvent({
+      name: 'Assignee Conflict',
+      startDate: new Date('2027-08-01T19:00:00Z'),
+      parts: [{ assigneeId: aliceId, hasConflict: true, name: 'Discours' }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result).not.toBeNull()
+      expect(result?.kind).toBe('part')
+      expect(result?.id).toBe(seeded.partIds[0])
+      expect(result?.eventName).toBe('Assignee Conflict')
+    } finally {
+      await cleanupEvent(seeded.eventId)
+    }
+  })
+
+  it('returns the conflict when the user is the part assistant (not assignee)', async () => {
+    const seeded = await seedEvent({
+      name: 'Assistant Conflict',
+      startDate: new Date('2027-08-02T19:00:00Z'),
+      parts: [{ assigneeId: bobId, assistantId: aliceId, hasConflict: true, name: 'Lecture' }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result?.kind).toBe('part')
+      expect(result?.id).toBe(seeded.partIds[0])
+    } finally {
+      await cleanupEvent(seeded.eventId)
+    }
+  })
+
+  it('returns the conflict for a service role with kind="service-role"', async () => {
+    const seeded = await seedEvent({
+      name: 'Service Role Conflict',
+      startDate: new Date('2027-08-03T19:00:00Z'),
+      serviceRoles: [{ assigneeId: aliceId, hasConflict: true, name: 'Son' }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result?.kind).toBe('service-role')
+      expect(result?.id).toBe(seeded.serviceRoleIds[0])
+      expect(result?.eventName).toBe('Service Role Conflict')
+    } finally {
+      await cleanupEvent(seeded.eventId)
+    }
+  })
+
+  it('picks the earliest conflict when several exist across part and service role', async () => {
+    const later = await seedEvent({
+      name: 'Later Part',
+      startDate: new Date('2027-09-15T19:00:00Z'),
+      parts: [{ assigneeId: aliceId, hasConflict: true }],
+    })
+    const earlier = await seedEvent({
+      name: 'Earlier Service Role',
+      startDate: new Date('2027-09-01T19:00:00Z'),
+      serviceRoles: [{ assigneeId: aliceId, hasConflict: true }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result?.kind).toBe('service-role')
+      expect(result?.eventName).toBe('Earlier Service Role')
+      expect(result?.id).toBe(earlier.serviceRoleIds[0])
+    } finally {
+      await cleanupEvent(earlier.eventId)
+      await cleanupEvent(later.eventId)
+    }
+  })
+
+  it('ignores assignments where hasConflict is false', async () => {
+    const seeded = await seedEvent({
+      name: 'No Conflict',
+      startDate: new Date('2027-10-01T19:00:00Z'),
+      parts: [{ assigneeId: aliceId, hasConflict: false }],
+      serviceRoles: [{ assigneeId: aliceId, hasConflict: false }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result).toBeNull()
+    } finally {
+      await cleanupEvent(seeded.eventId)
+    }
+  })
+
+  it('ignores conflicts on past events', async () => {
+    const seeded = await seedEvent({
+      name: 'Past Conflict',
+      startDate: new Date('2024-01-01T19:00:00Z'),
+      endDate: new Date('2024-01-01T21:00:00Z'),
+      parts: [{ assigneeId: aliceId, hasConflict: true }],
+    })
+    try {
+      const result = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(result).toBeNull()
+    } finally {
+      await cleanupEvent(seeded.eventId)
+    }
+  })
+
+  it('does not leak conflicts across congregations (RLS)', async () => {
+    const otherTs = Date.now()
+    const otherCong = await testDb.congregation.create({
+      data: { name: `Dashboard Test Other ${otherTs}`, slug: `dashboard-test-other-${otherTs}`, active: true },
+    })
+
+    const otherSeed = await withScope(otherCong.id, async tx => {
+      const otherKind = await tx.eventKind.create({
+        data: { name: 'Midweek', key: `midweek-other-${otherTs}`, color: '#00aa00', congregationId: otherCong.id },
+      })
+      const otherMember = await tx.member.create({
+        data: { firstname: 'Eve', lastname: 'Cross', isPublisher: true, congregationId: otherCong.id },
+      })
+      const otherAccount = await tx.userAccount.create({
+        data: {
+          email: `eve-cross-${otherTs}@test.com`,
+          password: 'hashed',
+          active: true,
+          memberId: otherMember.id,
+          congregationId: otherCong.id,
+        },
+      })
+      const event = await tx.event.create({
+        data: {
+          name: 'Other Cong Event',
+          kindId: otherKind.id,
+          startDate: new Date('2027-11-01T19:00:00Z'),
+          endDate: new Date('2027-11-01T21:00:00Z'),
+          createdById: otherAccount.id,
+          congregationId: otherCong.id,
+        },
+      })
+      // Same numeric id range as Alice — guarantees that without RLS the other-cong row would match
+      const part = await tx.programmePartAssignment.create({
+        data: {
+          eventId: event.id,
+          assigneeId: otherMember.id,
+          name: 'Discours',
+          section: 'main',
+          order: 1,
+          hasConflict: true,
+          congregationId: otherCong.id,
+        },
+      })
+      return {
+        otherKindId: otherKind.id,
+        otherMemberId: otherMember.id,
+        otherAccountId: otherAccount.id,
+        eventId: event.id,
+        partId: part.id,
+      }
+    })
+
+    try {
+      // Query as Alice's member id, but scoped to the other congregation:
+      // RLS must hide the other-cong row even if some member id happened to collide.
+      const aliceFromOtherCong = await withScope(otherCong.id, tx => getConflictingAssignments(tx, aliceId))
+      expect(aliceFromOtherCong).toBeNull()
+
+      // And from Alice's own congregation, the other cong's row must also be invisible.
+      const aliceFromHerCong = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(aliceFromHerCong).toBeNull()
+    } finally {
+      await withScope(otherCong.id, async tx => {
+        await tx.programmePartAssignment.delete({
+          where: { id_congregationId: { id: otherSeed.partId, congregationId: otherCong.id } },
+        })
+        await tx.event.delete({
+          where: { id_congregationId: { id: otherSeed.eventId, congregationId: otherCong.id } },
+        })
+        await tx.userAccount.delete({ where: { id: otherSeed.otherAccountId } })
+        await tx.member.delete({ where: { id: otherSeed.otherMemberId } })
+        await tx.eventKind.delete({
+          where: { id_congregationId: { id: otherSeed.otherKindId, congregationId: otherCong.id } },
+        })
+      })
+      await testDb.congregation.delete({ where: { id: otherCong.id } })
+    }
+  })
+
+  // Invariant pin: the dashboard alert is correct only as long as `refreshConflictFlags`
+  // keeps the assignment-level `hasConflict` flag in sync with the actual day-off state.
+  // We exercise the "no overlapping day-off → flag must clear" path end-to-end, which
+  // catches future regressions where refreshConflictFlags forgets to recompute the flag
+  // for templated events or stops touching one of the two assignment tables.
+  it('refreshConflictFlags clears stale hasConflict and the alert disappears', async () => {
+    const setup = await withScope(congregationId, async tx => {
+      const eventKind = await tx.eventKind.findFirstOrThrow({
+        where: { congregationId, key: { not: EventKind.Off } },
+      })
+      const template = await tx.programmeTemplate.create({
+        data: {
+          name: 'Invariant Template',
+          key: `invariant-template-${ts}`,
+          kindId: eventKind.id,
+          congregationId,
+        },
+      })
+      const event = await tx.event.create({
+        data: {
+          name: 'Invariant Event',
+          kindId: eventKind.id,
+          templateId: template.id,
+          startDate: new Date('2027-12-01T19:00:00Z'),
+          endDate: new Date('2027-12-01T21:00:00Z'),
+          createdById: aliceAccountId,
+          congregationId,
+        },
+      })
+      // Pre-set the flag to true to simulate a stale conflict left over from a now-deleted day-off.
+      const part = await tx.programmePartAssignment.create({
+        data: {
+          eventId: event.id,
+          assigneeId: aliceId,
+          name: 'Discours',
+          section: 'main',
+          order: 1,
+          hasConflict: true,
+          congregationId,
+        },
+      })
+      const serviceRole = await tx.programmeServiceRoleAssignment.create({
+        data: {
+          eventId: event.id,
+          assigneeId: aliceId,
+          name: 'Son',
+          hasConflict: true,
+          congregationId,
+        },
+      })
+      return { templateId: template.id, eventId: event.id, partId: part.id, serviceRoleId: serviceRole.id }
+    })
+
+    try {
+      const before = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(before?.id).toBe(setup.partId)
+
+      await withScope(congregationId, tx =>
+        refreshConflictFlags(
+          tx,
+          aliceId,
+          new Date('2027-11-30T00:00:00Z'),
+          new Date('2027-12-02T00:00:00Z'),
+          congregationId,
+        ),
+      )
+
+      const partFlag = await withScope(congregationId, tx =>
+        tx.programmePartAssignment.findUniqueOrThrow({
+          where: { id_congregationId: { id: setup.partId, congregationId } },
+          select: { hasConflict: true },
+        }),
+      )
+      const serviceFlag = await withScope(congregationId, tx =>
+        tx.programmeServiceRoleAssignment.findUniqueOrThrow({
+          where: { id_congregationId: { id: setup.serviceRoleId, congregationId } },
+          select: { hasConflict: true },
+        }),
+      )
+      expect(partFlag.hasConflict).toBe(false)
+      expect(serviceFlag.hasConflict).toBe(false)
+
+      const after = await withScope(congregationId, tx => getConflictingAssignments(tx, aliceId))
+      expect(after).toBeNull()
+    } finally {
+      await withScope(congregationId, async tx => {
+        await tx.programmeServiceRoleAssignment.delete({
+          where: { id_congregationId: { id: setup.serviceRoleId, congregationId } },
+        })
+        await tx.programmePartAssignment.delete({
+          where: { id_congregationId: { id: setup.partId, congregationId } },
+        })
+        await tx.event.delete({ where: { id_congregationId: { id: setup.eventId, congregationId } } })
+        await tx.programmeTemplate.delete({
+          where: { id_congregationId: { id: setup.templateId, congregationId } },
+        })
       })
     }
   })

--- a/app/features/dashboard/server/dashboard.server.ts
+++ b/app/features/dashboard/server/dashboard.server.ts
@@ -248,6 +248,57 @@ export async function getUpcomingAssignments(db: TransactionClient, userId: numb
   return assignments.slice(0, 5)
 }
 
+export async function getConflictingAssignments(db: TransactionClient, userId: number) {
+  const now = new Date()
+
+  const [partConflicts, serviceConflicts] = await Promise.all([
+    db.programmePartAssignment.findMany({
+      where: {
+        hasConflict: true,
+        OR: [{ assigneeId: userId }, { assistantId: userId }],
+        event: { startDate: { gte: now } },
+      },
+      select: {
+        id: true,
+        event: { select: { name: true, startDate: true } },
+      },
+      orderBy: { event: { startDate: 'asc' } },
+      take: 1,
+    }),
+    db.programmeServiceRoleAssignment.findMany({
+      where: {
+        hasConflict: true,
+        assigneeId: userId,
+        event: { startDate: { gte: now } },
+      },
+      select: {
+        id: true,
+        event: { select: { name: true, startDate: true } },
+      },
+      orderBy: { event: { startDate: 'asc' } },
+      take: 1,
+    }),
+  ])
+
+  const candidates = [
+    ...partConflicts.map(c => ({
+      kind: 'part' as const,
+      id: c.id,
+      eventName: c.event.name,
+      eventStartDate: c.event.startDate,
+    })),
+    ...serviceConflicts.map(c => ({
+      kind: 'service-role' as const,
+      id: c.id,
+      eventName: c.event.name,
+      eventStartDate: c.event.startDate,
+    })),
+  ]
+
+  candidates.sort((a, b) => a.eventStartDate.getTime() - b.eventStartDate.getTime())
+  return candidates.at(0) ?? null
+}
+
 export async function getNextMeeting(db: TransactionClient, userId: number) {
   const now = new Date()
 

--- a/app/features/dashboard/ui/build-urgent-items.test.ts
+++ b/app/features/dashboard/ui/build-urgent-items.test.ts
@@ -72,20 +72,8 @@ function makeNextMeeting(
   }
 }
 
-function makeAbsence(id: number, startDate: Date, endDate: Date) {
-  return {
-    id,
-    startDate,
-    endDate,
-    name: 'Absence',
-    description: '',
-    congregationId: 1,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    createdById: 1,
-    kindId: 1,
-    templateId: null as number | null,
-  }
+function makeConflict(id: number, eventName: string, eventStartDate: Date, kind: 'part' | 'service-role' = 'part') {
+  return { kind, id, eventName, eventStartDate }
 }
 
 // --- urgentTerritoriesItems ---
@@ -237,59 +225,36 @@ describe('urgentServiceRoleItems', () => {
 // --- urgentDayoffConflictItems ---
 
 describe('urgentDayoffConflictItems', () => {
-  it('returns empty array for null meeting', () => {
-    expect(urgentDayoffConflictItems(null, [makeAbsence(1, new Date(), new Date())])).toEqual([])
+  it('returns empty array when there is no conflict', () => {
+    expect(urgentDayoffConflictItems(null)).toEqual([])
   })
 
-  it('returns empty array for null absences', () => {
-    const meeting = makeNextMeeting(new Date(2026, 3, 25), { userPartIds: [10] })
-    expect(urgentDayoffConflictItems(meeting, null)).toEqual([])
-  })
-
-  it('returns empty array when user has no assignments', () => {
-    const meeting = makeNextMeeting(new Date(2026, 3, 25))
-    const absences = [makeAbsence(1, new Date(2026, 3, 25), new Date(2026, 3, 25))]
-    expect(urgentDayoffConflictItems(meeting, absences)).toEqual([])
-  })
-
-  it('returns empty array when absence does not overlap meeting', () => {
-    const meetingDate = new Date(2026, 3, 25, 19, 0)
-    const meeting = makeNextMeeting(meetingDate, {
-      userPartIds: [10],
-      partAssignments: [
-        { id: 10, name: 'Discours', section: 'main', topic: '', order: 1, assignee: null, assistant: null },
-      ],
-    })
-    // Absence is the day before the meeting
-    const absences = [makeAbsence(1, new Date(2026, 3, 20), new Date(2026, 3, 23))]
-    expect(urgentDayoffConflictItems(meeting, absences)).toEqual([])
-  })
-
-  it('returns conflict item when absence overlaps meeting date', () => {
-    const meetingDate = new Date(2026, 3, 25, 19, 0)
-    const meeting = makeNextMeeting(meetingDate, {
-      userPartIds: [10],
-      partAssignments: [
-        { id: 10, name: 'Discours', section: 'main', topic: '', order: 1, assignee: null, assistant: null },
-      ],
-    })
-    // Absence spans the meeting day
-    const absences = [makeAbsence(7, new Date(2026, 3, 24), new Date(2026, 3, 26))]
-    const items = urgentDayoffConflictItems(meeting, absences)
+  it('returns conflict item with priority 2 for a part assignment', () => {
+    const eventStart = new Date(2026, 3, 25, 19, 0)
+    const conflict = makeConflict(7, 'Réunion de semaine', eventStart, 'part')
+    const items = urgentDayoffConflictItems(conflict)
     expect(items).toHaveLength(1)
     expect(items[0].priority).toBe(2)
     expect(items[0].to).toBe('/me/days-off')
     expect(items[0].label).toContain('Réunion de semaine')
+    expect(items[0].key).toBe('dayoff-conflict-part-7')
+    // The relative date must reflect the conflicting event, not the next meeting
+    expect(items[0].relativeDate).toBe(eventStart)
   })
 
-  it('detects conflict when absence starts same day as meeting', () => {
-    const meetingDate = new Date(2026, 3, 25, 19, 0)
-    const meeting = makeNextMeeting(meetingDate, {
-      userServiceRoleIds: [5],
-      serviceRoleAssignments: [{ id: 5, name: 'Son', assignee: null }],
-    })
-    const absences = [makeAbsence(8, new Date(2026, 3, 25, 0, 0), new Date(2026, 3, 27))]
-    expect(urgentDayoffConflictItems(meeting, absences)).toHaveLength(1)
+  it('returns conflict item for a service role assignment', () => {
+    const conflict = makeConflict(5, 'Réunion publique', new Date(2026, 5, 1, 9, 30), 'service-role')
+    const items = urgentDayoffConflictItems(conflict)
+    expect(items).toHaveLength(1)
+    expect(items[0].key).toBe('dayoff-conflict-service-role-5')
+    expect(items[0].label).toContain('Réunion publique')
+  })
+
+  it('surfaces conflicts well beyond the next meeting horizon', () => {
+    // Two months out — old behaviour ignored anything past the next meeting
+    const conflict = makeConflict(99, 'Assemblée régionale', new Date(2026, 5, 24, 9, 0))
+    const items = urgentDayoffConflictItems(conflict)
+    expect(items).toHaveLength(1)
   })
 })
 
@@ -360,8 +325,8 @@ describe('buildUrgentItems', () => {
       ],
       serviceRoleAssignments: [{ id: 5, name: 'Son', assignee: null }],
     })
-    const absences = [makeAbsence(7, new Date(2026, 3, 24), new Date(2026, 3, 26))]
-    const items = buildUrgentItems(null, null, meeting, absences)
+    const conflict = makeConflict(7, 'Réunion de semaine', meetingDate)
+    const items = buildUrgentItems(null, null, meeting, conflict)
     const priorities = items.map(i => i.priority)
     expect(priorities).toEqual([0, 2, 3])
   })

--- a/app/features/dashboard/ui/build-urgent-items.ts
+++ b/app/features/dashboard/ui/build-urgent-items.ts
@@ -1,8 +1,8 @@
 import { CalendarOff, FileText, MapPin, Mic } from 'lucide-react'
 
 import type {
+  getConflictingAssignments,
   getNextMeeting,
-  getUpcomingAbsences,
   getUserTerritories,
 } from '~/features/dashboard/server/dashboard.server'
 import * as m from '~/i18n/paraglide/messages'
@@ -20,7 +20,7 @@ export type UrgentItem = {
 
 type Territories = Awaited<ReturnType<typeof getUserTerritories>> | null
 type NextMeeting = Awaited<ReturnType<typeof getNextMeeting>>
-type UpcomingAbsences = Awaited<ReturnType<typeof getUpcomingAbsences>>['upcoming'] | null
+type DayoffConflict = Awaited<ReturnType<typeof getConflictingAssignments>>
 
 const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000
 
@@ -97,29 +97,18 @@ export function urgentServiceRoleItems(nextMeeting: NextMeeting): UrgentItem[] {
   ]
 }
 
-export function urgentDayoffConflictItems(nextMeeting: NextMeeting, absences: UpcomingAbsences): UrgentItem[] {
-  if (!nextMeeting || !absences || absences.length === 0) return []
-  const hasUserAssignment = nextMeeting.userPartIds.length > 0 || nextMeeting.userServiceRoleIds.length > 0
-  if (!hasUserAssignment) return []
-
-  const meetingStart = new Date(nextMeeting.startDate).getTime()
-  const meetingEnd = new Date(nextMeeting.endDate).getTime()
-  const conflicting = absences.find(a => {
-    const absStart = new Date(a.startDate).getTime()
-    const absEnd = new Date(a.endDate).getTime()
-    return absStart <= meetingEnd && absEnd >= meetingStart
-  })
-  if (!conflicting) return []
+export function urgentDayoffConflictItems(conflict: DayoffConflict): UrgentItem[] {
+  if (!conflict) return []
 
   return [
     {
-      key: `dayoff-conflict-${conflicting.id}`,
-      label: m.dashboard_urgent_dayoff_conflict({ eventName: nextMeeting.name }),
+      key: `dayoff-conflict-${conflict.kind}-${conflict.id}`,
+      label: m.dashboard_urgent_dayoff_conflict({ eventName: conflict.eventName }),
       to: '/me/days-off',
       icon: CalendarOff,
       borderClass: 'border-l-amber-500 bg-amber-500/5',
       iconClass: 'text-amber-600 dark:text-amber-400',
-      relativeDate: nextMeeting.startDate,
+      relativeDate: conflict.eventStartDate,
       priority: 2,
     },
   ]
@@ -145,13 +134,13 @@ export function buildUrgentItems(
   territories: Territories,
   unreadDocumentCount: number | null,
   nextMeeting: NextMeeting,
-  absences: UpcomingAbsences,
+  dayoffConflict: DayoffConflict,
 ): UrgentItem[] {
   const items = [
     ...urgentTerritoriesItems(territories),
     ...urgentPartAssignmentItems(nextMeeting),
     ...urgentServiceRoleItems(nextMeeting),
-    ...urgentDayoffConflictItems(nextMeeting, absences),
+    ...urgentDayoffConflictItems(dayoffConflict),
     ...urgentDocumentsItem(unreadDocumentCount),
   ]
   items.sort((a, b) => a.priority - b.priority)


### PR DESCRIPTION
## Summary
- Day-off conflict alert now scans every future programme assignment via the existing `hasConflict` flag instead of only the next meeting
- New `getConflictingAssignments` query (`dashboard.server.ts`) returns the earliest conflict across part assignments and service-role assignments, with a `kind` discriminator that disambiguates React keys
- Loader passes the conflict through; `urgentDayoffConflictItems` becomes a pure mapper, dropping the in-UI overlap math

## Test plan
- [x] `pnpm test:typecheck`
- [x] `pnpm test:unit run app/features/dashboard` (41 passing)
- [x] `pnpm test:integration run app/features/dashboard` (18 passing — 7 new cases for `getConflictingAssignments` + 1 invariant test for `refreshConflictFlags` clear path)
- [x] `pnpm exec biome check app/features/dashboard`
- [ ] Smoke test: assign a publisher to an event months out, create an overlapping day off, confirm the urgent strip surfaces the conflict (was previously hidden behind any nearer non-conflicting meeting)