### PR TITLE
fix(display-board): polyfill Map/WeakMap getOrInsertComputed for older browsers

### DIFF
--- a/app/features/display-board/ui/PdfViewer.tsx
+++ b/app/features/display-board/ui/PdfViewer.tsx
@@ -62,6 +62,7 @@ const SCROLLBAR_BUDGET_PX = 16
 async function loadPdfJs() {
   try {
     await import('./pdf-globals-shim')
+    await import('./pdf-upsert-shim')
     await import('es-arraybuffer-base64/auto')
     const pdfjs = await import('pdfjs-dist')
     const workerSrc = (await import('./pdf-worker?worker&url')).default

--- a/app/features/display-board/ui/pdf-upsert-shim.ts
+++ b/app/features/display-board/ui/pdf-upsert-shim.ts
@@ -1,0 +1,36 @@
+// pdfjs-dist >= 5.5 calls `Map.prototype.getOrInsertComputed` (TC39 upsert
+// proposal). Native support: Chrome 145+, Firefox 144+, Safari 18.4+. Older
+// engines (Samsung Internet 29 = Chromium 136, in-app webviews, etc.) throw
+// `getOrInsertComputed is not a function` during PDF render.
+//
+// Polyfill Map/WeakMap with both `getOrInsert` and `getOrInsertComputed`
+// before pdfjs-dist loads. Safe to delete once minimum supported browsers
+// ship the methods natively.
+// biome-ignore lint/suspicious/noExplicitAny: prototype patching needs loose typing
+type AnyMap = { has(k: any): boolean; get(k: any): any; set(k: any, v: any): unknown }
+
+function defineIfMissing(target: object, name: string, fn: (this: AnyMap, ...args: unknown[]) => unknown) {
+  if (typeof (target as Record<string, unknown>)[name] === 'function') return
+  Object.defineProperty(target, name, { value: fn, writable: true, configurable: true })
+}
+
+function getOrInsert(this: AnyMap, key: unknown, value: unknown) {
+  if (this.has(key)) return this.get(key)
+  this.set(key, value)
+  return value
+}
+
+function getOrInsertComputed(this: AnyMap, key: unknown, callbackFn: unknown) {
+  if (typeof callbackFn !== 'function') throw new TypeError('callbackFn must be callable')
+  if (this.has(key)) return this.get(key)
+  const value = (callbackFn as (k: unknown) => unknown)(key)
+  this.set(key, value)
+  return value
+}
+
+defineIfMissing(Map.prototype, 'getOrInsert', getOrInsert)
+defineIfMissing(Map.prototype, 'getOrInsertComputed', getOrInsertComputed)
+defineIfMissing(WeakMap.prototype, 'getOrInsert', getOrInsert)
+defineIfMissing(WeakMap.prototype, 'getOrInsertComputed', getOrInsertComputed)
+
+export {}

--- a/app/features/display-board/ui/pdf-worker.ts
+++ b/app/features/display-board/ui/pdf-worker.ts
@@ -1,3 +1,4 @@
 import './pdf-globals-shim'
+import './pdf-upsert-shim'
 import 'es-arraybuffer-base64/auto'
 import 'pdfjs-dist/build/pdf.worker.min.mjs'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "**/*.css",
         "**/pdf-worker.ts",
         "**/pdf-globals-shim.ts",
+        "**/pdf-upsert-shim.ts",
         "**/env.server.ts"
     ],
     "type": "module",


### PR DESCRIPTION
## Summary

- Samsung Internet 29 (Chromium 136) crashes on every board PDF with `TypeError: this[#t].getOrInsertComputed is not a function` because pdfjs-dist 5.5+ uses `Map.prototype.getOrInsertComputed` (TC39 upsert proposal, native in Chrome 145+ / Firefox 144+ / Safari 18.4+).
- Adds `pdf-upsert-shim.ts` that polyfills `Map`/`WeakMap` `getOrInsert` + `getOrInsertComputed` only when missing, imported before pdfjs in both `PdfViewer.loadPdfJs` and the `pdf-worker.ts` wrapper; listed in `package.json` `sideEffects` so Rollup keeps the worker-bundle import.
- Audit of pdfjs-dist 5.7 confirms `getOrInsertComputed` is the only post-Chrome-136 builtin it relies on (`Promise.try`, `Promise.withResolvers`, `Float16Array`, `Set.prototype.intersection` all shipped earlier; Uint8Array base64/hex was already shimmed in #190).

## Test plan

- [x] `pnpm test:lint`
- [x] `pnpm test:typecheck`
- [x] `pnpm test:unit` (152 files / 1065 tests pass)
- [ ] Open a board PDF on Samsung Internet 29 / Android — confirm the document renders instead of showing the "Impossible de charger le document" error overlay with `getOrInsertComputed`
- [ ] Open a board PDF on desktop Chromium ≥ 145 — confirm rendering is unchanged (polyfill no-ops because the native method exists)