### PR TITLE
feat(territories): show attribution kind on /me/territories pages

### DIFF
--- a/app/features/territories/routes/my-territories/list.tsx
+++ b/app/features/territories/routes/my-territories/list.tsx
@@ -1,12 +1,12 @@
 import { ChevronRight, Download, MapPin } from 'lucide-react'
 import { Link } from 'react-router'
 
-import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import {
   getUserTerritoriesWithDetails,
   type TerritoryStatus,
 } from '~/features/territories/server/my-territories.server'
+import { AttributionKindBadge } from '~/features/territories/ui/AttributionKindBadge'
 
 import * as m from '~/i18n/paraglide/messages'
 import { currentAccountContext, withScopeFromContext } from '~/shared/auth/route-context.server'
@@ -43,16 +43,6 @@ function statusLabel(status: TerritoryStatus): string {
   if (status === 'on-time') return m.dashboard_territory_on_time()
   if (status === 'due-soon') return m.dashboard_territory_due_soon()
   return m.dashboard_territory_overdue()
-}
-
-function attributionTypeLabel(type: TerritoryAttributionKind): string | null {
-  if (type === TerritoryAttributionKind.Campaign) return m.attributions_type_campaign()
-  if (type === TerritoryAttributionKind.Phone) return m.attributions_type_phone()
-  return null
-}
-
-function attributionTypeVariant(type: TerritoryAttributionKind): 'info' | 'success' {
-  return type === TerritoryAttributionKind.Phone ? 'success' : 'info'
 }
 
 function territoryTypeLabel(type: string): string {
@@ -108,11 +98,7 @@ export default function MyTerritoriesList({ loaderData }: Route.ComponentProps) 
                       <Badge variant={statusVariant[t.status]} className="text-[10px]">
                         {statusLabel(t.status)}
                       </Badge>
-                      {attributionTypeLabel(t.type) != null && (
-                        <Badge variant={attributionTypeVariant(t.type)} className="text-[10px]">
-                          {attributionTypeLabel(t.type)}
-                        </Badge>
-                      )}
+                      <AttributionKindBadge type={t.type} className="text-[10px]" />
                     </div>
                     <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-muted-foreground text-xs">
                       <span>{territoryTypeLabel(t.territory.type)}</span>

--- a/app/features/territories/routes/my-territories/list.tsx
+++ b/app/features/territories/routes/my-territories/list.tsx
@@ -1,6 +1,7 @@
 import { ChevronRight, Download, MapPin } from 'lucide-react'
 import { Link } from 'react-router'
 
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { TerritoryKind } from '~/features/territories/model/territory-kind.type'
 import {
   getUserTerritoriesWithDetails,
@@ -42,6 +43,16 @@ function statusLabel(status: TerritoryStatus): string {
   if (status === 'on-time') return m.dashboard_territory_on_time()
   if (status === 'due-soon') return m.dashboard_territory_due_soon()
   return m.dashboard_territory_overdue()
+}
+
+function attributionTypeLabel(type: TerritoryAttributionKind): string | null {
+  if (type === TerritoryAttributionKind.Campaign) return m.attributions_type_campaign()
+  if (type === TerritoryAttributionKind.Phone) return m.attributions_type_phone()
+  return null
+}
+
+function attributionTypeVariant(type: TerritoryAttributionKind): 'info' | 'success' {
+  return type === TerritoryAttributionKind.Phone ? 'success' : 'info'
 }
 
 function territoryTypeLabel(type: string): string {
@@ -90,13 +101,18 @@ export default function MyTerritoriesList({ loaderData }: Route.ComponentProps) 
                   className="flex items-center gap-3 px-4 pt-4 pb-0 transition-colors hover:bg-muted/30"
                 >
                   <div className="flex flex-1 flex-col gap-1">
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <span className="font-display font-semibold text-lg">
                         {m.territory_doc_title({ name: t.territory.number })}
                       </span>
                       <Badge variant={statusVariant[t.status]} className="text-[10px]">
                         {statusLabel(t.status)}
                       </Badge>
+                      {attributionTypeLabel(t.type) != null && (
+                        <Badge variant={attributionTypeVariant(t.type)} className="text-[10px]">
+                          {attributionTypeLabel(t.type)}
+                        </Badge>
+                      )}
                     </div>
                     <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-muted-foreground text-xs">
                       <span>{territoryTypeLabel(t.territory.type)}</span>

--- a/app/features/territories/routes/my-territories/view.tsx
+++ b/app/features/territories/routes/my-territories/view.tsx
@@ -1,6 +1,7 @@
 import { AdvancedMarker, Map as GoogleMap, APIProvider as GoogleMapApiProvider } from '@vis.gl/react-google-maps'
 import { Download, MapPin } from 'lucide-react'
 import { redirect } from 'react-router'
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings.server'
 import {
   computeStatus,
@@ -77,6 +78,16 @@ function statusLabel(status: TerritoryStatus): string {
   return m.dashboard_territory_overdue()
 }
 
+function attributionTypeLabel(type: TerritoryAttributionKind): string | null {
+  if (type === TerritoryAttributionKind.Campaign) return m.attributions_type_campaign()
+  if (type === TerritoryAttributionKind.Phone) return m.attributions_type_phone()
+  return null
+}
+
+function attributionTypeVariant(type: TerritoryAttributionKind): 'info' | 'success' {
+  return type === TerritoryAttributionKind.Phone ? 'success' : 'info'
+}
+
 export default function MyTerritoryView({ loaderData }: Route.ComponentProps) {
   const { territory, entrances, attribution, phoneTypeActive, mapTabActive, googleMaps } = loaderData
 
@@ -98,6 +109,9 @@ export default function MyTerritoryView({ loaderData }: Route.ComponentProps) {
 
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <Badge variant={statusVariant[attribution.status]}>{statusLabel(attribution.status)}</Badge>
+        {attributionTypeLabel(attribution.type) != null && (
+          <Badge variant={attributionTypeVariant(attribution.type)}>{attributionTypeLabel(attribution.type)}</Badge>
+        )}
         <span className="text-muted-foreground">
           {m.my_territories_attributed_on({ date: formatAbsoluteDate(attribution.startDate) })}
         </span>

--- a/app/features/territories/routes/my-territories/view.tsx
+++ b/app/features/territories/routes/my-territories/view.tsx
@@ -1,7 +1,6 @@
 import { AdvancedMarker, Map as GoogleMap, APIProvider as GoogleMapApiProvider } from '@vis.gl/react-google-maps'
 import { Download, MapPin } from 'lucide-react'
 import { redirect } from 'react-router'
-import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
 import { aggregateEntrance } from '~/features/territories/server/buildings.server'
 import {
   computeStatus,
@@ -9,6 +8,7 @@ import {
   type TerritoryStatus,
 } from '~/features/territories/server/my-territories.server'
 
+import { AttributionKindBadge } from '~/features/territories/ui/AttributionKindBadge'
 import { EntranceMarkerPin } from '~/features/territories/ui/EntranceMarkerPin'
 import { TerritoryEntranceCard } from '~/features/territories/ui/TerritoryEntranceCard'
 import * as m from '~/i18n/paraglide/messages'
@@ -78,16 +78,6 @@ function statusLabel(status: TerritoryStatus): string {
   return m.dashboard_territory_overdue()
 }
 
-function attributionTypeLabel(type: TerritoryAttributionKind): string | null {
-  if (type === TerritoryAttributionKind.Campaign) return m.attributions_type_campaign()
-  if (type === TerritoryAttributionKind.Phone) return m.attributions_type_phone()
-  return null
-}
-
-function attributionTypeVariant(type: TerritoryAttributionKind): 'info' | 'success' {
-  return type === TerritoryAttributionKind.Phone ? 'success' : 'info'
-}
-
 export default function MyTerritoryView({ loaderData }: Route.ComponentProps) {
   const { territory, entrances, attribution, phoneTypeActive, mapTabActive, googleMaps } = loaderData
 
@@ -109,9 +99,7 @@ export default function MyTerritoryView({ loaderData }: Route.ComponentProps) {
 
       <div className="flex flex-wrap items-center gap-2 text-sm">
         <Badge variant={statusVariant[attribution.status]}>{statusLabel(attribution.status)}</Badge>
-        {attributionTypeLabel(attribution.type) != null && (
-          <Badge variant={attributionTypeVariant(attribution.type)}>{attributionTypeLabel(attribution.type)}</Badge>
-        )}
+        <AttributionKindBadge type={attribution.type} />
         <span className="text-muted-foreground">
           {m.my_territories_attributed_on({ date: formatAbsoluteDate(attribution.startDate) })}
         </span>

--- a/app/features/territories/server/my-territories.server.test.ts
+++ b/app/features/territories/server/my-territories.server.test.ts
@@ -60,14 +60,14 @@ describe('getUserTerritoriesWithDetails', () => {
         id: 1,
         startDate: new Date(2025, 2, 1),
         lateDate: new Date(2025, 3, 10), // overdue
-        type: 'default',
+        type: 'Default',
         territory: { id: 1, number: 'T-1', type: 'doors-to-doors', entrances: [] },
       },
       {
         id: 2,
         startDate: new Date(2025, 3, 1),
         lateDate: new Date(2025, 4, 15), // on-time
-        type: 'default',
+        type: 'Phone',
         territory: { id: 2, number: 'T-2', type: 'doors-to-doors', entrances: [] },
       },
     ] as never)
@@ -76,7 +76,9 @@ describe('getUserTerritoriesWithDetails', () => {
 
     expect(result).toHaveLength(2)
     expect(result[0].status).toBe('overdue')
+    expect(result[0].type).toBe('Default')
     expect(result[1].status).toBe('on-time')
+    expect(result[1].type).toBe('Phone')
   })
 })
 

--- a/app/features/territories/ui/AttributionKindBadge.tsx
+++ b/app/features/territories/ui/AttributionKindBadge.tsx
@@ -4,12 +4,16 @@ import { TerritoryAttributionKind } from '~/features/territories/model/territory
 import * as m from '~/i18n/paraglide/messages'
 import { Badge } from '~/shared/ui/badge'
 
-type Props = {
+type AttributionKindBadgeProps = {
   type: TerritoryAttributionKind
   className?: string
 }
 
-export function AttributionKindBadge({ type, className }: Props) {
+export function AttributionKindBadge({ type, className }: AttributionKindBadgeProps) {
+  if (type === TerritoryAttributionKind.Default) {
+    return null
+  }
+
   if (type === TerritoryAttributionKind.Phone) {
     return (
       <Badge variant="secondary" className={className}>

--- a/app/features/territories/ui/AttributionKindBadge.tsx
+++ b/app/features/territories/ui/AttributionKindBadge.tsx
@@ -1,0 +1,32 @@
+import { Megaphone, Phone } from 'lucide-react'
+
+import { TerritoryAttributionKind } from '~/features/territories/model/territory-attribution-kind.type'
+import * as m from '~/i18n/paraglide/messages'
+import { Badge } from '~/shared/ui/badge'
+
+type Props = {
+  type: TerritoryAttributionKind
+  className?: string
+}
+
+export function AttributionKindBadge({ type, className }: Props) {
+  if (type === TerritoryAttributionKind.Phone) {
+    return (
+      <Badge variant="secondary" className={className}>
+        <Phone />
+        {m.attributions_type_phone()}
+      </Badge>
+    )
+  }
+
+  if (type === TerritoryAttributionKind.Campaign) {
+    return (
+      <Badge variant="secondary" className={className}>
+        <Megaphone />
+        {m.attributions_type_campaign()}
+      </Badge>
+    )
+  }
+
+  return null
+}

--- a/docs/product/territories.md
+++ b/docs/product/territories.md
@@ -25,6 +25,7 @@ The personal list shows all territories currently attributed to the member as a 
 - **Territory number** and **type badge** (color-coded)
 - **Quantity label** — e.g., *42 households*, *12 phones*, *8 businesses*
 - **Status badge** — On time / due soon / overdue
+- **Assignment type indicator** — A pill with an icon appears for *Phones* (phone icon) and *Distribution campaign* (megaphone icon) assignments, so the publisher can tell at a glance how the territory is meant to be worked. *Door to door* — the default — shows no extra indicator. This mirrors the watermark on the printed territory card.
 - **Due date** — Displayed as relative time
 - **PDF download** — Download the territory card directly from the list
 
@@ -39,7 +40,7 @@ Clicking a territory opens a detail page with two tabs:
   - PDF download button for offline use
 - **Map** — Full-width interactive Google Map with markers for each address (when configured). Shows a consent banner before loading the map. If no API key is set, a message indicates the map is unavailable. Markers use the same blue check pin as the admin views (see [Map markers](#map-markers)).
 
-Assignment info (start date, return date with relative time, status) is shown above the tabs.
+Assignment info (start date, return date with relative time, status, and the assignment-type pill for *Phones* / *Distribution campaign*) is shown above the tabs.
 
 Members only ever see territories they currently have an active assignment for.
 
@@ -116,6 +117,8 @@ The *Assignment type* field offers:
 - **Door to door** — Standard territory assignment
 - **Phones** — Phone witnessing assignment
 - **Distribution campaign** — Special campaign assignment (e.g. memorial invitations)
+
+The assignment type is surfaced in three places so the publisher always knows how to approach the territory: as a watermark on the printed territory card, as a pill (with a phone or megaphone icon) on the publisher's `/me/territories` list cards, and again on the territory detail page. *Door to door* is the default and shows no extra indicator in any of these places.
 
 ### Overdue tracking
 


### PR DESCRIPTION
## Summary
- Add a badge surfacing the attribution kind (Campaign, Phones) on the publisher-facing `/me/territories` list cards and `/me/territories/:id` detail header.
- Default door-to-door kind renders nothing, mirroring the no-watermark behaviour of the territory PDF.
- Reuses the existing `attributions_type_campaign` / `attributions_type_phone` Paraglide keys, so no new translations are needed.

## Test plan
- [ ] Assign a Campaign attribution to a publisher and confirm the blue "Campagne de distribution" badge appears on `/me/territories` and `/me/territories/:id`.
- [ ] Assign a Phones attribution and confirm the green "Téléphones" badge appears on both pages.
- [ ] Assign a default (door-to-door) attribution and confirm no extra badge appears.
- [ ] Verify the PDF watermark still matches the on-screen badge for each kind.