### PR TITLE
test(territories): fix card-overlays FK flake by draining audit writes

### DIFF
--- a/app/features/territories/server/card-overlays.integration.test.ts
+++ b/app/features/territories/server/card-overlays.integration.test.ts
@@ -1,6 +1,7 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { PrismaClient } from '~/database/generated/client'
+import { flushPendingAuditWrites } from '~/shared/domain/audit.server'
 
 const adapter = new PrismaPg({
   connectionString: process.env.DB_RUNTIME_URL ?? process.env.DB_URL,
@@ -61,7 +62,9 @@ afterAll(async () => {
       await tx.territoryCardOverlay.deleteMany({})
     })
   }
-  // Audit logs reference the congregation via FK; clear them before dropping the test congregations.
+  // Drain fire-and-forget audit writes so the deleteMany below clears them all,
+  // otherwise an in-flight write can land after cleanup and break the congregation FK.
+  await flushPendingAuditWrites()
   await testDb.auditLog.deleteMany({ where: { congregationId: { in: [aId, bId] } } })
   await testDb.congregation.deleteMany({ where: { id: { in: [aId, bId] } } })
   await testDb.$disconnect()

--- a/app/shared/domain/audit.server.test.ts
+++ b/app/shared/domain/audit.server.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/shared/infra/logger.server', () => ({
   default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }))
 
-const { audit, AuditAction } = await import('./audit.server')
+const { audit, AuditAction, flushPendingAuditWrites } = await import('./audit.server')
 const { unscopedDb: db } = await import('~/shared/infra/db.server')
 
 beforeEach(() => {
@@ -62,5 +62,45 @@ describe('audit', () => {
       action: AuditAction.UserLogin,
       congregationId: 10,
     })
+  })
+})
+
+describe('flushPendingAuditWrites', () => {
+  it('resolves only after all pending audit writes settle', async () => {
+    const resolvers: Array<() => void> = []
+    vi.mocked(db.auditLog.create).mockImplementation(
+      () => new Promise(resolve => resolvers.push(() => resolve({} as never))) as never,
+    )
+
+    audit({ action: AuditAction.UserLogin, congregationId: 1 })
+    audit({ action: AuditAction.UserLogin, congregationId: 2 })
+
+    let flushed = false
+    const flush = flushPendingAuditWrites().then(() => {
+      flushed = true
+    })
+
+    await Promise.resolve()
+    expect(flushed).toBe(false)
+
+    resolvers[0]()
+    await Promise.resolve()
+    expect(flushed).toBe(false)
+
+    resolvers[1]()
+    await flush
+    expect(flushed).toBe(true)
+  })
+
+  it('resolves immediately when no writes are pending', async () => {
+    await expect(flushPendingAuditWrites()).resolves.toBeUndefined()
+  })
+
+  it('also drains writes that reject', async () => {
+    vi.mocked(db.auditLog.create).mockRejectedValue(new Error('DB error') as never)
+
+    audit({ action: AuditAction.UserLogin, congregationId: 1 })
+
+    await expect(flushPendingAuditWrites()).resolves.toBeUndefined()
   })
 })

--- a/app/shared/domain/audit.server.ts
+++ b/app/shared/domain/audit.server.ts
@@ -117,13 +117,15 @@ interface AuditEntry {
   metadata?: Record<string, unknown>
 }
 
+const pendingAuditWrites = new Set<Promise<unknown>>()
+
 /**
  * Enregistre un evenement dans le journal d'audit.
  * Utilise unscopedDb pour ecrire sans contexte RLS (l'audit est transversal).
  * Ne lance jamais d'exception — les erreurs d'audit ne doivent pas bloquer les operations.
  */
 export function audit(entry: AuditEntry): void {
-  unscopedDb.auditLog
+  const promise = unscopedDb.auditLog
     .create({
       data: {
         action: entry.action,
@@ -138,6 +140,18 @@ export function audit(entry: AuditEntry): void {
     .catch(error => {
       logger.error('Failed to write audit log', { error, auditAction: entry.action })
     })
+    .finally(() => {
+      pendingAuditWrites.delete(promise)
+    })
+  pendingAuditWrites.add(promise)
+}
+
+/**
+ * Awaits all fire-and-forget `audit()` writes started so far. Test-only — production code
+ * intentionally lets audit writes settle in the background.
+ */
+export async function flushPendingAuditWrites(): Promise<void> {
+  await Promise.all(pendingAuditWrites)
 }
 
 /**


### PR DESCRIPTION
## Summary

- The `card-overlays.integration.test.ts` cleanup can intermittently fail with an FK violation on `Congregation` ↔ `AuditLog` because `audit()` is fire-and-forget via `unscopedDb` — a stray write can land after the test's `auditLog.deleteMany` and before the `congregation.deleteMany`, leaving a referenced row.
- Adds `flushPendingAuditWrites()` to `audit.server.ts` which tracks in-flight `audit()` promises and lets callers await them. The test awaits it just before the cleanup deletes.
- Production behavior is unchanged: `audit()` still doesn't block its callers; the helper is for tests that need to assert a clean slate.

## Test plan

- [x] `pnpm test:unit` (1146 tests passing, including 3 new tests covering `flushPendingAuditWrites`)
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint`
- [x] `pnpm test:integration -- card-overlays.integration.test.ts` — 5 consecutive clean runs locally