### PR TITLE
fix(events): resolve programme part eligibility from both role sources

### DIFF
--- a/app/features/events/server/allowed-roles.integration.test.ts
+++ b/app/features/events/server/allowed-roles.integration.test.ts
@@ -40,6 +40,7 @@ let templateId: number
 let speakerPartId: number
 let serviceRoleId: number
 let foreignTemplatePartId: number
+let customRoleId: number
 
 beforeAll(async () => {
   const primary = await testDb.congregation.create({
@@ -124,6 +125,17 @@ beforeAll(async () => {
         // Non-publisher (school student) is also a member — should be eligible by default
         { memberId: nonPublisherUserId, roleId: memberRoleId, congregationId: primaryCongId },
       ],
+    })
+
+    // Custom role assigned to the elder's UserAccount only (no MemberRoleAssignment).
+    // Used by the regression test that verifies eligibility resolves through
+    // both assignment tables, mirroring the three-source rule in #183.
+    const custom = await tx.role.create({
+      data: { key: `custom-${ts}`, name: 'Custom', isBuiltIn: false, congregationId: primaryCongId },
+    })
+    customRoleId = custom.id
+    await tx.userRoleAssignment.create({
+      data: { userId: elderAccountId, roleId: customRoleId, congregationId: primaryCongId },
     })
 
     // Template + parts + service role
@@ -233,6 +245,11 @@ describe('resolveEligibleUserIds (integration)', () => {
   it('does not leak users from another congregation', async () => {
     const result = await withScope(foreignCongId, tx => resolveEligibleUserIds(tx, [foreignElderRoleId], foreignCongId))
     expect(result).toEqual([])
+  })
+
+  it('includes members reached only via UserRoleAssignment on the linked account', async () => {
+    const result = await withScope(primaryCongId, tx => resolveEligibleUserIds(tx, [customRoleId], primaryCongId))
+    expect(result).toEqual([elderUserId])
   })
 })
 

--- a/app/features/events/server/allowed-roles.server.test.ts
+++ b/app/features/events/server/allowed-roles.server.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('~/shared/infra/db.server', () => ({
   unscopedDb: {
     role: { findFirst: vi.fn() },
+    member: { findMany: vi.fn() },
     memberRoleAssignment: { findMany: vi.fn() },
     programmeTemplatePartAllowedRole: { findMany: vi.fn(), createMany: vi.fn(), deleteMany: vi.fn() },
     programmePartAssignmentAllowedRole: { findMany: vi.fn(), createMany: vi.fn(), deleteMany: vi.fn() },
@@ -47,36 +48,26 @@ describe('resolveEligibleUserIds', () => {
     expect(result).toEqual([])
   })
 
-  it('returns member IDs assigned to any allowed role for non-empty list', async () => {
-    vi.mocked(db.memberRoleAssignment.findMany).mockResolvedValue([
-      { memberId: 5 },
-      { memberId: 7 },
-      { memberId: 5 }, // duplicate (member has both roles)
-    ] as never)
+  it('returns member IDs reached via either assignment table for non-empty list', async () => {
+    vi.mocked(db.member.findMany).mockResolvedValue([{ id: 5 }, { id: 7 }] as never)
 
     const result = await resolveEligibleUserIds(db, [10, 20], 1)
 
-    expect(db.memberRoleAssignment.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ roleId: { in: [10, 20] }, congregationId: 1 }),
-      }),
-    )
-    expect(result.sort()).toEqual([5, 7])
+    expect(db.member.findMany).toHaveBeenCalledWith({
+      where: {
+        congregationId: 1,
+        leftAt: null,
+        anonymizedAt: null,
+        OR: [
+          { roleAssignments: { some: { roleId: { in: [10, 20] } } } },
+          { account: { roleAssignments: { some: { roleId: { in: [10, 20] } } } } },
+        ],
+      },
+      select: { id: true },
+    })
+    expect(result).toEqual([5, 7])
     expect(db.role.findFirst).not.toHaveBeenCalled()
-  })
-
-  it('filters out leavers and anonymized members via the where clause', async () => {
-    vi.mocked(db.memberRoleAssignment.findMany).mockResolvedValue([] as never)
-
-    await resolveEligibleUserIds(db, [10], 1)
-
-    expect(db.memberRoleAssignment.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          member: { leftAt: null, anonymizedAt: null },
-        }),
-      }),
-    )
+    expect(db.memberRoleAssignment.findMany).not.toHaveBeenCalled()
   })
 })
 

--- a/app/features/events/server/allowed-roles.server.ts
+++ b/app/features/events/server/allowed-roles.server.ts
@@ -1,13 +1,19 @@
+import { findMembersWithAnyRole } from '~/shared/auth/permissions.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
 
 export type PartRoleKind = 'speaker' | 'reader'
 
 /**
  * Resolve member ids eligible for a programme assignment with the given allowed
- * roles. Reads from `MemberRoleAssignment` — identity roles (brother, elder,
- * pioneer, …) are auto-synced from Member flags. The default fallback (when no
- * allowed roles are specified) is "every current Member of the congregation"
- * via the built-in `member` role, so school students can be picked too.
+ * roles. A role reaches a Member two ways: directly via `MemberRoleAssignment`
+ * (identity roles like brother/elder/pioneer, auto-synced from Member flags)
+ * or via the linked `UserAccount`'s `UserRoleAssignment` (custom/management
+ * roles granted to the account). Both must be unioned — the canonical rule
+ * lives in `app/shared/auth/permissions.server.ts`.
+ *
+ * The default fallback (when no allowed roles are specified) is "every current
+ * Member of the congregation" via the built-in `member` role, so school
+ * students can be picked too.
  */
 export async function resolveEligibleUserIds(
   db: TransactionClient,
@@ -31,15 +37,7 @@ export async function resolveEligibleUserIds(
     return [...new Set(assignments.map(a => a.memberId))]
   }
 
-  const assignments = await db.memberRoleAssignment.findMany({
-    where: {
-      roleId: { in: allowedRoleIds },
-      congregationId,
-      member: { leftAt: null, anonymizedAt: null },
-    },
-    select: { memberId: true },
-  })
-  return [...new Set(assignments.map(a => a.memberId))]
+  return findMembersWithAnyRole(db, allowedRoleIds, congregationId)
 }
 
 export async function getTemplatePartAllowedRoleIds(

--- a/app/shared/auth/permissions.server.integration.test.ts
+++ b/app/shared/auth/permissions.server.integration.test.ts
@@ -4,9 +4,12 @@ import { PrismaClient } from '~/database/generated/client'
 import { Permission } from '~/shared/types/permission'
 
 const { seedPermissions } = await import('~/shared/domain/setup.server')
-const { resolveEffectivePermissions, resolveEffectiveRoleIds, findAccountsWithPermission } = await import(
-  './permissions.server'
-)
+const {
+  resolveEffectivePermissions,
+  resolveEffectiveRoleIds,
+  findAccountsWithPermission,
+  findMembersWithAnyRole,
+} = await import('./permissions.server')
 
 const adapter = new PrismaPg({
   connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
@@ -23,6 +26,9 @@ let memberOnlyAccountId: number
 let accountOnlyAccountId: number
 let directGrantAccountId: number
 let noMemberAccountId: number
+let memberOnlyMemberId: number
+let accountOnlyMemberId: number
+let leaverMemberId: number
 
 beforeAll(async () => {
   await seedPermissions(testDb)
@@ -57,6 +63,7 @@ beforeAll(async () => {
   const memberOnlyMember = await testDb.member.create({
     data: { firstname: 'Mem', lastname: 'Only', isPublisher: true, congregationId },
   })
+  memberOnlyMemberId = memberOnlyMember.id
   const memberOnlyAccount = await testDb.userAccount.create({
     data: {
       email: `perms-mem-${ts}@test.com`,
@@ -75,6 +82,7 @@ beforeAll(async () => {
   const accountOnlyMember = await testDb.member.create({
     data: { firstname: 'Acc', lastname: 'Only', isPublisher: false, congregationId },
   })
+  accountOnlyMemberId = accountOnlyMember.id
   const accountOnlyAccount = await testDb.userAccount.create({
     data: {
       email: `perms-acc-${ts}@test.com`,
@@ -87,6 +95,22 @@ beforeAll(async () => {
   accountOnlyAccountId = accountOnlyAccount.id
   await testDb.userRoleAssignment.create({
     data: { userId: accountOnlyAccount.id, roleId: accountRoleId, congregationId },
+  })
+
+  // A Member that holds memberRoleId but has left the congregation. Used to
+  // verify findMembersWithAnyRole excludes leavers.
+  const leaverMember = await testDb.member.create({
+    data: {
+      firstname: 'Left',
+      lastname: 'Member',
+      isPublisher: true,
+      leftAt: new Date('2024-01-01'),
+      congregationId,
+    },
+  })
+  leaverMemberId = leaverMember.id
+  await testDb.memberRoleAssignment.create({
+    data: { memberId: leaverMember.id, roleId: memberRoleId, congregationId },
   })
 
   // Account 3: BoardViewer reached only via direct CongregationUserPermission.
@@ -182,5 +206,32 @@ describe('findAccountsWithPermission (integration)', () => {
   it('does not return accounts that lack the permission', async () => {
     const accounts = await findAccountsWithPermission(testDb, congregationId, Permission.BoardViewer)
     expect(accounts.some(a => a.id === noMemberAccountId)).toBe(false)
+  })
+})
+
+describe('findMembersWithAnyRole (integration)', () => {
+  it('returns the member when the role is assigned via MemberRoleAssignment', async () => {
+    const ids = await findMembersWithAnyRole(testDb, [memberRoleId], congregationId)
+    expect(ids).toContain(memberOnlyMemberId)
+  })
+
+  it('returns the member when the role is assigned via UserRoleAssignment on the linked account', async () => {
+    const ids = await findMembersWithAnyRole(testDb, [accountRoleId], congregationId)
+    expect(ids).toEqual([accountOnlyMemberId])
+  })
+
+  it('unions both sources when both role IDs are queried at once', async () => {
+    const ids = await findMembersWithAnyRole(testDb, [memberRoleId, accountRoleId], congregationId)
+    expect(ids.sort((a, b) => a - b)).toEqual([memberOnlyMemberId, accountOnlyMemberId].sort((a, b) => a - b))
+  })
+
+  it('excludes leavers even when they hold the role', async () => {
+    const ids = await findMembersWithAnyRole(testDb, [memberRoleId], congregationId)
+    expect(ids).not.toContain(leaverMemberId)
+  })
+
+  it('returns an empty array when roleIds is empty', async () => {
+    const ids = await findMembersWithAnyRole(testDb, [], congregationId)
+    expect(ids).toEqual([])
   })
 })

--- a/app/shared/auth/permissions.server.test.ts
+++ b/app/shared/auth/permissions.server.test.ts
@@ -7,11 +7,17 @@ vi.mock('~/shared/infra/db.server', () => ({
     rolePermission: { findMany: vi.fn() },
     role: { findMany: vi.fn() },
     userAccount: { findMany: vi.fn() },
+    member: { findMany: vi.fn() },
   },
 }))
 
-const { resolveEffectivePermissions, resolveEffectiveRoleIds, findAccountsWithPermission, requireNotLastAdmin } =
-  await import('./permissions.server')
+const {
+  resolveEffectivePermissions,
+  resolveEffectiveRoleIds,
+  findAccountsWithPermission,
+  findMembersWithAnyRole,
+  requireNotLastAdmin,
+} = await import('./permissions.server')
 const { unscopedDb } = await import('~/shared/infra/db.server')
 
 beforeEach(() => {
@@ -159,6 +165,42 @@ describe('findAccountsWithPermission', () => {
         ],
       },
       select: { id: true, email: true, firstname: true, active: true },
+    })
+  })
+})
+
+describe('findMembersWithAnyRole', () => {
+  it('returns [] without hitting the database when roleIds is empty', async () => {
+    const result = await findMembersWithAnyRole(unscopedDb, [], 7)
+
+    expect(result).toEqual([])
+    expect(unscopedDb.member.findMany).not.toHaveBeenCalled()
+  })
+
+  it('returns the mapped member IDs', async () => {
+    vi.mocked(unscopedDb.member.findMany).mockResolvedValue([{ id: 5 }, { id: 11 }] as never)
+
+    const result = await findMembersWithAnyRole(unscopedDb, [10, 20], 1)
+
+    expect(result).toEqual([5, 11])
+  })
+
+  it('queries Member with the two-source role filter scoped to the congregation, excluding leavers and anonymized', async () => {
+    vi.mocked(unscopedDb.member.findMany).mockResolvedValue([] as never)
+
+    await findMembersWithAnyRole(unscopedDb, [10, 20], 7)
+
+    expect(unscopedDb.member.findMany).toHaveBeenCalledWith({
+      where: {
+        congregationId: 7,
+        leftAt: null,
+        anonymizedAt: null,
+        OR: [
+          { roleAssignments: { some: { roleId: { in: [10, 20] } } } },
+          { account: { roleAssignments: { some: { roleId: { in: [10, 20] } } } } },
+        ],
+      },
+      select: { id: true },
     })
   })
 })

--- a/app/shared/auth/permissions.server.ts
+++ b/app/shared/auth/permissions.server.ts
@@ -8,7 +8,10 @@ import { Permission } from '~/shared/types/permission'
 //   2. Account-bound role — UserRoleAssignment → Role → RolePermission
 //   3. Member-bound role — MemberRoleAssignment → Role → RolePermission, via UserAccount.member
 //
-// The rule lives in the two builders below, one per query direction. Every
+// Roles reach a Member through two of those paths — the direct grant (#1) is
+// account-scoped only and does not factor in when resolving role → members.
+//
+// The rule lives in the builders below, one per query direction. Every
 // permission/role-membership resolver in the app must go through them.
 
 function rolesAssignedToAccount(userId: number): Prisma.RoleWhereInput {
@@ -33,6 +36,17 @@ function accountsWithPermissionFilter(permissionKey: Permission): Prisma.UserAcc
           },
         },
       },
+    ],
+  }
+}
+
+function membersWithAnyRoleFilter(roleIds: number[]): Prisma.MemberWhereInput {
+  return {
+    leftAt: null,
+    anonymizedAt: null,
+    OR: [
+      { roleAssignments: { some: { roleId: { in: roleIds } } } },
+      { account: { roleAssignments: { some: { roleId: { in: roleIds } } } } },
     ],
   }
 }
@@ -84,6 +98,19 @@ export async function findAccountsWithPermission(
     where: { congregationId, ...accountsWithPermissionFilter(permissionKey) },
     select: { id: true, email: true, firstname: true, active: true },
   })
+}
+
+export async function findMembersWithAnyRole(
+  db: DbClient,
+  roleIds: number[],
+  congregationId: number,
+): Promise<number[]> {
+  if (roleIds.length === 0) return []
+  const rows = await db.member.findMany({
+    where: { congregationId, ...membersWithAnyRoleFilter(roleIds) },
+    select: { id: true },
+  })
+  return rows.map(r => r.id)
 }
 
 /**


### PR DESCRIPTION
## Summary

- `resolveEligibleUserIds` (programme part allowed-speaker / allowed-reader resolver) joined only through `MemberRoleAssignment`. Custom roles live on `UserRoleAssignment` per the schema, so picking one in the PartEditSheet returned an empty eligible list and the server-side validation in `programme-assignments.server.ts` rejected matching assignments. Same single-source bug class as #183, in the reverse direction (role → members).
- Adds a fourth canonical primitive `findMembersWithAnyRole` in `app/shared/auth/permissions.server.ts` that unions `MemberRoleAssignment` with `UserAccount.roleAssignments` via the linked Member. `resolveEligibleUserIds` now delegates to it. Direct `CongregationUserPermission` doesn't factor in (it's account-scoped only), so the new builder is two-source.
- The display-board's role-gated sections were already correct via `resolveEffectiveRoleIds` and `findAccountsWithPermission` (both migrated in #183); no changes needed there.

## Test plan

- [x] `pnpm test:unit` — added 3 unit tests for `findMembersWithAnyRole` covering empty input, mapped IDs, and the where shape; retargeted `resolveEligibleUserIds` non-empty test to the new query shape.
- [x] `pnpm test:integration` — added 5 integration tests for `findMembersWithAnyRole` (MemberRoleAssignment only, UserRoleAssignment only, union, leaver exclusion, empty input) and a regression test in `allowed-roles.integration.test.ts` asserting an elder reached only via `UserRoleAssignment` on a custom role is eligible.
- [x] `pnpm test:lint && pnpm test:typecheck` — clean.
- [ ] Manual: as a Roles Manager, create a custom role, assign it to an account linked to a Member, set it as the allowed speaker on a programme part, open the assign sheet, and confirm the linked Member appears in the eligible list.