### PR TITLE
fix(events): programme PDF export improvements

### DIFF
--- a/app/features/events/routes/programs/export-pdf-download.tsx
+++ b/app/features/events/routes/programs/export-pdf-download.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'react-router'
 import {
   getEventsForExport,
   parseExportConfigs,
+  programmeExportInclude,
   type TemplateExportConfig,
 } from '~/features/events/server/programme-export.server'
 import { ProgrammeBoardDocument } from '~/features/events/ui/ProgrammeBoardDocument'
@@ -103,17 +104,7 @@ function handleLegacyFormat(
         ...(templateId ? { templateId } : { templateId: { not: null } }),
         startDate: { gte: startDate, lte: endDate },
       },
-      include: {
-        template: true,
-        partAssignments: {
-          include: { assignee: true, assistant: true },
-          orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
-        },
-        serviceRoleAssignments: {
-          include: { assignee: true },
-          orderBy: { name: 'asc' },
-        },
-      },
+      include: programmeExportInclude,
       orderBy: { startDate: 'asc' },
     })
 

--- a/app/features/events/server/programme-assignments.server.ts
+++ b/app/features/events/server/programme-assignments.server.ts
@@ -5,6 +5,7 @@ import {
   resolveEligibleUserIds,
 } from '~/features/events/server/allowed-roles.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
+import { sanitizeText } from '~/shared/utils/sanitize-text'
 
 export function getEventProgramme(db: TransactionClient, eventId: number, congregationId: number) {
   return db.event.findFirst({
@@ -45,6 +46,8 @@ export async function assignPart(
   })
   if (!existing) return { error: "L'attribution n'existe pas." }
 
+  const cleanTopic = sanitizeText(topic)
+
   if (externalSpeakerId != null) {
     const speaker = await db.externalSpeaker.findFirst({
       where: { id: externalSpeakerId, congregationId, archivedAt: null },
@@ -55,7 +58,7 @@ export async function assignPart(
       where: {
         id_congregationId: { id: assignmentId, congregationId },
       },
-      data: { assigneeId: null, assistantId: null, externalSpeakerId, topic, hasConflict: false },
+      data: { assigneeId: null, assistantId: null, externalSpeakerId, topic: cleanTopic, hasConflict: false },
     })
     return { assignment }
   }
@@ -96,7 +99,7 @@ export async function assignPart(
     where: {
       id_congregationId: { id: assignmentId, congregationId },
     },
-    data: { assigneeId, assistantId, externalSpeakerId: null, topic, hasConflict: false },
+    data: { assigneeId, assistantId, externalSpeakerId: null, topic: cleanTopic, hasConflict: false },
   })
 
   return { assignment }

--- a/app/features/events/server/programme-export.server.test.ts
+++ b/app/features/events/server/programme-export.server.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/shared/infra/db.server', () => ({
+  unscopedDb: {
+    event: { findMany: vi.fn() },
+  },
+}))
+
+const { getEventsForExport, programmeExportInclude } = await import('./programme-export.server')
+const { unscopedDb: db } = await import('~/shared/infra/db.server')
+
+describe('getEventsForExport', () => {
+  it('includes the externalSpeaker relation on partAssignments', () => {
+    vi.mocked(db.event.findMany).mockResolvedValue([] as never)
+
+    getEventsForExport(db, [1], new Date('2026-01-01'), new Date('2026-01-31'))
+
+    const call = vi.mocked(db.event.findMany).mock.calls[0]?.[0]
+    expect(call?.include?.partAssignments).toBeDefined()
+    const partAssignments = call?.include?.partAssignments as { include: Record<string, unknown> }
+    expect(partAssignments.include.externalSpeaker).toBe(true)
+    expect(partAssignments.include.assignee).toBe(true)
+    expect(partAssignments.include.assistant).toBe(true)
+  })
+})
+
+describe('programmeExportInclude', () => {
+  it('is the canonical include shape for export queries', () => {
+    expect(programmeExportInclude.partAssignments.include).toEqual({
+      assignee: true,
+      assistant: true,
+      externalSpeaker: true,
+    })
+  })
+})

--- a/app/features/events/server/programme-export.server.ts
+++ b/app/features/events/server/programme-export.server.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { Prisma } from '~/database/generated/client'
 import { ValidationError } from '~/shared/errors/app-error.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
 
@@ -29,6 +30,18 @@ export function parseExportConfigs(raw: string): TemplateExportConfig[] {
   }
 }
 
+export const programmeExportInclude = {
+  template: true,
+  partAssignments: {
+    include: { assignee: true, assistant: true, externalSpeaker: true },
+    orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
+  },
+  serviceRoleAssignments: {
+    include: { assignee: true },
+    orderBy: { name: 'asc' },
+  },
+} satisfies Prisma.EventInclude
+
 /**
  * Fetches events with their part and service role assignments for PDF export.
  * Events are ordered by startDate ascending.
@@ -39,17 +52,7 @@ export function getEventsForExport(db: TransactionClient, templateIds: number[],
       templateId: { in: templateIds },
       startDate: { gte: startDate, lte: endDate },
     },
-    include: {
-      template: true,
-      partAssignments: {
-        include: { assignee: true, assistant: true },
-        orderBy: [{ order: 'asc' }, { trackOrder: { sort: 'asc', nulls: 'last' } }],
-      },
-      serviceRoleAssignments: {
-        include: { assignee: true },
-        orderBy: { name: 'asc' },
-      },
-    },
+    include: programmeExportInclude,
     orderBy: { startDate: 'asc' },
   })
 }

--- a/app/features/events/server/programme-templates.server.ts
+++ b/app/features/events/server/programme-templates.server.ts
@@ -4,6 +4,7 @@ import {
 } from '~/features/events/server/allowed-roles.server'
 import { AuditAction, audit } from '~/shared/domain/audit.server'
 import type { TransactionClient } from '~/shared/infra/db.server'
+import { sanitizeText } from '~/shared/utils/sanitize-text'
 
 export function getTemplates(db: TransactionClient, congregationId: number) {
   return db.programmeTemplate.findMany({
@@ -37,7 +38,11 @@ export function updateTemplate(
     where: {
       id_congregationId: { id: templateId, congregationId },
     },
-    data,
+    data: {
+      ...data,
+      ...(data.name != null ? { name: sanitizeText(data.name) } : {}),
+      ...(data.description != null ? { description: sanitizeText(data.description) } : {}),
+    },
   })
 }
 
@@ -60,9 +65,9 @@ export async function upsertTemplatePart(
   actorId: number,
 ) {
   const baseData = {
-    name: partData.name,
-    section: partData.section,
-    track: partData.track,
+    name: sanitizeText(partData.name),
+    section: sanitizeText(partData.section),
+    track: sanitizeText(partData.track),
     trackOrder: partData.trackOrder,
     order: partData.order,
     durationMin: partData.durationMin,

--- a/app/features/events/ui/ProgrammeBoardDocument.tsx
+++ b/app/features/events/ui/ProgrammeBoardDocument.tsx
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
 import { groupPartsBySlot } from '~/features/events/model/group-parts-by-slot'
 import type { ExportEvent, TemplateExportConfig } from '~/features/events/server/programme-export.server'
+import { formatMemberName, getPartAssigneeDisplay } from '~/features/events/ui/part-display'
 
 function ensureFontsRegistered() {
   const fontsDir = path.join(process.cwd(), 'public', 'fonts')
@@ -29,12 +30,6 @@ function sectionColor(section: string): string | null {
     if (lower.includes(pattern)) return color
   }
   return null
-}
-
-function formatName(user: { firstname: string | null; lastname: string | null } | null): string | null {
-  if (!user) return null
-  const name = `${user.firstname ?? ''} ${user.lastname ?? ''}`.trim()
-  return name || null
 }
 
 function formatDate(date: Date | string): string {
@@ -340,7 +335,7 @@ function EventCard({
           <Text style={styles.servicesTitle}>Services</Text>
           <View style={styles.servicesGrid}>
             {event.serviceRoleAssignments.map((role, roleIdx) => {
-              const name = formatName(role.assignee)
+              const name = formatMemberName(role.assignee)
               return (
                 <View key={roleIdx} style={styles.serviceItem}>
                   <Text style={styles.serviceRoleName}>{role.name}</Text>
@@ -370,10 +365,11 @@ function SectionHeader({ section }: { section: string }) {
 // Long dot string — the flex container + maxHeight clip it to one line
 const DOT_LEADER = ' .'.repeat(200)
 
-function formatAssigneeWithAssistant(assignee: string | null, assistant: string | null): string | null {
-  if (!assignee) return null
-  if (assistant) return `${assignee} / ${assistant}`
-  return assignee
+function formatPartRightText(part: PartAssignment): string | null {
+  const { primary, assistant } = getPartAssigneeDisplay(part)
+  if (!primary) return null
+  if (assistant) return `${primary} / ${assistant}`
+  return primary
 }
 
 function DotLeader() {
@@ -385,9 +381,7 @@ function DotLeader() {
 }
 
 function SinglePart({ part }: { part: PartAssignment }) {
-  const assigneeName = formatName(part.assignee)
-  const assistantName = formatName(part.assistant)
-  const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
+  const rightText = formatPartRightText(part)
   const displayName = part.topic !== '' ? part.topic : part.name
 
   return (
@@ -417,9 +411,7 @@ function MultiTrackPart({ parts }: { parts: PartAssignment[] }) {
         </Text>
       </View>
       {parts.map((part, idx) => {
-        const assigneeName = formatName(part.assignee)
-        const assistantName = formatName(part.assistant)
-        const rightText = formatAssigneeWithAssistant(assigneeName, assistantName)
+        const rightText = formatPartRightText(part)
         const trackName = part.track || `Salle ${idx + 1}`
         return (
           <View key={idx} style={styles.trackRow}>

--- a/app/features/events/ui/ProgrammeBoardDocument.tsx
+++ b/app/features/events/ui/ProgrammeBoardDocument.tsx
@@ -3,6 +3,7 @@ import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/rendere
 import { groupPartsBySlot } from '~/features/events/model/group-parts-by-slot'
 import type { ExportEvent, TemplateExportConfig } from '~/features/events/server/programme-export.server'
 import { formatMemberName, getPartAssigneeDisplay } from '~/features/events/ui/part-display'
+import { sanitizeText } from '~/shared/utils/sanitize-text'
 
 function ensureFontsRegistered() {
   const fontsDir = path.join(process.cwd(), 'public', 'fonts')
@@ -351,12 +352,13 @@ function EventCard({
 }
 
 function SectionHeader({ section }: { section: string }) {
-  const color = sectionColor(section) ?? '#64748b'
+  const cleanSection = sanitizeText(section)
+  const color = sectionColor(cleanSection) ?? '#64748b'
   return (
     <View style={styles.sectionRow}>
       <View style={[styles.sectionBar, { backgroundColor: color }]} />
       <View style={[styles.sectionNameContainer, { backgroundColor: color }]}>
-        <Text style={styles.sectionName}>{section}</Text>
+        <Text style={styles.sectionName}>{cleanSection}</Text>
       </View>
     </View>
   )
@@ -382,7 +384,7 @@ function DotLeader() {
 
 function SinglePart({ part }: { part: PartAssignment }) {
   const rightText = formatPartRightText(part)
-  const displayName = part.topic !== '' ? part.topic : part.name
+  const displayName = sanitizeText(part.topic !== '' ? part.topic : part.name)
 
   return (
     <View style={styles.partRow}>
@@ -398,7 +400,7 @@ function SinglePart({ part }: { part: PartAssignment }) {
 
 function MultiTrackPart({ parts }: { parts: PartAssignment[] }) {
   const representative = parts[0]
-  const displayName = representative.topic !== '' ? representative.topic : representative.name
+  const displayName = sanitizeText(representative.topic !== '' ? representative.topic : representative.name)
 
   return (
     <View>

--- a/app/features/events/ui/ProgrammeDocument.tsx
+++ b/app/features/events/ui/ProgrammeDocument.tsx
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
 import { formatMemberName, getPartAssigneeDisplay } from '~/features/events/ui/part-display'
+import { sanitizeText } from '~/shared/utils/sanitize-text'
 
 const fontsDir = path.join(process.cwd(), 'public', 'fonts')
 
@@ -296,7 +297,7 @@ function EventBlock({
             <View key={groupIdx}>
               {group.section !== '' && (
                 <View style={[styles.sectionHeader, { backgroundColor: color ?? '#64748b' }]}>
-                  <Text style={styles.sectionHeaderText}>{group.section}</Text>
+                  <Text style={styles.sectionHeaderText}>{sanitizeText(group.section)}</Text>
                 </View>
               )}
               {group.parts.map((part, partIdx) => {
@@ -330,13 +331,15 @@ function EventBlock({
 
 function PartRow({ part, isAlt }: { part: PartAssignment; isAlt: boolean }) {
   const { primary, assistant } = getPartAssigneeDisplay(part)
-  const displayName = part.track ? `${part.name} — ${part.track}` : part.name
+  const cleanName = sanitizeText(part.name)
+  const cleanTrack = sanitizeText(part.track)
+  const displayName = cleanTrack ? `${cleanName} — ${cleanTrack}` : cleanName
 
   return (
     <View style={[styles.partRow, isAlt ? styles.partRowAlt : {}]}>
       <Text style={styles.partName}>{displayName}</Text>
       <Text style={styles.partDuration}>{part.durationMin ? `${part.durationMin}'` : ''}</Text>
-      <Text style={styles.partTopic}>{part.topic || ''}</Text>
+      <Text style={styles.partTopic}>{part.topic ? sanitizeText(part.topic) : ''}</Text>
       {primary ? <Text style={styles.partAssignee}>{primary}</Text> : <Text style={styles.unassigned}>—</Text>}
       {assistant ? <Text style={styles.partAssistant}>{assistant}</Text> : <Text style={styles.partAssistant} />}
     </View>

--- a/app/features/events/ui/ProgrammeDocument.tsx
+++ b/app/features/events/ui/ProgrammeDocument.tsx
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { Document, Font, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
+import { formatMemberName, getPartAssigneeDisplay } from '~/features/events/ui/part-display'
 
 const fontsDir = path.join(process.cwd(), 'public', 'fonts')
 
@@ -37,6 +38,7 @@ interface PartAssignment {
   topic: string
   assignee: { firstname: string | null; lastname: string | null } | null
   assistant: { firstname: string | null; lastname: string | null } | null
+  externalSpeaker: { name: string } | null
 }
 
 interface ServiceRoleAssignment {
@@ -213,12 +215,6 @@ const styles = StyleSheet.create({
   },
 })
 
-function formatName(user: { firstname: string | null; lastname: string | null } | null): string | null {
-  if (!user) return null
-  const name = `${user.firstname ?? ''} ${user.lastname ?? ''}`.trim()
-  return name || null
-}
-
 function formatDate(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date
   return d.toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })
@@ -317,7 +313,7 @@ function EventBlock({
           <Text style={styles.serviceSectionTitle}>Services</Text>
           <View style={styles.serviceGrid}>
             {event.serviceRoleAssignments.map((role, roleIdx) => {
-              const name = formatName(role.assignee)
+              const name = formatMemberName(role.assignee)
               return (
                 <View key={roleIdx} style={styles.serviceItem}>
                   <Text style={styles.serviceRoleName}>{role.name}</Text>
@@ -333,8 +329,7 @@ function EventBlock({
 }
 
 function PartRow({ part, isAlt }: { part: PartAssignment; isAlt: boolean }) {
-  const assigneeName = formatName(part.assignee)
-  const assistantName = part.assistant ? formatName(part.assistant) : null
+  const { primary, assistant } = getPartAssigneeDisplay(part)
   const displayName = part.track ? `${part.name} — ${part.track}` : part.name
 
   return (
@@ -342,16 +337,8 @@ function PartRow({ part, isAlt }: { part: PartAssignment; isAlt: boolean }) {
       <Text style={styles.partName}>{displayName}</Text>
       <Text style={styles.partDuration}>{part.durationMin ? `${part.durationMin}'` : ''}</Text>
       <Text style={styles.partTopic}>{part.topic || ''}</Text>
-      {assigneeName ? (
-        <Text style={styles.partAssignee}>{assigneeName}</Text>
-      ) : (
-        <Text style={styles.unassigned}>—</Text>
-      )}
-      {assistantName ? (
-        <Text style={styles.partAssistant}>{assistantName}</Text>
-      ) : (
-        <Text style={styles.partAssistant} />
-      )}
+      {primary ? <Text style={styles.partAssignee}>{primary}</Text> : <Text style={styles.unassigned}>—</Text>}
+      {assistant ? <Text style={styles.partAssistant}>{assistant}</Text> : <Text style={styles.partAssistant} />}
     </View>
   )
 }

--- a/app/features/events/ui/part-display.test.ts
+++ b/app/features/events/ui/part-display.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { formatMemberName, getPartAssigneeDisplay } from './part-display'
+
+describe('formatMemberName', () => {
+  it('returns null for null input', () => {
+    expect(formatMemberName(null)).toBeNull()
+  })
+
+  it('joins firstname and lastname', () => {
+    expect(formatMemberName({ firstname: 'Jane', lastname: 'Doe' })).toBe('Jane Doe')
+  })
+
+  it('trims when one part is missing', () => {
+    expect(formatMemberName({ firstname: 'Jane', lastname: null })).toBe('Jane')
+    expect(formatMemberName({ firstname: null, lastname: 'Doe' })).toBe('Doe')
+  })
+
+  it('returns null when both parts are empty', () => {
+    expect(formatMemberName({ firstname: null, lastname: null })).toBeNull()
+    expect(formatMemberName({ firstname: '', lastname: '' })).toBeNull()
+  })
+})
+
+describe('getPartAssigneeDisplay', () => {
+  it('returns the external speaker name when set, with no assistant', () => {
+    const result = getPartAssigneeDisplay({
+      assignee: { firstname: 'Jane', lastname: 'Doe' },
+      assistant: { firstname: 'John', lastname: 'Reader' },
+      externalSpeaker: { name: 'Joe External' },
+    })
+    expect(result).toEqual({ primary: 'Joe External', assistant: null, isExternal: true })
+  })
+
+  it('returns assignee and assistant when no external speaker', () => {
+    const result = getPartAssigneeDisplay({
+      assignee: { firstname: 'Jane', lastname: 'Doe' },
+      assistant: { firstname: 'John', lastname: 'Reader' },
+      externalSpeaker: null,
+    })
+    expect(result).toEqual({ primary: 'Jane Doe', assistant: 'John Reader', isExternal: false })
+  })
+
+  it('returns nulls when nothing is assigned', () => {
+    const result = getPartAssigneeDisplay({
+      assignee: null,
+      assistant: null,
+      externalSpeaker: null,
+    })
+    expect(result).toEqual({ primary: null, assistant: null, isExternal: false })
+  })
+})

--- a/app/features/events/ui/part-display.ts
+++ b/app/features/events/ui/part-display.ts
@@ -1,0 +1,33 @@
+interface MemberName {
+  firstname: string | null
+  lastname: string | null
+}
+
+export function formatMemberName(member: MemberName | null): string | null {
+  if (!member) return null
+  const name = `${member.firstname ?? ''} ${member.lastname ?? ''}`.trim()
+  return name || null
+}
+
+interface PartInput {
+  assignee: MemberName | null
+  assistant: MemberName | null
+  externalSpeaker: { name: string } | null
+}
+
+export interface PartAssigneeDisplay {
+  primary: string | null
+  assistant: string | null
+  isExternal: boolean
+}
+
+export function getPartAssigneeDisplay(part: PartInput): PartAssigneeDisplay {
+  if (part.externalSpeaker) {
+    return { primary: part.externalSpeaker.name, assistant: null, isExternal: true }
+  }
+  return {
+    primary: formatMemberName(part.assignee),
+    assistant: formatMemberName(part.assistant),
+    isExternal: false,
+  }
+}

--- a/app/shared/utils/sanitize-text.test.ts
+++ b/app/shared/utils/sanitize-text.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeText } from './sanitize-text'
+
+describe('sanitizeText', () => {
+  it('returns the input unchanged when no invisible chars are present', () => {
+    expect(sanitizeText('Engage la conversation')).toBe('Engage la conversation')
+  })
+
+  it('strips a leading zero-width no-break space (BOM)', () => {
+    expect(sanitizeText('﻿Engage la conversation')).toBe('Engage la conversation')
+  })
+
+  it('strips a leading zero-width space', () => {
+    expect(sanitizeText('​Engage la conversation')).toBe('Engage la conversation')
+  })
+
+  it('strips zero-width joiners and non-joiners anywhere in the string', () => {
+    expect(sanitizeText('Eng‌age‍la‍conversation')).toBe('Engagelaconversation')
+  })
+
+  it('strips a leading left-to-right embedding marker', () => {
+    expect(sanitizeText('‪Engage la conversation')).toBe('Engage la conversation')
+  })
+
+  it('strips a soft hyphen', () => {
+    expect(sanitizeText('Engage­la conversation')).toBe('Engagela conversation')
+  })
+
+  it('strips a combining grapheme joiner', () => {
+    expect(sanitizeText('͏Engage la conversation')).toBe('Engage la conversation')
+  })
+
+  it('strips multiple invisible chars in a single pass', () => {
+    expect(sanitizeText('﻿​(Préparation​la suite)')).toBe('(Préparationla suite)')
+  })
+
+  it('preserves regular whitespace and accented letters', () => {
+    expect(sanitizeText("Étude biblique de l'assemblée")).toBe("Étude biblique de l'assemblée")
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(sanitizeText('')).toBe('')
+  })
+})

--- a/app/shared/utils/sanitize-text.ts
+++ b/app/shared/utils/sanitize-text.ts
@@ -1,0 +1,19 @@
+/**
+ * Strips invisible Unicode formatting codepoints that cause leading characters
+ * to appear dropped in PDF output: the font lacks a glyph for them, but the
+ * codepoint still sits in the content stream taking up logical position.
+ *
+ * Removed:
+ *   U+00AD                   soft hyphen
+ *   U+034F                   combining grapheme joiner
+ *   U+180E                   Mongolian vowel separator (deprecated)
+ *   U+200B - U+200D, U+2060  zero-width space / joiners / word joiner
+ *   U+202A - U+202E          bidi embedding / override
+ *   U+2066 - U+2069          bidi isolate
+ *   U+FEFF                   BOM / zero-width no-break space
+ */
+const INVISIBLE_RE = /[\u00AD\u180E\u200B-\u200D\u2060\u202A-\u202E\u2066-\u2069\uFEFF]|\u034F/g
+
+export function sanitizeText(input: string): string {
+  return input.replace(INVISIBLE_RE, '')
+}


### PR DESCRIPTION
## Summary

- Show external speakers in the programme PDF export. The Prisma include used by the export loader omitted the `externalSpeaker` relation and the renderers had no code path for it, so parts assigned to an external speaker printed as unassigned. Shared `programmeExportInclude` now covers both the new and legacy export routes; a `getPartAssigneeDisplay` helper drives rendering.
- Strip invisible Unicode (BOM, zero-width spaces/joiners, bidi marks, soft hyphen, combining grapheme joiner) from programme inputs. Pasted-in template part names and topics sometimes carried these codepoints, which the PDF font has no glyph for, making the leading character appear dropped on export. Sanitize at write time (`assignPart` topic, `upsertTemplatePart` name/section/track, `updateTemplate` name/description) and at render time in both PDF documents so legacy dirty data renders correctly without a migration.

## Test plan

- [x] `pnpm test:unit` — 1084 passing (19 new tests across `programme-export.server.test.ts`, `part-display.test.ts`, `sanitize-text.test.ts`)
- [x] `pnpm test:lint` — clean on changed files
- [x] `pnpm test:typecheck` — clean
- [ ] Manual: export a programme PDF where at least one part is assigned to an external speaker — speaker name shows in the assignee column with no assistant
- [ ] Manual: paste a topic containing a zero-width / BOM character via the assignment dialog, save, re-export — leading character renders correctly